### PR TITLE
feat: add morning brief harness pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ htmlcov/
 
 hard-disk
 data/
+.worktrees/

--- a/docs/05-morning-market-brief-cli-gap-analysis.md
+++ b/docs/05-morning-market-brief-cli-gap-analysis.md
@@ -1,0 +1,535 @@
+# Morning Market Brief — V1 Implementation Plan
+
+Date: 2026-04-08
+Status: deterministic evidence pipeline implemented; final note-generation step still pending
+
+## Goal
+
+Implement a v1 morning-brief pipeline where:
+- Minerva CLI manages portfolio state and collects structured daily evidence
+- Minerva CLI prepares an agent-ready evidence pack
+- Charlie (main agent) writes the actual morning brief and Slack distillation
+- the existing scheduled job uses these commands instead of doing the whole job in one prompt
+
+## V1 scope
+
+Implement these commands in v1:
+- `minerva portfolio sync`
+- `minerva portfolio adjacency`
+- `minerva portfolio thesis`
+- `minerva brief filings`
+- `minerva brief earnings`
+- `minerva brief macro`
+- `minerva brief ir`
+- `minerva brief market`
+- `minerva brief prep`
+- `minerva brief audit`
+- `minerva brief review-log`
+
+V1 also includes:
+- manifest writing
+- deterministic evidence renders
+- cron/scheduler update to run the commands in sequence before the main-agent writeup
+
+## Out of scope for v1
+
+- first-class `brief news` CLI command for Reuters/newswire collection
+- automatic IR URL discovery
+- automatic adjacency discovery/refresh
+- bidirectional writes back into the Google Sheet
+- replacing the main agent’s analysis with deterministic scoring
+
+## Current implementation status
+
+As of 2026-04-09, the deterministic harness surface exists and is fixture-tested:
+- `portfolio sync`
+- `portfolio adjacency` (`list`, `add`, `remove`, `render`)
+- `portfolio thesis` (`list`, `show`, `set`, `render`)
+- `brief filings`, `earnings`, `macro`, `ir`, `market`, `prep`, `audit`, `review-log`
+- `scripts/run_morning_brief_v1.sh`
+
+What is true right now:
+- the harness collects and normalizes evidence into raw, structured, and rendered artifacts
+- the wrapper script performs the deterministic collection flow and enforces a manifest status gate before post-write steps continue
+- the note files are created at the expected locations, but they are still seeded with placeholder text (`Pending main-agent writeup.`)
+
+So the remaining functional gap is not collection. It is the final write stage that turns prepared evidence into a real `morning-brief-report.md` and `slack-brief.md`.
+
+---
+
+## Storage layout
+
+### Portfolio state
+
+```text
+hard-disk/data/portfolio/
+├── INDEX.md
+├── current/
+│   ├── INDEX.md
+│   ├── holdings.json
+│   ├── watchlist.json
+│   ├── universe.json
+│   ├── adjacent-map.json
+│   ├── thesis-cards.json
+│   ├── ir-registry.json
+│   └── rendered.md
+├── history/
+│   ├── INDEX.md
+│   ├── sync-log.jsonl
+│   ├── universe-history.jsonl
+│   ├── metadata-history.jsonl
+│   └── rendered-history.md
+└── transactions.json
+```
+
+Notes:
+- `portfolio/`, `current/`, and `history/` should be indexed
+- watchlist is local-only for now and can start empty
+- `transactions.json` is the single general ledger file
+- history should be compact log-based history, not a full dated snapshot every day
+
+### Daily morning run artifacts
+
+```text
+hard-disk/reports/daily-news/
+├── INDEX.md
+├── 2026-04-08/
+│   ├── notes/
+│   │   ├── morning-brief-report.md
+│   │   └── slack-brief.md
+│   ├── data/
+│   │   ├── raw/
+│   │   │   ├── filings.json
+│   │   │   ├── earnings.json
+│   │   │   ├── macro.json
+│   │   │   ├── ir.json
+│   │   │   ├── market.json
+│   │   │   └── manifest.json
+│   │   ├── structured/
+│   │   │   ├── universe.json
+│   │   │   ├── prepared-evidence.json
+│   │   │   └── audit.json
+│   │   └── rendered/
+│   │       ├── evidence.md
+│   │       ├── grouped-events.md
+│   │       ├── audit.md
+│   │       └── source-status.md
+│   └── INDEX.md
+├── review-log.jsonl
+└── ...
+```
+
+Notes:
+- `daily-news/` should be indexed
+- raw outputs are JSON
+- prepared outputs are JSON
+- rendered support files are markdown
+- the actual narrative brief is intended to live in `notes/`
+- current code seeds placeholder note files there until the main-agent write step is wired in
+
+---
+
+## Current command surface
+
+## Portfolio namespace
+
+### `minerva portfolio sync`
+Purpose:
+- pull holdings and transactions from the Google Sheet
+- merge with a locally managed watchlist
+- update `current/` portfolio state
+- append compact history entries
+- render a markdown summary
+
+Inputs:
+- sheet identifier / config
+- holdings tab
+- transactions tab
+- local watchlist file
+- optional `--date` or `--as-of`
+
+Writes:
+- `current/holdings.json`
+- `current/watchlist.json`
+- `current/universe.json`
+- `transactions.json`
+- history log files under `history/`
+- `current/rendered.md`
+
+Implementation details:
+- watchlist is local-only for v1; start with an empty file if needed
+- normalize each security to a canonical identifier
+- compute `universe.json` as holdings + watchlist
+- append change records to history logs instead of writing full dated snapshots
+- render markdown after each sync so the current state is easy to inspect
+
+### `minerva portfolio adjacency`
+Purpose:
+- manage the curated adjacent-company map stored locally
+
+Subcommands:
+- `list` — show all stored adjacency mappings
+- `add` — add one adjacency relationship
+- `remove` — delete one adjacency relationship
+- `render` — render the adjacency map as markdown
+
+Writes:
+- `current/adjacent-map.json`
+- optional history entry
+- rendered adjacency markdown
+
+Implementation details:
+- store adjacency locally for now
+- each mapping should include:
+  - monitored company
+  - adjacent company
+  - relationship type
+  - optional note / priority
+- keep this human-curated in v1
+
+### `minerva portfolio thesis`
+Purpose:
+- manage compact thesis cards per monitored security
+
+Subcommands:
+- `list` — list securities with thesis cards
+- `show` — show one thesis card
+- `set` — create or replace one thesis card
+- `render` — render all thesis cards as markdown
+
+Writes:
+- `current/thesis-cards.json`
+- optional history entry
+- rendered thesis markdown
+
+Implementation details:
+- thesis cards should be compact, not full reports
+- likely fields:
+  - security identifier
+  - thesis summary
+  - key expectations
+  - disconfirming signals
+  - updated timestamp
+
+## Brief namespace
+
+### `minerva brief filings`
+Purpose:
+- collect overnight SEC filings for the monitored universe
+- filter to material forms
+- normalize them into event rows
+
+Inputs:
+- `universe.json`
+- form allowlist / denylist
+- `--date` or `--since` / `--until`
+
+Writes:
+- raw filings JSON
+- normalized filings event JSON
+- optional rendered markdown list
+
+Implementation details:
+- this must reuse existing `sec` primitives
+- `sec` remains the low-level ticker/document namespace
+- `brief filings` is the watchlist-wide orchestration layer on top of `sec`
+- do not duplicate SEC retrieval logic
+
+### `minerva brief earnings`
+Purpose:
+- collect reported and upcoming earnings for monitored names
+- include adjacent names with strong read-through value
+- include non-adjacent names only when clearly market-relevant
+
+Inputs:
+- `universe.json`
+- adjacency map
+- `--date` or date window
+
+Proposed v1 source:
+- use one configured market-data provider for earnings metadata; recommendation: start with a single provider such as Finnhub so `brief earnings` and `brief market` share the same provider layer
+
+Writes:
+- raw earnings source JSON
+- normalized earnings events JSON
+- optional rendered schedule/results markdown
+
+Implementation details:
+- normalize:
+  - reported vs scheduled
+  - before-open vs after-close vs unknown timing
+  - monitored vs adjacent vs non-adjacent market-relevant
+- this command collects metadata and references only; it does not do deep earnings analysis
+
+### `minerva brief macro`
+Purpose:
+- collect the day’s macro / policy schedule in normalized form
+
+Inputs:
+- `--date` or run window
+
+Proposed v1 sources:
+- small curated list of official calendars/pages
+- likely starting set: BLS, BEA, Census, Treasury, and Federal Reserve
+
+Writes:
+- raw macro JSON
+- normalized macro events JSON
+- optional rendered calendar markdown
+
+Implementation details:
+- keep the schema simple:
+  - event name
+  - release time
+  - source
+  - category
+  - importance tag
+- maintain the tracked macro-source list in a small local registry/config file
+
+### `minerva brief ir`
+Purpose:
+- scan known IR / press-release pages for monitored names
+- capture overnight releases and normalize them
+
+Inputs:
+- `universe.json`
+- local IR registry
+- `--date` or time window
+
+Registry location:
+- `hard-disk/data/portfolio/current/ir-registry.json`
+
+Writes:
+- raw IR scan JSON
+- normalized IR release events JSON
+- optional rendered markdown list
+
+Implementation details:
+- store IR URLs locally in v1
+- populate the initial registry manually or semi-manually once per monitored company
+- do not attempt automatic IR discovery in v1
+- collect only titles, URLs, timestamps, and references here; deeper extraction is separate
+
+### `minerva brief market`
+Purpose:
+- collect only the market context that is large or explanatory enough to matter
+
+Inputs:
+- `--date` or run window
+
+Proposed v1 source:
+- use the same configured market-data provider chosen for `brief earnings`; recommendation: start with one provider such as Finnhub so earnings and market share the same integration layer
+
+Writes:
+- raw market snapshot JSON
+- normalized market-context JSON
+- optional rendered markdown summary
+
+Implementation details:
+- keep this intentionally narrow
+- collect only:
+  - major index moves
+  - rates / FX when material
+  - other moves only when outsized or explanatory
+- do not turn this into a generic dashboard dump
+
+### `minerva brief prep`
+Purpose:
+- prepare a cleaner agent-ready evidence pack from collected raw inputs
+
+Inputs:
+- filings / earnings / macro / IR / market JSON
+- `universe.json`
+- adjacency map
+- thesis cards
+
+Writes:
+- `prepared-evidence.json`
+- `grouped-events.md`
+- `source-status.md`
+- optional suppression log
+
+Implementation details:
+- this is evidence hygiene, not final judgment
+- do:
+  - deduplication
+  - relationship tagging
+  - event-type tagging
+  - stale/empty suppression
+  - candidate section grouping
+- do not try to replace the main agent’s prioritization
+
+### `minerva brief audit`
+Purpose:
+- run a bounded cross-check for misses after prep
+
+Inputs:
+- prepared evidence
+- manifest
+- optional broader scan inputs
+
+Writes:
+- `audit.json`
+- optional rendered audit markdown
+
+Implementation details:
+- keep this bounded
+- this is a miss-check, not a second full brief pipeline
+
+### `minerva brief review-log`
+Purpose:
+- append one structured review entry per daily-news run
+
+Inputs:
+- manifest from the just-completed run
+- audit output from that same run, if present
+- optional operator notes
+
+Writes:
+- `hard-disk/reports/daily-news/review-log.jsonl`
+
+Implementation details:
+- write one entry after each daily-news session
+- this command mainly reads the current run’s manifest + audit output and appends one structured record
+- capture:
+  - run id/date
+  - source failures
+  - degraded modes used
+  - misses found later
+  - recurring collection pain points
+
+---
+
+## Daily run flow
+
+The daily run should work like this:
+
+1. `minerva portfolio sync`
+2. `minerva brief filings`
+3. `minerva brief earnings`
+4. `minerva brief macro`
+5. `minerva brief ir`
+6. `minerva brief market`
+7. `minerva brief prep`
+8. Charlie reads the evidence pack and writes:
+   - `notes/morning-brief-report.md`
+   - `notes/slack-brief.md`
+9. `minerva brief audit`
+10. `minerva brief review-log`
+11. OpenClaw posts the Slack brief
+
+The important boundary is:
+- CLI collects and prepares evidence
+- Charlie writes the actual analysis
+
+Current implementation note:
+- steps 1 through 7, plus 9 and 10, are implemented in the harness
+- step 8 is still an orchestration gap, which is why the current note files are placeholders instead of a finished brief
+
+---
+
+## Cron / scheduler update
+
+The existing scheduled job should be updated so it no longer tries to do the entire morning brief in one agent prompt.
+
+Instead, it should:
+1. run the deterministic CLI commands first
+2. hand the resulting evidence pack to Charlie
+3. have Charlie write the morning brief and Slack brief
+4. optionally run audit + review-log after that
+
+## Recommended implementation pattern
+
+Do **not** put a giant chain directly into the cron line.
+
+Instead, create one thin wrapper script, for example:
+- `scripts/run_morning_brief_v1.sh`
+
+That script should:
+1. derive the run date
+2. create the daily run folder if needed
+3. call the CLI commands in order
+4. invoke the main-agent step using the prepared evidence path
+5. append review logs
+6. exit non-zero if the deterministic collection phase failed in a way that should block delivery
+
+## Expected command sequence inside the wrapper
+
+```bash
+minerva portfolio sync --date "$RUN_DATE"
+minerva brief filings --date "$RUN_DATE"
+minerva brief earnings --date "$RUN_DATE"
+minerva brief macro --date "$RUN_DATE"
+minerva brief ir --date "$RUN_DATE"
+minerva brief market --date "$RUN_DATE"
+minerva brief prep --date "$RUN_DATE"
+# main-agent writeup step happens here
+minerva brief audit --date "$RUN_DATE"
+minerva brief review-log --date "$RUN_DATE"
+```
+
+## Scheduler behavior change
+
+Today’s job logic is effectively:
+- scheduled prompt -> agent tries to do everything
+
+V1 should become:
+- scheduled trigger -> wrapper script / orchestrator -> deterministic CLI collection -> main-agent writeup -> Slack delivery
+
+That is the key operational change.
+
+## Concrete cron migration plan
+
+Because the schedule mechanism itself appears to live outside this repo, the safest migration is to change only the execution target, not to rebuild the schedule logic from scratch.
+
+Recommended change:
+1. keep the existing trigger time the same
+2. replace the old one-shot prompt entrypoint with a call to `scripts/run_morning_brief_v1.sh`
+3. pass any required source/registry environment variables in the cron environment or a sourced env file
+4. have the scheduled orchestration layer wait for `prepared_evidence` + `manifest` from the wrapper, then invoke Charlie for the write step
+5. only after the write step succeeds, run `brief audit` and `brief review-log` if they are not already folded into the orchestration wrapper
+
+Recommended cron-owned responsibilities:
+- set a stable working directory
+- export `UV_CACHE_DIR`
+- export `MINERVA_WORKSPACE_ROOT`
+- export any provider/source/registry env vars
+- call the wrapper script with the run date
+- capture stdout/stderr to a dated log file
+- alert on non-zero exit
+
+Recommended wrapper-owned responsibilities:
+- portfolio sync
+- deterministic evidence collection
+- manifest status gating
+- printing the exact `prepared_evidence` and `manifest` paths for the next orchestrator step
+
+Recommended agent/orchestrator responsibilities:
+- read `prepared-evidence.json`
+- write `notes/morning-brief-report.md`
+- write `notes/slack-brief.md`
+- deliver the Slack brief
+
+In other words, cron should trigger the harness, not impersonate the analyst.
+
+---
+
+## Build order
+
+Recommended implementation order:
+
+1. `portfolio sync`
+2. `portfolio adjacency`
+3. `portfolio thesis`
+4. `brief filings`
+5. `brief earnings`
+6. `brief macro`
+7. `brief ir`
+8. `brief market`
+9. `brief prep`
+10. manifest writing + rendered evidence files
+11. `brief audit`
+12. `brief review-log`
+13. scheduler/wrapper update
+
+This order gets the evidence pipeline working before the cron integration depends on it.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,14 @@
+# docs
+
+| Name | Type | Notes |
+| --- | --- | --- |
+| `00-jobwatch-architecture.md` | file | Architecture notes for JobWatch. |
+| `02-investment-harness.md` | file | Investment harness design notes. |
+| `03-log-analysis-company-analysis-2026-04-07.md` | file | Session-log review of company-analysis workflows and CLI opportunities. |
+| `04-browser-cli-v2-python-port.md` | file | Combined doc: implementation deep dive of the TS/JS browser-cli-v2 + full Python migration plan. |
+| `05-morning-market-brief-cli-gap-analysis.md` | file | V1 implementation plan for the morning market brief pipeline, including CLI commands, storage layout, and scheduler integration. |
+| `06-collect-evidence-analyze-business-cli-plan.md` | file | Design doc for a workflow-aware Minerva evidence/analysis layer supporting the `collect-evidence` and `analyze-business` skills. |
+
+## Notes
+- Docs hold higher-level designs, reports, and durable reference writeups.
+- The morning-brief doc lives here because it defines the repo-level CLI additions, storage layout, and scheduler integration for the daily pipeline.

--- a/scripts/run_morning_brief_v1.sh
+++ b/scripts/run_morning_brief_v1.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${ROOT_DIR}/.uv-cache}"
+export MINERVA_WORKSPACE_ROOT="${MINERVA_WORKSPACE_ROOT:-${ROOT_DIR}/hard-disk}"
+
+RUN_DATE="${1:-$(date +%F)}"
+WITH_POST_WRITE="${MINERVA_WITH_POST_WRITE:-0}"
+MINERVA_RUNNER="${MINERVA_RUNNER:-uv run minerva}"
+MINERVA_SKIP_STATUS_CHECK="${MINERVA_SKIP_STATUS_CHECK:-0}"
+MINERVA_BRIEF_EARNINGS_PROVIDER="${MINERVA_BRIEF_EARNINGS_PROVIDER:-auto}"
+MINERVA_BRIEF_MARKET_PROVIDER="${MINERVA_BRIEF_MARKET_PROVIDER:-auto}"
+
+IFS=' ' read -r -a MINERVA_RUNNER_ARR <<< "${MINERVA_RUNNER}"
+
+mkdir -p "${MINERVA_WORKSPACE_ROOT}/reports/daily-news/${RUN_DATE}"
+
+run() {
+  "${MINERVA_RUNNER_ARR[@]}" "$@"
+}
+
+portfolio_sync_args=(portfolio sync --date "${RUN_DATE}")
+if [[ -n "${MINERVA_PORTFOLIO_HOLDINGS_SOURCE:-}" ]]; then
+  portfolio_sync_args+=(--holdings-source "${MINERVA_PORTFOLIO_HOLDINGS_SOURCE}")
+fi
+if [[ -n "${MINERVA_PORTFOLIO_TRANSACTIONS_SOURCE:-}" ]]; then
+  portfolio_sync_args+=(--transactions-source "${MINERVA_PORTFOLIO_TRANSACTIONS_SOURCE}")
+fi
+if [[ -n "${MINERVA_PORTFOLIO_WATCHLIST_SOURCE:-}" ]]; then
+  portfolio_sync_args+=(--watchlist-source "${MINERVA_PORTFOLIO_WATCHLIST_SOURCE}")
+fi
+run "${portfolio_sync_args[@]}"
+
+filings_args=(brief filings --date "${RUN_DATE}")
+if [[ -n "${MINERVA_BRIEF_FILINGS_SOURCE:-}" ]]; then
+  filings_args+=(--source "${MINERVA_BRIEF_FILINGS_SOURCE}")
+fi
+run "${filings_args[@]}"
+
+earnings_args=(brief earnings --date "${RUN_DATE}" --provider "${MINERVA_BRIEF_EARNINGS_PROVIDER}")
+if [[ -n "${MINERVA_BRIEF_EARNINGS_SOURCE:-}" ]]; then
+  earnings_args+=(--source "${MINERVA_BRIEF_EARNINGS_SOURCE}")
+fi
+run "${earnings_args[@]}"
+
+macro_args=(brief macro --date "${RUN_DATE}")
+if [[ -n "${MINERVA_BRIEF_MACRO_SOURCE:-}" ]]; then
+  macro_args+=(--source "${MINERVA_BRIEF_MACRO_SOURCE}")
+fi
+if [[ -n "${MINERVA_BRIEF_MACRO_REGISTRY:-}" ]]; then
+  macro_args+=(--registry "${MINERVA_BRIEF_MACRO_REGISTRY}")
+fi
+run "${macro_args[@]}"
+
+ir_args=(brief ir --date "${RUN_DATE}")
+if [[ -n "${MINERVA_BRIEF_IR_REGISTRY:-}" ]]; then
+  ir_args+=(--registry "${MINERVA_BRIEF_IR_REGISTRY}")
+fi
+run "${ir_args[@]}"
+
+market_args=(brief market --date "${RUN_DATE}" --provider "${MINERVA_BRIEF_MARKET_PROVIDER}")
+if [[ -n "${MINERVA_BRIEF_MARKET_SOURCE:-}" ]]; then
+  market_args+=(--source "${MINERVA_BRIEF_MARKET_SOURCE}")
+fi
+run "${market_args[@]}"
+
+run brief prep --date "${RUN_DATE}"
+
+PREPARED_PATH="${MINERVA_WORKSPACE_ROOT:-hard-disk}/reports/daily-news/${RUN_DATE}/data/structured/prepared-evidence.json"
+MANIFEST_PATH="${MINERVA_WORKSPACE_ROOT:-hard-disk}/reports/daily-news/${RUN_DATE}/data/raw/manifest.json"
+
+if [[ "${MINERVA_SKIP_STATUS_CHECK}" != "1" ]]; then
+  uv run python - "${MANIFEST_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+sources = manifest.get("sources", {})
+required = ["filings", "earnings", "macro", "ir", "market", "prep"]
+missing = [name for name in required if name not in sources]
+blocking = [name for name in required if sources.get(name, {}).get("status") == "error"]
+if missing:
+    print(f"missing manifest source entries: {', '.join(missing)}", file=sys.stderr)
+    raise SystemExit(1)
+if blocking:
+    print(f"blocking morning-brief collection errors: {', '.join(blocking)}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+fi
+
+echo "prepared_evidence: ${PREPARED_PATH}"
+echo "manifest: ${MANIFEST_PATH}"
+echo "main_agent_step: write notes/morning-brief-report.md and notes/slack-brief.md from the prepared evidence"
+
+if [[ "${WITH_POST_WRITE}" == "1" ]]; then
+  run brief audit --date "${RUN_DATE}"
+  run brief review-log --date "${RUN_DATE}"
+fi

--- a/src/harness/cli.py
+++ b/src/harness/cli.py
@@ -10,9 +10,11 @@ import typer
 
 from harness.commands import register_commands
 from harness.commands import analyze as analyze_commands
+from harness.commands import brief as brief_commands
 from harness.commands import extract as extract_commands
 from harness.commands import fileinfo as fileinfo_commands
 from harness.commands import plot as plot_commands
+from harness.commands import portfolio as portfolio_commands
 from harness.commands import research as research_commands
 from harness.commands import sec as sec_commands
 from harness.commands import valuation as valuation_commands
@@ -186,7 +188,7 @@ def dispatch_command(argv: list[str], stdin: bytes = b"", settings: HarnessSetti
             stderr=(
                 "What went wrong: an empty command segment was provided.\n"
                 "What to do instead: provide a command name before any arguments.\n"
-                "Available alternatives: sec, valuation, analyze, plot, extract, fileinfo, research"
+                "Available alternatives: sec, portfolio, brief, valuation, analyze, plot, extract, fileinfo, research"
             ),
             exit_code=1,
         )
@@ -194,6 +196,12 @@ def dispatch_command(argv: list[str], stdin: bytes = b"", settings: HarnessSetti
     command: str = argv[0]
     dispatchers: dict[str, Callable[[list[str], HarnessSettings, bytes], CommandResult]] = {
         "sec": lambda full_argv, current_settings, current_stdin: sec_commands.dispatch(
+            full_argv[1:], settings=current_settings, stdin=current_stdin
+        ),
+        "portfolio": lambda full_argv, current_settings, current_stdin: portfolio_commands.dispatch(
+            full_argv[1:], settings=current_settings, stdin=current_stdin
+        ),
+        "brief": lambda full_argv, current_settings, current_stdin: brief_commands.dispatch(
             full_argv[1:], settings=current_settings, stdin=current_stdin
         ),
         "valuation": lambda full_argv, current_settings, current_stdin: valuation_commands.dispatch(

--- a/src/harness/commands/__init__.py
+++ b/src/harness/commands/__init__.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import typer
 
-from harness.commands import analyze, extract, fileinfo, plot, research, sec, valuation
+from harness.commands import analyze, brief, extract, fileinfo, plot, portfolio, research, sec, valuation
 
 
 def register_commands(app: typer.Typer) -> None:
     """Register all command groups on the root Typer app."""
     app.add_typer(sec.app, name="sec")
+    app.add_typer(portfolio.app, name="portfolio")
+    app.add_typer(brief.app, name="brief")
     app.add_typer(valuation.app, name="valuation")
     app.add_typer(analyze.app, name="analyze")
     app.add_typer(plot.app, name="plot")

--- a/src/harness/commands/brief.py
+++ b/src/harness/commands/brief.py
@@ -1,0 +1,401 @@
+"""Morning brief evidence collection commands."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import typer
+
+from harness.commands.common import elapsed_ms, error_result, parse_flag_args
+from harness.commands.sec import _configure_edgar
+from harness.config import HarnessSettings, get_settings
+from harness.morning_brief import (
+    append_review_log,
+    audit_evidence,
+    collect_earnings,
+    collect_filings,
+    collect_ir,
+    collect_macro,
+    collect_market,
+    prepare_evidence,
+)
+from harness.output import CommandResult, OutputEnvelope
+from harness.portfolio_state import parse_iso_date
+
+BRIEF_HELP = (
+    "Morning brief evidence collection commands.\n\n"
+    "Examples:\n"
+    "  minerva brief filings --date 2026-04-08\n"
+    "  minerva brief earnings --date 2026-04-08 --source ./market-data.json\n"
+    "  minerva brief prep --date 2026-04-08\n"
+)
+
+app = typer.Typer(help=BRIEF_HELP, no_args_is_help=True)
+
+
+def dispatch(args: list[str], settings: HarnessSettings | None = None, stdin: bytes = b"") -> CommandResult:
+    """Dispatch brief commands for `minerva run`."""
+    _ = stdin
+    active_settings = settings or get_settings()
+    if not args:
+        return CommandResult.from_text("", stderr=_usage_error("no `brief` subcommand was provided"), exit_code=1)
+
+    subcommand = args[0]
+    try:
+        if subcommand == "filings":
+            parsed = parse_flag_args(args[1:])
+            return filings_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                source=str(parsed["source"]) if "source" in parsed else None,
+                since=parse_iso_date(str(parsed["since"])) if "since" in parsed else None,
+                until=parse_iso_date(str(parsed["until"])) if "until" in parsed else None,
+                forms=_split_csv(str(parsed.get("forms", ""))) or None,
+                limit_per_company=int(parsed.get("limit-per-company", 10)),
+                settings=active_settings,
+            )
+        if subcommand == "earnings":
+            parsed = parse_flag_args(args[1:])
+            return earnings_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                source=str(parsed["source"]) if "source" in parsed else None,
+                provider=str(parsed.get("provider", "auto")),
+                settings=active_settings,
+            )
+        if subcommand == "macro":
+            parsed = parse_flag_args(args[1:])
+            return macro_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                source=str(parsed["source"]) if "source" in parsed else None,
+                registry=str(parsed["registry"]) if "registry" in parsed else None,
+                settings=active_settings,
+            )
+        if subcommand == "ir":
+            parsed = parse_flag_args(args[1:])
+            return ir_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                registry=str(parsed["registry"]) if "registry" in parsed else None,
+                settings=active_settings,
+            )
+        if subcommand == "market":
+            parsed = parse_flag_args(args[1:])
+            return market_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                source=str(parsed["source"]) if "source" in parsed else None,
+                provider=str(parsed.get("provider", "auto")),
+                settings=active_settings,
+            )
+        if subcommand == "prep":
+            parsed = parse_flag_args(args[1:])
+            return prep_command(run_date=parse_iso_date(str(parsed.get("date") or "")), settings=active_settings)
+        if subcommand == "audit":
+            parsed = parse_flag_args(args[1:])
+            return audit_command(run_date=parse_iso_date(str(parsed.get("date") or "")), settings=active_settings)
+        if subcommand == "review-log":
+            parsed = parse_flag_args(args[1:])
+            return review_log_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                notes=str(parsed.get("notes", "")),
+                settings=active_settings,
+            )
+    except ValueError as exc:
+        return CommandResult.from_text("", stderr=str(exc), exit_code=1)
+
+    return CommandResult.from_text("", stderr=_usage_error(f"unknown `brief` subcommand `{subcommand}`"), exit_code=1)
+
+
+def filings_command(
+    *,
+    run_date,
+    source: str | None,
+    since,
+    until,
+    forms: list[str] | None,
+    limit_per_company: int,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Collect monitored SEC filings for the run window."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    if not source:
+        identity_error = _configure_edgar(active_settings)
+        if identity_error:
+            return error_result(
+                identity_error,
+                "set EDGAR_IDENTITY or pass `--source` for a local filings payload",
+                ["`export EDGAR_IDENTITY='Minerva Research name@email.com'`", "`brief filings --date 2026-04-08 --source ./filings.json`"],
+                start,
+            )
+    try:
+        summary = collect_filings(
+            active_settings.ensure_workspace_root(),
+            run_date=run_date,
+            source=source,
+            since=since,
+            until=until,
+            forms=forms,
+            limit_per_company=limit_per_company,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to collect filings: {exc}",
+            "verify the portfolio universe and SEC identity, then retry",
+            ["`portfolio sync --holdings-source ./holdings.csv --transactions-source ./transactions.csv`", "`brief filings --date 2026-04-08`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def earnings_command(
+    *,
+    run_date,
+    source: str | None,
+    provider: str,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Collect earnings metadata."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = collect_earnings(
+            active_settings.ensure_workspace_root(),
+            run_date=run_date,
+            source=source,
+            provider=provider,
+            finnhub_api_key=active_settings.finnhub_api_key,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to collect earnings: {exc}",
+            "provide a source file or configure market data credentials",
+            ["`brief earnings --date 2026-04-08 --source ./market-data.json`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def macro_command(
+    *,
+    run_date,
+    source: str | None,
+    registry: str | None,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Collect macro schedule evidence."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = collect_macro(
+            active_settings.ensure_workspace_root(),
+            run_date=run_date,
+            source=source,
+            registry_path=Path(registry) if registry else None,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to collect macro events: {exc}",
+            "provide a macro events source or update the local registry",
+            ["`brief macro --date 2026-04-08 --source ./macro-events.json`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def ir_command(
+    *,
+    run_date,
+    registry: str | None,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Collect IR releases from configured feeds."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = collect_ir(
+            active_settings.ensure_workspace_root(),
+            run_date=run_date,
+            registry_path=Path(registry) if registry else None,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to collect IR releases: {exc}",
+            "update `ir-registry.json` or pass an alternate registry file",
+            ["`brief ir --date 2026-04-08`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def market_command(
+    *,
+    run_date,
+    source: str | None,
+    provider: str,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Collect narrow market context evidence."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = collect_market(
+            active_settings.ensure_workspace_root(),
+            run_date=run_date,
+            source=source,
+            provider=provider,
+            finnhub_api_key=active_settings.finnhub_api_key,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to collect market context: {exc}",
+            "provide a market source file or configure market data credentials",
+            ["`brief market --date 2026-04-08 --source ./market-data.json`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def prep_command(*, run_date, settings: HarnessSettings | None = None) -> CommandResult:
+    """Prepare agent-ready evidence from collected sources."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = prepare_evidence(active_settings.ensure_workspace_root(), run_date=run_date)
+    except Exception as exc:
+        return error_result(
+            f"failed to prepare evidence: {exc}",
+            "run the collection commands first, then retry",
+            ["`brief filings --date 2026-04-08`", "`brief prep --date 2026-04-08`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def audit_command(*, run_date, settings: HarnessSettings | None = None) -> CommandResult:
+    """Run a bounded audit of the prepared evidence."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = audit_evidence(active_settings.ensure_workspace_root(), run_date=run_date)
+    except Exception as exc:
+        return error_result(
+            f"failed to audit evidence: {exc}",
+            "run `brief prep` first, then retry",
+            ["`brief prep --date 2026-04-08`", "`brief audit --date 2026-04-08`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def review_log_command(*, run_date, notes: str, settings: HarnessSettings | None = None) -> CommandResult:
+    """Append one review-log entry for the run."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = append_review_log(active_settings.ensure_workspace_root(), run_date=run_date, notes=notes)
+    except Exception as exc:
+        return error_result(
+            f"failed to append the review log: {exc}",
+            "run `brief audit` first, then retry",
+            ["`brief review-log --date 2026-04-08 --notes '...'`"],
+            start,
+        )
+    return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
+
+
+@app.command("filings", help="Collect overnight SEC filings for the monitored universe.")
+def filings_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    source: str | None = typer.Option(None, "--source", help="Fixture-backed filings payload file."),
+    since: str | None = typer.Option(None, "--since", help="Window start date."),
+    until: str | None = typer.Option(None, "--until", help="Window end date."),
+    forms: str = typer.Option("", "--forms", help="Comma-separated filing forms."),
+    limit_per_company: int = typer.Option(10, "--limit-per-company", min=1, help="Max filings per company."),
+) -> None:
+    _print(
+        filings_command(
+            run_date=parse_iso_date(date_arg),
+            source=source,
+            since=parse_iso_date(since) if since else None,
+            until=parse_iso_date(until) if until else None,
+            forms=_split_csv(forms) or None,
+            limit_per_company=limit_per_company,
+        )
+    )
+
+
+@app.command("earnings", help="Collect reported and upcoming earnings metadata.")
+def earnings_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    source: str | None = typer.Option(None, "--source", help="Shared market data source file."),
+    provider: str = typer.Option("auto", "--provider", help="Provider mode: auto, file, or finnhub."),
+) -> None:
+    _print(earnings_command(run_date=parse_iso_date(date_arg), source=source, provider=provider))
+
+
+@app.command("macro", help="Collect the run-date macro and policy calendar.")
+def macro_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    source: str | None = typer.Option(None, "--source", help="Macro events source file."),
+    registry: str | None = typer.Option(None, "--registry", help="Optional macro registry path."),
+) -> None:
+    _print(macro_command(run_date=parse_iso_date(date_arg), source=source, registry=registry))
+
+
+@app.command("ir", help="Scan configured IR feeds for overnight releases.")
+def ir_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    registry: str | None = typer.Option(None, "--registry", help="Optional IR registry path."),
+) -> None:
+    _print(ir_command(run_date=parse_iso_date(date_arg), registry=registry))
+
+
+@app.command("market", help="Collect narrow market context that materially matters.")
+def market_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    source: str | None = typer.Option(None, "--source", help="Shared market data source file."),
+    provider: str = typer.Option("auto", "--provider", help="Provider mode: auto, file, or finnhub."),
+) -> None:
+    _print(market_command(run_date=parse_iso_date(date_arg), source=source, provider=provider))
+
+
+@app.command("prep", help="Prepare the agent-ready evidence pack.")
+def prep_cli(date_arg: str | None = typer.Option(None, "--date", help="Run date.")) -> None:
+    _print(prep_command(run_date=parse_iso_date(date_arg)))
+
+
+@app.command("audit", help="Run a bounded miss-check after prep.")
+def audit_cli(date_arg: str | None = typer.Option(None, "--date", help="Run date.")) -> None:
+    _print(audit_command(run_date=parse_iso_date(date_arg)))
+
+
+@app.command("review-log", help="Append a structured review-log entry.")
+def review_log_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    notes: str = typer.Option("", "--notes", help="Optional operator notes."),
+) -> None:
+    _print(review_log_command(run_date=parse_iso_date(date_arg), notes=notes))
+
+
+def _usage_error(message: str) -> str:
+    return "\n".join(
+        [
+            f"What went wrong: {message}",
+            "What to do instead: use one of the supported brief commands",
+            "Available alternatives: `brief filings`, `brief prep`, `brief review-log --notes ...`",
+            "",
+            BRIEF_HELP.rstrip(),
+        ]
+    )
+
+
+def _summary_lines(summary: dict[str, object]) -> str:
+    return "\n".join(f"{key}: {summary[key]}" for key in sorted(summary))
+
+
+def _split_csv(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _print(result: CommandResult) -> None:
+    envelope = OutputEnvelope.from_result(result, workspace_root=get_settings().ensure_workspace_root())
+    typer.echo(envelope.render())

--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -1,0 +1,436 @@
+"""Portfolio state commands for the morning brief workflow."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from harness.commands.common import abort_with_help, elapsed_ms, error_result, parse_flag_args
+from harness.config import HarnessSettings, get_settings
+from harness.output import CommandResult, OutputEnvelope
+from harness.portfolio_state import (
+    add_adjacency_entry,
+    canonical_security_id,
+    ensure_portfolio_layout,
+    load_json,
+    parse_iso_date,
+    portfolio_paths,
+    remove_adjacency_entry,
+    render_adjacency_markdown,
+    render_thesis_markdown,
+    set_thesis_card,
+    sync_portfolio,
+    write_json,
+)
+
+PORTFOLIO_HELP = (
+    "Portfolio state commands for the morning brief pipeline.\n\n"
+    "Examples:\n"
+    "  minerva portfolio sync --holdings-source ./holdings.csv --transactions-source ./transactions.csv --date 2026-04-08\n"
+    "  minerva portfolio adjacency add NVDA TSM --type supply-chain --priority high\n"
+    "  minerva portfolio thesis set NVDA --summary \"AI capex demand stays strong\" --expectations \"Blackwell ramps;Gross margin normalizes\"\n"
+)
+
+ADJACENCY_HELP = "Manage the local adjacent-company map."
+THESIS_HELP = "Manage compact thesis cards for monitored securities."
+
+app = typer.Typer(help=PORTFOLIO_HELP, no_args_is_help=True)
+adjacency_app = typer.Typer(help=ADJACENCY_HELP, no_args_is_help=True)
+thesis_app = typer.Typer(help=THESIS_HELP, no_args_is_help=True)
+app.add_typer(adjacency_app, name="adjacency")
+app.add_typer(thesis_app, name="thesis")
+
+
+def dispatch(args: list[str], settings: HarnessSettings | None = None, stdin: bytes = b"") -> CommandResult:
+    """Dispatch portfolio commands for `minerva run`."""
+    _ = stdin
+    active_settings = settings or get_settings()
+    if not args:
+        return CommandResult.from_text("", stderr=_usage_error("no `portfolio` subcommand was provided"), exit_code=1)
+
+    subcommand = args[0]
+    try:
+        if subcommand == "sync":
+            parsed = parse_flag_args(args[1:])
+            return sync_command(
+                as_of=parse_iso_date(str(parsed.get("date") or parsed.get("as-of") or "")),
+                holdings_source=str(parsed["holdings-source"]) if "holdings-source" in parsed else None,
+                transactions_source=str(parsed["transactions-source"]) if "transactions-source" in parsed else None,
+                watchlist_source=str(parsed["watchlist-source"]) if "watchlist-source" in parsed else None,
+                sheet_id=str(parsed["sheet-id"]) if "sheet-id" in parsed else None,
+                holdings_gid=str(parsed["holdings-gid"]) if "holdings-gid" in parsed else None,
+                transactions_gid=str(parsed["transactions-gid"]) if "transactions-gid" in parsed else None,
+                settings=active_settings,
+            )
+        if subcommand == "adjacency":
+            return _dispatch_adjacency(args[1:], active_settings)
+        if subcommand == "thesis":
+            return _dispatch_thesis(args[1:], active_settings)
+    except ValueError as exc:
+        return CommandResult.from_text("", stderr=str(exc), exit_code=1)
+
+    return CommandResult.from_text("", stderr=_usage_error(f"unknown `portfolio` subcommand `{subcommand}`"), exit_code=1)
+
+
+def sync_command(
+    *,
+    as_of,
+    holdings_source: str | None,
+    transactions_source: str | None,
+    watchlist_source: str | None,
+    sheet_id: str | None,
+    holdings_gid: str | None,
+    transactions_gid: str | None,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Sync holdings, watchlist, and transactions into local state."""
+    start = time.perf_counter()
+    active_settings = settings or get_settings()
+    try:
+        summary = sync_portfolio(
+            active_settings.ensure_workspace_root(),
+            as_of=as_of,
+            holdings_source=holdings_source,
+            transactions_source=transactions_source,
+            watchlist_source=watchlist_source,
+            sheet_id=sheet_id,
+            holdings_gid=holdings_gid,
+            transactions_gid=transactions_gid,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to sync portfolio state: {exc}",
+            "provide holdings and transaction sources or configure a sheet export",
+            ["`portfolio sync --holdings-source ./holdings.csv --transactions-source ./transactions.csv`"],
+            start,
+            help_text=PORTFOLIO_HELP,
+        )
+    lines = [
+        f"as_of: {summary['as_of']}",
+        f"holdings: {summary['holdings_count']}",
+        f"watchlist: {summary['watchlist_count']}",
+        f"universe: {summary['universe_count']}",
+        f"transactions: {summary['transactions_count']}",
+        f"rendered_to: {summary['rendered_path']}",
+    ]
+    return CommandResult.from_text("\n".join(lines), duration_ms=elapsed_ms(start))
+
+
+def list_adjacency_command(*, settings: HarnessSettings | None = None) -> CommandResult:
+    """List adjacency entries."""
+    start = time.perf_counter()
+    paths = ensure_portfolio_layout((settings or get_settings()).ensure_workspace_root())
+    entries = load_json(paths.adjacency_map, default=[])
+    return CommandResult.from_text(render_adjacency_markdown(entries), duration_ms=elapsed_ms(start))
+
+
+def add_adjacency_command(
+    *,
+    monitored: str,
+    adjacent: str,
+    relationship_type: str,
+    note: str | None,
+    priority: str | None,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Add an adjacency entry."""
+    start = time.perf_counter()
+    try:
+        entry = add_adjacency_entry(
+            (settings or get_settings()).ensure_workspace_root(),
+            monitored=monitored,
+            adjacent=adjacent,
+            relationship_type=relationship_type,
+            note=note,
+            priority=priority,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to add adjacency entry: {exc}",
+            "pass monitored and adjacent identifiers plus a relationship type",
+            ["`portfolio adjacency add NVDA TSM --type supply-chain`"],
+            start,
+        )
+    return CommandResult.from_text(json_lines(entry), duration_ms=elapsed_ms(start))
+
+
+def remove_adjacency_command(
+    *,
+    monitored: str,
+    adjacent: str,
+    relationship_type: str | None = None,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Remove adjacency entries for one pair."""
+    start = time.perf_counter()
+    try:
+        summary = remove_adjacency_entry(
+            (settings or get_settings()).ensure_workspace_root(),
+            monitored=monitored,
+            adjacent=adjacent,
+            relationship_type=relationship_type,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to remove adjacency entry: {exc}",
+            "pass monitored and adjacent identifiers, and optionally a relationship type",
+            ["`portfolio adjacency remove NVDA TSM --type supply-chain`"],
+            start,
+        )
+    return CommandResult.from_text(json_lines(summary), duration_ms=elapsed_ms(start))
+
+
+def render_adjacency_command(*, settings: HarnessSettings | None = None) -> CommandResult:
+    """Render adjacency markdown to disk."""
+    start = time.perf_counter()
+    paths = ensure_portfolio_layout((settings or get_settings()).ensure_workspace_root())
+    entries = load_json(paths.adjacency_map, default=[])
+    body = render_adjacency_markdown(entries)
+    paths.adjacency_rendered.write_text(body, encoding="utf-8")
+    return CommandResult.from_text(f"rendered_to: {paths.adjacency_rendered}", duration_ms=elapsed_ms(start))
+
+
+def list_thesis_command(*, settings: HarnessSettings | None = None) -> CommandResult:
+    """List thesis cards."""
+    start = time.perf_counter()
+    paths = ensure_portfolio_layout((settings or get_settings()).ensure_workspace_root())
+    cards = load_json(paths.thesis_cards, default=[])
+    return CommandResult.from_text(render_thesis_markdown(cards), duration_ms=elapsed_ms(start))
+
+
+def show_thesis_command(*, security: str, settings: HarnessSettings | None = None) -> CommandResult:
+    """Show one thesis card."""
+    start = time.perf_counter()
+    paths = ensure_portfolio_layout((settings or get_settings()).ensure_workspace_root())
+    cards = load_json(paths.thesis_cards, default=[])
+    security_id = canonical_security_id(security)
+    selected = [card for card in cards if str(card.get("security_id", "")).upper() == security_id]
+    if not selected:
+        return error_result(
+            f"no thesis card exists for {security_id}",
+            "set one first with `portfolio thesis set`",
+            [f"`portfolio thesis set {security_id} --summary ...`"],
+            start,
+        )
+    return CommandResult.from_text(render_thesis_markdown(selected), duration_ms=elapsed_ms(start))
+
+
+def set_thesis_command(
+    *,
+    security: str,
+    summary: str,
+    expectations: str,
+    disconfirming: str,
+    settings: HarnessSettings | None = None,
+) -> CommandResult:
+    """Create or replace one thesis card."""
+    start = time.perf_counter()
+    try:
+        card = set_thesis_card(
+            (settings or get_settings()).ensure_workspace_root(),
+            security=security,
+            summary=summary,
+            expectations=_split_multi_value(expectations),
+            disconfirming_signals=_split_multi_value(disconfirming),
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to set thesis card: {exc}",
+            "pass a security identifier and summary, then retry",
+            ["`portfolio thesis set NVDA --summary 'AI capex demand stays strong'`"],
+            start,
+        )
+    return CommandResult.from_text(json_lines(card), duration_ms=elapsed_ms(start))
+
+
+def render_thesis_command(*, settings: HarnessSettings | None = None) -> CommandResult:
+    """Render thesis cards to disk."""
+    start = time.perf_counter()
+    paths = ensure_portfolio_layout((settings or get_settings()).ensure_workspace_root())
+    cards = load_json(paths.thesis_cards, default=[])
+    body = render_thesis_markdown(cards)
+    paths.thesis_rendered.write_text(body, encoding="utf-8")
+    return CommandResult.from_text(f"rendered_to: {paths.thesis_rendered}", duration_ms=elapsed_ms(start))
+
+
+@app.command("sync", help="Sync holdings, transactions, and watchlist state.")
+def sync_cli(
+    ctx: typer.Context,
+    date_arg: str | None = typer.Option(None, "--date", help="ISO date for the sync run."),
+    as_of: str | None = typer.Option(None, "--as-of", help="Alias for --date."),
+    holdings_source: str | None = typer.Option(None, "--holdings-source", help="CSV/JSON/YAML holdings source."),
+    transactions_source: str | None = typer.Option(None, "--transactions-source", help="CSV/JSON/YAML transactions source."),
+    watchlist_source: str | None = typer.Option(None, "--watchlist-source", help="Optional local watchlist source."),
+    sheet_id: str | None = typer.Option(None, "--sheet-id", help="Google Sheet identifier."),
+    holdings_gid: str | None = typer.Option(None, "--holdings-gid", help="Google Sheet gid for holdings."),
+    transactions_gid: str | None = typer.Option(None, "--transactions-gid", help="Google Sheet gid for transactions."),
+) -> None:
+    if not holdings_source and not sheet_id and not portfolio_paths(get_settings().ensure_workspace_root()).holdings.exists():
+        abort_with_help(
+            ctx,
+            what_went_wrong="no holdings source was provided",
+            what_to_do="pass `--holdings-source` or a Google Sheet export configuration",
+            alternatives=["`minerva portfolio sync --holdings-source ./holdings.csv --transactions-source ./transactions.csv`"],
+        )
+    _print(
+        sync_command(
+            as_of=parse_iso_date(date_arg or as_of),
+            holdings_source=holdings_source,
+            transactions_source=transactions_source,
+            watchlist_source=watchlist_source,
+            sheet_id=sheet_id,
+            holdings_gid=holdings_gid,
+            transactions_gid=transactions_gid,
+        )
+    )
+
+
+@adjacency_app.command("list", help="List stored adjacency mappings.")
+def adjacency_list_cli() -> None:
+    _print(list_adjacency_command())
+
+
+@adjacency_app.command("add", help="Add or replace one adjacency relationship.")
+def adjacency_add_cli(
+    monitored: str = typer.Argument(..., help="Monitored company identifier."),
+    adjacent: str = typer.Argument(..., help="Adjacent company identifier."),
+    relationship_type: str = typer.Option(..., "--type", help="Relationship type."),
+    note: str | None = typer.Option(None, "--note", help="Optional note."),
+    priority: str | None = typer.Option(None, "--priority", help="Optional priority tag."),
+) -> None:
+    _print(
+        add_adjacency_command(
+            monitored=monitored,
+            adjacent=adjacent,
+            relationship_type=relationship_type,
+            note=note,
+            priority=priority,
+        )
+    )
+
+
+@adjacency_app.command("remove", help="Remove one adjacency mapping pair.")
+def adjacency_remove_cli(
+    monitored: str = typer.Argument(..., help="Monitored company identifier."),
+    adjacent: str = typer.Argument(..., help="Adjacent company identifier."),
+    relationship_type: str | None = typer.Option(None, "--type", help="Optional relationship type filter."),
+) -> None:
+    _print(remove_adjacency_command(monitored=monitored, adjacent=adjacent, relationship_type=relationship_type))
+
+
+@adjacency_app.command("render", help="Render adjacency markdown.")
+def adjacency_render_cli() -> None:
+    _print(render_adjacency_command())
+
+
+@thesis_app.command("list", help="List thesis cards.")
+def thesis_list_cli() -> None:
+    _print(list_thesis_command())
+
+
+@thesis_app.command("show", help="Show one thesis card.")
+def thesis_show_cli(security: str = typer.Argument(..., help="Security identifier.")) -> None:
+    _print(show_thesis_command(security=security))
+
+
+@thesis_app.command("set", help="Create or replace one thesis card.")
+def thesis_set_cli(
+    security: str = typer.Argument(..., help="Security identifier."),
+    summary: str = typer.Option(..., "--summary", help="Compact thesis summary."),
+    expectations: str = typer.Option("", "--expectations", help="Semicolon-separated key expectations."),
+    disconfirming: str = typer.Option("", "--disconfirming", help="Semicolon-separated disconfirming signals."),
+) -> None:
+    _print(set_thesis_command(security=security, summary=summary, expectations=expectations, disconfirming=disconfirming))
+
+
+@thesis_app.command("render", help="Render thesis cards markdown.")
+def thesis_render_cli() -> None:
+    _print(render_thesis_command())
+
+
+def _dispatch_adjacency(args: list[str], settings: HarnessSettings) -> CommandResult:
+    if not args:
+        return CommandResult.from_text("", stderr=_usage_error("no `portfolio adjacency` action was provided"), exit_code=1)
+    action = args[0]
+    if action == "list":
+        return list_adjacency_command(settings=settings)
+    if action == "render":
+        return render_adjacency_command(settings=settings)
+    if action == "add":
+        if len(args) < 3:
+            return CommandResult.from_text("", stderr=_usage_error("missing monitored/adjacent identifiers"), exit_code=1)
+        parsed = parse_flag_args(args[3:])
+        return add_adjacency_command(
+            monitored=args[1],
+            adjacent=args[2],
+            relationship_type=str(parsed.get("type", "")),
+            note=str(parsed["note"]) if "note" in parsed else None,
+            priority=str(parsed["priority"]) if "priority" in parsed else None,
+            settings=settings,
+        )
+    if action == "remove":
+        if len(args) < 3:
+            return CommandResult.from_text("", stderr=_usage_error("missing monitored/adjacent identifiers"), exit_code=1)
+        parsed = parse_flag_args(args[3:])
+        return remove_adjacency_command(
+            monitored=args[1],
+            adjacent=args[2],
+            relationship_type=str(parsed["type"]) if "type" in parsed else None,
+            settings=settings,
+        )
+    return CommandResult.from_text("", stderr=_usage_error(f"unknown adjacency action `{action}`"), exit_code=1)
+
+
+def _dispatch_thesis(args: list[str], settings: HarnessSettings) -> CommandResult:
+    if not args:
+        return CommandResult.from_text("", stderr=_usage_error("no `portfolio thesis` action was provided"), exit_code=1)
+    action = args[0]
+    if action == "list":
+        return list_thesis_command(settings=settings)
+    if action == "render":
+        return render_thesis_command(settings=settings)
+    if action == "show":
+        if len(args) < 2:
+            return CommandResult.from_text("", stderr=_usage_error("missing security identifier"), exit_code=1)
+        return show_thesis_command(security=args[1], settings=settings)
+    if action == "set":
+        if len(args) < 2:
+            return CommandResult.from_text("", stderr=_usage_error("missing security identifier"), exit_code=1)
+        parsed = parse_flag_args(args[2:])
+        return set_thesis_command(
+            security=args[1],
+            summary=str(parsed.get("summary", "")),
+            expectations=str(parsed.get("expectations", "")),
+            disconfirming=str(parsed.get("disconfirming", "")),
+            settings=settings,
+        )
+    return CommandResult.from_text("", stderr=_usage_error(f"unknown thesis action `{action}`"), exit_code=1)
+
+
+def _usage_error(message: str) -> str:
+    return "\n".join(
+        [
+            f"What went wrong: {message}",
+            "What to do instead: use one of the supported portfolio commands",
+            "Available alternatives: `portfolio sync`, `portfolio adjacency list`, `portfolio thesis set NVDA --summary ...`",
+            "",
+            PORTFOLIO_HELP.rstrip(),
+        ]
+    )
+
+
+def _split_multi_value(value: str) -> list[str]:
+    normalized = value.replace("|", ";")
+    return [item.strip() for item in normalized.split(";") if item.strip()]
+
+
+def json_lines(payload: dict[str, Any]) -> str:
+    return "\n".join(f"{key}: {payload[key]}" for key in sorted(payload))
+
+
+def _print(result: CommandResult) -> None:
+    envelope = OutputEnvelope.from_result(result, workspace_root=get_settings().ensure_workspace_root())
+    typer.echo(envelope.render())

--- a/src/harness/config.py
+++ b/src/harness/config.py
@@ -16,6 +16,7 @@ class HarnessSettings(BaseModel):
     edgar_identity: str | None = None
     parallel_api_key: str | None = None
     gemini_api_key: str | None = None
+    finnhub_api_key: str | None = None
     minerva_plot_theme: str = "minerva-classic"
 
     @property
@@ -38,5 +39,6 @@ def get_settings() -> HarnessSettings:
         edgar_identity=os.getenv("EDGAR_IDENTITY"),
         parallel_api_key=os.getenv("PARALLEL_API_KEY"),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
+        finnhub_api_key=os.getenv("FINNHUB_API_KEY"),
         minerva_plot_theme=os.getenv("MINERVA_PLOT_THEME", "minerva-classic"),
     )

--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -1,0 +1,1289 @@
+"""Morning market brief evidence collection and preparation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+import requests
+
+from harness.portfolio_state import (
+    append_jsonl,
+    canonical_security_id,
+    ensure_portfolio_layout,
+    load_json,
+    load_payload,
+    now_utc_iso,
+    parse_iso_date,
+    portfolio_paths,
+    read_text_source,
+    write_json,
+)
+from minerva.sec import get_recent_filings
+
+
+DEFAULT_FILING_FORMS = ["8-K", "10-K", "10-Q", "SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"]
+DEFAULT_INDEX_SYMBOLS = ["SPY", "QQQ", "DIA", "IWM"]
+
+
+@dataclass(slots=True)
+class RunPaths:
+    """Filesystem layout for one morning brief run."""
+
+    workspace_root: Path
+    run_date: date
+
+    @property
+    def root(self) -> Path:
+        return self.workspace_root / "reports" / "daily-news" / self.run_date.isoformat()
+
+    @property
+    def notes_dir(self) -> Path:
+        return self.root / "notes"
+
+    @property
+    def data_dir(self) -> Path:
+        return self.root / "data"
+
+    @property
+    def raw_dir(self) -> Path:
+        return self.data_dir / "raw"
+
+    @property
+    def structured_dir(self) -> Path:
+        return self.data_dir / "structured"
+
+    @property
+    def rendered_dir(self) -> Path:
+        return self.data_dir / "rendered"
+
+    @property
+    def manifest(self) -> Path:
+        return self.raw_dir / "manifest.json"
+
+    @property
+    def review_log(self) -> Path:
+        return self.workspace_root / "reports" / "daily-news" / "review-log.jsonl"
+
+
+def ensure_daily_run_layout(workspace_root: Path, run_date: date) -> RunPaths:
+    """Create the run folder layout and starter files."""
+    paths = RunPaths(workspace_root=workspace_root.resolve(), run_date=run_date)
+    root = paths.workspace_root / "reports" / "daily-news"
+    root.mkdir(parents=True, exist_ok=True)
+    paths.notes_dir.mkdir(parents=True, exist_ok=True)
+    paths.raw_dir.mkdir(parents=True, exist_ok=True)
+    paths.structured_dir.mkdir(parents=True, exist_ok=True)
+    paths.rendered_dir.mkdir(parents=True, exist_ok=True)
+
+    _ensure_index(root / "INDEX.md", "Daily News Runs", "Daily morning brief evidence runs and review logs.")
+    _ensure_index(paths.root / "INDEX.md", f"Daily Run {run_date.isoformat()}", "Evidence and notes for one run date.")
+    _ensure_index(paths.notes_dir / "INDEX.md", "Notes", "Morning brief writeups produced after evidence prep.")
+    _ensure_index(paths.data_dir / "INDEX.md", "Data", "Raw, structured, and rendered evidence for this run.")
+    _ensure_index(paths.raw_dir / "INDEX.md", "Raw Evidence", "Raw source payloads and the run manifest.")
+    _ensure_index(paths.structured_dir / "INDEX.md", "Structured Evidence", "Prepared and audited evidence artifacts.")
+    _ensure_index(paths.rendered_dir / "INDEX.md", "Rendered Evidence", "Deterministic markdown renders for human review.")
+
+    for notes_file, title in (
+        (paths.notes_dir / "morning-brief-report.md", "Morning Brief Report"),
+        (paths.notes_dir / "slack-brief.md", "Slack Brief"),
+    ):
+        if not notes_file.exists():
+            notes_file.write_text(f"# {title}\n\nPending main-agent writeup.\n", encoding="utf-8")
+
+    if not paths.review_log.exists():
+        paths.review_log.write_text("", encoding="utf-8")
+    if not paths.manifest.exists():
+        write_json(paths.manifest, _manifest_seed(paths))
+    else:
+        manifest = load_manifest(run_paths=paths)
+        manifest.setdefault("outputs", {})
+        manifest["outputs"].update(_default_manifest_outputs(paths))
+        write_json(paths.manifest, manifest)
+    return paths
+
+
+def collect_filings(
+    workspace_root: Path,
+    *,
+    run_date: date,
+    source: str | None = None,
+    forms: list[str] | None = None,
+    since: date | None = None,
+    until: date | None = None,
+    limit_per_company: int = 10,
+) -> dict[str, Any]:
+    """Collect normalized SEC filing events for the monitored universe."""
+    ensure_portfolio_layout(workspace_root)
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+    if not universe:
+        raise ValueError("portfolio universe is empty; run `minerva portfolio sync` first")
+
+    effective_since = since or run_date
+    effective_until = until or run_date
+    raw_companies: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    degraded_reasons: list[str] = []
+
+    if source:
+        raw_companies, events = _load_filings_source_payload(source, universe, run_date)
+    else:
+        for security in universe:
+            ticker = str(security.get("ticker") or security.get("security_id") or "").strip()
+            if not ticker:
+                continue
+            try:
+                filings = get_recent_filings(
+                    ticker,
+                    forms=forms or DEFAULT_FILING_FORMS,
+                    since=effective_since,
+                    until=effective_until,
+                    limit=limit_per_company,
+                )
+            except Exception as exc:
+                errors.append({"security_id": str(security.get("security_id", ticker)), "error": str(exc)})
+                continue
+            raw_companies.append({"security": security, "filings": filings})
+            for filing in filings:
+                events.append(_normalize_filing_event(security, filing))
+
+    sorted_events = sorted(events, key=lambda item: (item["event_date"], item["security_id"], item["headline"]))
+
+    payload = {
+        "date": run_date.isoformat(),
+        "collected_at": now_utc_iso(),
+        "forms": forms or DEFAULT_FILING_FORMS,
+        "source": source,
+        "companies": raw_companies,
+        "events": sorted_events,
+        "errors": errors,
+        "degraded_reasons": degraded_reasons,
+    }
+    raw_path = run_paths.raw_dir / "filings.json"
+    rendered_path = run_paths.rendered_dir / "filings.md"
+    write_json(raw_path, payload)
+    rendered_path.write_text(render_event_markdown("Filings", sorted_events), encoding="utf-8")
+    status = "success" if not errors else ("degraded" if events else "error")
+    update_manifest_source(
+        run_paths,
+        "filings",
+        {
+            "status": status,
+            "event_count": len(sorted_events),
+            "error_count": len(errors),
+            "raw_path": str(raw_path),
+            "rendered_path": str(rendered_path),
+            "source": source,
+            "window": {"since": effective_since.isoformat(), "until": effective_until.isoformat()},
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    return {"status": status, "event_count": len(sorted_events), "error_count": len(errors), "raw_path": raw_path}
+
+
+def collect_earnings(
+    workspace_root: Path,
+    *,
+    run_date: date,
+    source: str | None = None,
+    provider: str = "auto",
+    finnhub_api_key: str | None = None,
+) -> dict[str, Any]:
+    """Collect earnings metadata and normalize it into events."""
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+    adjacency_map = load_json(portfolio_paths(workspace_root).adjacency_map, default=[])
+    payload, degraded_reasons = load_market_provider_payload(
+        source=source,
+        provider=provider,
+        finnhub_api_key=finnhub_api_key,
+        run_date=run_date,
+    )
+    source_rows = payload.get("earnings", payload if isinstance(payload, list) else [])
+    events: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+
+    for row in source_rows:
+        event = _normalize_earnings_event(row, run_date, universe, adjacency_map)
+        if event is None:
+            suppressed.append(dict(row))
+            continue
+        events.append(event)
+    sorted_events = sorted(events, key=lambda item: (item["event_date"], item["relationship"], item["security_id"], item["headline"]))
+
+    raw_path = run_paths.raw_dir / "earnings.json"
+    rendered_path = run_paths.rendered_dir / "earnings.md"
+    write_json(
+        raw_path,
+        {
+            "date": run_date.isoformat(),
+            "collected_at": now_utc_iso(),
+            "provider": provider,
+            "source": source,
+            "payload": payload,
+            "events": sorted_events,
+            "suppressed": suppressed,
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    rendered_path.write_text(render_event_markdown("Earnings", sorted_events), encoding="utf-8")
+    status = "degraded" if degraded_reasons else "success"
+    update_manifest_source(
+        run_paths,
+        "earnings",
+        {
+            "status": status,
+            "event_count": len(sorted_events),
+            "suppressed_count": len(suppressed),
+            "raw_path": str(raw_path),
+            "rendered_path": str(rendered_path),
+            "provider": provider,
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    return {"status": status, "event_count": len(sorted_events), "raw_path": raw_path}
+
+
+def collect_macro(
+    workspace_root: Path,
+    *,
+    run_date: date,
+    source: str | None = None,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    """Collect the run-date macro schedule from a local registry or source file."""
+    ensure_portfolio_layout(workspace_root)
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    paths = portfolio_paths(workspace_root)
+    registry_file = registry_path or paths.macro_registry
+    registry = load_json(registry_file, default={"sources": []})
+    events_source = source or registry.get("events_source")
+    degraded_reasons: list[str] = []
+    source_rows: list[dict[str, Any]] = []
+    if events_source:
+        loaded_payload, _ = load_payload(str(events_source))
+        if isinstance(loaded_payload, list):
+            source_rows = [dict(item) for item in loaded_payload if isinstance(item, dict)]
+        elif isinstance(loaded_payload, dict):
+            source_rows = [dict(item) for item in loaded_payload.get("events", []) if isinstance(item, dict)]
+    else:
+        degraded_reasons.append("no macro events source configured")
+
+    events = [_normalize_macro_event(row, run_date) for row in source_rows]
+    events = [event for event in events if event is not None]
+    sorted_events = sorted(events, key=lambda item: (item["event_date"], item.get("release_time", ""), item["headline"]))
+
+    raw_path = run_paths.raw_dir / "macro.json"
+    rendered_path = run_paths.rendered_dir / "macro.md"
+    write_json(
+        raw_path,
+        {
+            "date": run_date.isoformat(),
+            "collected_at": now_utc_iso(),
+            "registry": registry,
+            "events": sorted_events,
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    rendered_path.write_text(render_event_markdown("Macro", sorted_events), encoding="utf-8")
+    status = "degraded" if degraded_reasons else "success"
+    update_manifest_source(
+        run_paths,
+        "macro",
+        {
+            "status": status,
+            "event_count": len(sorted_events),
+            "raw_path": str(raw_path),
+            "rendered_path": str(rendered_path),
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    return {"status": status, "event_count": len(sorted_events), "raw_path": raw_path}
+
+
+def collect_ir(
+    workspace_root: Path,
+    *,
+    run_date: date,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    """Collect IR releases from a locally curated registry."""
+    ensure_portfolio_layout(workspace_root)
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    paths = portfolio_paths(workspace_root)
+    registry = load_json(registry_path or paths.ir_registry, default=[])
+
+    events: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    degraded_reasons: list[str] = []
+    if not registry:
+        degraded_reasons.append("no IR registry configured")
+    configured_feeds = 0
+    for entry in registry:
+        security_id = canonical_security_id(entry.get("security_id") or entry.get("ticker") or entry.get("company_name"))
+        for feed in entry.get("feeds", []):
+            feed_url = str(feed.get("url") or "").strip()
+            feed_format = str(feed.get("format") or "rss").strip().lower()
+            if not feed_url:
+                continue
+            configured_feeds += 1
+            try:
+                feed_events = _parse_ir_feed(feed_url, feed_format, run_date, security_id, entry)
+            except Exception as exc:
+                errors.append({"security_id": security_id, "url": feed_url, "error": str(exc)})
+                continue
+            events.extend(feed_events)
+    if registry and configured_feeds == 0:
+        degraded_reasons.append("IR registry has no configured feeds")
+    sorted_events = sorted(events, key=lambda item: (item["event_date"], item["security_id"], item["headline"]))
+
+    raw_path = run_paths.raw_dir / "ir.json"
+    rendered_path = run_paths.rendered_dir / "ir.md"
+    write_json(
+        raw_path,
+        {
+            "date": run_date.isoformat(),
+            "collected_at": now_utc_iso(),
+            "registry": registry,
+            "events": sorted_events,
+            "errors": errors,
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    rendered_path.write_text(render_event_markdown("IR", sorted_events), encoding="utf-8")
+    status = "success"
+    if degraded_reasons or errors:
+        status = "degraded" if sorted_events or degraded_reasons else "error"
+    update_manifest_source(
+        run_paths,
+        "ir",
+        {
+            "status": status,
+            "event_count": len(sorted_events),
+            "error_count": len(errors),
+            "raw_path": str(raw_path),
+            "rendered_path": str(rendered_path),
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    return {"status": status, "event_count": len(sorted_events), "raw_path": raw_path}
+
+
+def collect_market(
+    workspace_root: Path,
+    *,
+    run_date: date,
+    source: str | None = None,
+    provider: str = "auto",
+    finnhub_api_key: str | None = None,
+) -> dict[str, Any]:
+    """Collect a narrow market context snapshot."""
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    payload, degraded_reasons = load_market_provider_payload(
+        source=source,
+        provider=provider,
+        finnhub_api_key=finnhub_api_key,
+        run_date=run_date,
+    )
+    events = normalize_market_events(payload, run_date)
+    sorted_events = sorted(events, key=lambda item: (item["event_date"], item.get("category", ""), item["headline"]))
+
+    raw_path = run_paths.raw_dir / "market.json"
+    rendered_path = run_paths.rendered_dir / "market.md"
+    write_json(
+        raw_path,
+        {
+            "date": run_date.isoformat(),
+            "collected_at": now_utc_iso(),
+            "provider": provider,
+            "source": source,
+            "payload": payload,
+            "events": sorted_events,
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    rendered_path.write_text(render_event_markdown("Market", sorted_events), encoding="utf-8")
+    status = "degraded" if degraded_reasons else "success"
+    update_manifest_source(
+        run_paths,
+        "market",
+        {
+            "status": status,
+            "event_count": len(sorted_events),
+            "raw_path": str(raw_path),
+            "rendered_path": str(rendered_path),
+            "provider": provider,
+            "degraded_reasons": degraded_reasons,
+        },
+    )
+    return {"status": status, "event_count": len(sorted_events), "raw_path": raw_path}
+
+
+def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
+    """Build an agent-ready evidence pack from collected sources."""
+    ensure_portfolio_layout(workspace_root)
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    paths = portfolio_paths(workspace_root)
+    manifest = load_manifest(run_paths)
+    universe = load_json(paths.universe, default=[])
+    adjacency_map = load_json(paths.adjacency_map, default=[])
+    thesis_cards = load_json(paths.thesis_cards, default=[])
+
+    source_payloads = {name: _load_raw_source(run_paths, name) for name in ("filings", "earnings", "macro", "ir", "market")}
+    source_events = {name: payload.get("events", []) for name, payload in source_payloads.items()}
+
+    all_events: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source_name, events in source_events.items():
+        for event in events:
+            enriched = enrich_event_relationships(dict(event), universe, adjacency_map)
+            dedupe_key = build_event_key(enriched)
+            if dedupe_key in seen:
+                suppressed.append({"reason": "duplicate", "event": enriched})
+                continue
+            if enriched.get("event_date") not in {"", run_date.isoformat()}:
+                suppressed.append({"reason": "stale", "event": enriched})
+                continue
+            if not enriched.get("headline"):
+                suppressed.append({"reason": "missing-headline", "event": enriched})
+                continue
+            seen.add(dedupe_key)
+            enriched["source_name"] = source_name
+            all_events.append(enriched)
+
+    sorted_events = sorted(
+        all_events,
+        key=lambda item: (
+            item["group"],
+            item.get("relationship", ""),
+            item.get("security_id", ""),
+            item["headline"],
+        ),
+    )
+    grouped = group_prepared_events(sorted_events)
+    thesis_map = {str(card.get("security_id", "")): card for card in thesis_cards}
+    prepared = {
+        "date": run_date.isoformat(),
+        "generated_at": now_utc_iso(),
+        "universe": universe,
+        "events": sorted_events,
+        "grouped_events": grouped,
+        "suppressed": suppressed,
+        "thesis_cards": {key: thesis_map[key] for key in sorted(thesis_map)},
+        "source_status": manifest.get("sources", {}),
+    }
+
+    universe_path = run_paths.structured_dir / "universe.json"
+    prepared_path = run_paths.structured_dir / "prepared-evidence.json"
+    source_status_path = run_paths.rendered_dir / "source-status.md"
+    grouped_path = run_paths.rendered_dir / "grouped-events.md"
+    evidence_path = run_paths.rendered_dir / "evidence.md"
+    write_json(universe_path, universe)
+    write_json(prepared_path, prepared)
+    grouped_path.write_text(render_grouped_events_markdown(grouped), encoding="utf-8")
+    source_status_path.write_text(render_source_status_markdown(manifest.get("sources", {})), encoding="utf-8")
+    evidence_path.write_text(render_event_markdown("Prepared Evidence", sorted_events), encoding="utf-8")
+
+    update_manifest_source(
+        run_paths,
+        "prep",
+        {
+            "status": "success",
+            "event_count": len(sorted_events),
+            "suppressed_count": len(suppressed),
+            "prepared_path": str(prepared_path),
+            "grouped_events_path": str(grouped_path),
+            "source_status_path": str(source_status_path),
+            "evidence_path": str(evidence_path),
+            "universe_path": str(universe_path),
+        },
+    )
+    return {"status": "success", "event_count": len(sorted_events), "prepared_path": prepared_path}
+
+
+def audit_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
+    """Run a bounded audit on prepared evidence."""
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    manifest = load_manifest(run_paths)
+    prepared = load_json(run_paths.structured_dir / "prepared-evidence.json", default={})
+    prepared_events = prepared.get("events", [])
+    prepared_keys = {build_event_key(event) for event in prepared_events}
+    suppressed_keys = {
+        build_event_key(item.get("event", {}))
+        for item in prepared.get("suppressed", [])
+        if isinstance(item, dict) and isinstance(item.get("event"), dict)
+    }
+    raw_sources = {name: _load_raw_source(run_paths, name) for name in ("filings", "earnings", "macro", "ir", "market")}
+
+    missed_events: list[dict[str, Any]] = []
+    for name, payload in raw_sources.items():
+        for event in payload.get("events", []):
+            event_key = build_event_key(event)
+            if event_key in prepared_keys or event_key in suppressed_keys:
+                continue
+            if _event_date(event, run_date) != run_date.isoformat():
+                continue
+            if not str(event.get("headline") or "").strip():
+                continue
+            if event.get("source") == "market" and event.get("change_pct") is None:
+                missed_events.append({"source": name, "event": event})
+                continue
+            missed_events.append({"source": name, "event": event})
+
+    source_failures = {
+        name: details for name, details in manifest.get("sources", {}).items() if details.get("status") not in {"success", ""}
+    }
+    covered_security_ids = {str(event.get("security_id", "")) for event in prepared_events if event.get("relationship") == "monitored"}
+    universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+    uncovered_monitored = [
+        str(item.get("security_id", ""))
+        for item in universe
+        if str(item.get("security_id", "")) and str(item.get("security_id", "")) not in covered_security_ids
+    ]
+
+    audit_payload = {
+        "date": run_date.isoformat(),
+        "generated_at": now_utc_iso(),
+        "missed_events": missed_events,
+        "source_failures": source_failures,
+        "uncovered_monitored": uncovered_monitored,
+    }
+    audit_path = run_paths.structured_dir / "audit.json"
+    rendered_path = run_paths.rendered_dir / "audit.md"
+    write_json(audit_path, audit_payload)
+    rendered_path.write_text(render_audit_markdown(audit_payload), encoding="utf-8")
+    update_manifest_source(
+        run_paths,
+        "audit",
+        {
+            "status": "success",
+            "missed_event_count": len(missed_events),
+            "audit_path": str(audit_path),
+            "rendered_path": str(rendered_path),
+        },
+    )
+    return {"status": "success", "missed_event_count": len(missed_events), "audit_path": audit_path}
+
+
+def append_review_log(workspace_root: Path, *, run_date: date, notes: str | None = None) -> dict[str, Any]:
+    """Append one structured review log entry for the run."""
+    run_paths = ensure_daily_run_layout(workspace_root, run_date)
+    manifest = load_manifest(run_paths)
+    audit = load_json(run_paths.structured_dir / "audit.json", default={})
+    entry = {
+        "run_id": run_date.isoformat(),
+        "date": run_date.isoformat(),
+        "logged_at": now_utc_iso(),
+        "source_failures": {
+            name: details
+            for name, details in manifest.get("sources", {}).items()
+            if details.get("status") not in {"success", ""}
+        },
+        "degraded_modes_used": sorted(
+            {
+                reason
+                for details in manifest.get("sources", {}).values()
+                for reason in details.get("degraded_reasons", [])
+            }
+        ),
+        "misses_found_later": len(audit.get("missed_events", [])),
+        "recurring_pain_points": audit.get("uncovered_monitored", []),
+        "notes": (notes or "").strip(),
+    }
+    append_jsonl(run_paths.review_log, entry)
+    update_manifest_source(
+        run_paths,
+        "review-log",
+        {
+            "status": "success",
+            "review_log_path": str(run_paths.review_log),
+            "logged_at": entry["logged_at"],
+            "entry_count": len(_read_review_log(run_paths.review_log)),
+        },
+    )
+    return {"status": "success", "review_log_path": run_paths.review_log}
+
+
+def _load_filings_source_payload(
+    source: str,
+    universe: list[dict[str, Any]],
+    run_date: date,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Load fixture-backed filing payloads for deterministic local runs."""
+    payload, _ = load_payload(source)
+    universe_lookup = _build_universe_lookup(universe)
+
+    explicit_events: list[dict[str, Any]] = []
+    company_rows: list[dict[str, Any]] = []
+    filing_rows: list[dict[str, Any]] = []
+
+    if isinstance(payload, dict):
+        company_rows = [dict(item) for item in payload.get("companies", []) if isinstance(item, dict)]
+        explicit_events = [
+            _normalize_filing_source_event(dict(item), universe_lookup, run_date)
+            for item in payload.get("events", [])
+            if isinstance(item, dict)
+        ]
+        filing_rows = [dict(item) for item in payload.get("filings", []) if isinstance(item, dict)]
+    elif isinstance(payload, list):
+        filing_rows = [dict(item) for item in payload if isinstance(item, dict)]
+    else:
+        raise ValueError(f"unsupported filings source payload: {source}")
+
+    raw_companies: list[dict[str, Any]] = []
+    for item in company_rows:
+        security = _resolve_filing_security(item.get("security"), universe_lookup)
+        filings = [dict(filing) for filing in item.get("filings", []) if isinstance(filing, dict)]
+        raw_companies.append({"security": security, "filings": filings})
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for filing in filing_rows:
+        security = _resolve_filing_security(filing, universe_lookup)
+        security_id = str(security.get("security_id", "")).strip()
+        if not security_id:
+            continue
+        bucket = grouped.setdefault(security_id, {"security": security, "filings": []})
+        bucket["filings"].append(filing)
+    raw_companies.extend(grouped.values())
+    raw_companies = sorted(raw_companies, key=lambda item: str(item.get("security", {}).get("security_id", "")))
+
+    normalized_events = [event for event in explicit_events if event.get("event_date") == run_date.isoformat()]
+    if not explicit_events:
+        for company in raw_companies:
+            security = company.get("security", {})
+            for filing in company.get("filings", []):
+                event = _normalize_filing_event(security, filing)
+                if event.get("event_date") == run_date.isoformat():
+                    normalized_events.append(event)
+    normalized_events.sort(key=lambda item: (item["event_date"], item["security_id"], item["headline"]))
+    return raw_companies, normalized_events
+
+
+def _build_universe_lookup(universe: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    lookup: dict[str, dict[str, Any]] = {}
+    for security in universe:
+        normalized = dict(security)
+        security_id = canonical_security_id(
+            normalized.get("security_id") or normalized.get("ticker") or normalized.get("company_name")
+        )
+        if not security_id:
+            continue
+        normalized["security_id"] = security_id
+        normalized.setdefault("ticker", security_id)
+        for candidate in (security_id, normalized.get("ticker"), normalized.get("company_name")):
+            key = canonical_security_id(candidate)
+            if key:
+                lookup[key] = normalized
+    return lookup
+
+
+def _resolve_filing_security(value: Any, universe_lookup: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        raw = dict(value)
+        security_id = canonical_security_id(raw.get("security_id") or raw.get("ticker") or raw.get("company_name"))
+        if security_id and security_id in universe_lookup:
+            return dict(universe_lookup[security_id])
+        if security_id:
+            return {
+                "security_id": security_id,
+                "ticker": str(raw.get("ticker") or security_id),
+                "company_name": str(raw.get("company_name") or raw.get("name") or security_id),
+            }
+    security_id = canonical_security_id(value)
+    if security_id and security_id in universe_lookup:
+        return dict(universe_lookup[security_id])
+    if not security_id:
+        return {}
+    return {"security_id": security_id, "ticker": security_id, "company_name": str(value or security_id)}
+
+
+def _normalize_filing_source_event(
+    event: dict[str, Any],
+    universe_lookup: dict[str, dict[str, Any]],
+    run_date: date,
+) -> dict[str, Any]:
+    security = _resolve_filing_security(event, universe_lookup)
+    security_id = str(security.get("security_id", "")).strip()
+    form = str(event.get("form", "")).strip()
+    headline = str(event.get("headline") or "").strip()
+    if not headline:
+        headline = f"{security_id} filed {form}".strip() if security_id or form else "Filing event"
+    return {
+        "source": "filings",
+        "event_type": "filing",
+        "event_date": _event_date(event, run_date),
+        "security_id": security_id,
+        "ticker": str(security.get("ticker") or security_id),
+        "relationship": "monitored",
+        "headline": headline,
+        "form": form,
+        "reference_url": str(event.get("reference_url") or event.get("url") or "").strip(),
+        "metadata": event,
+    }
+
+
+def load_market_provider_payload(
+    *,
+    source: str | None,
+    provider: str,
+    finnhub_api_key: str | None,
+    run_date: date,
+) -> tuple[dict[str, Any], list[str]]:
+    """Load shared market-data payloads for earnings and market commands."""
+    degraded_reasons: list[str] = []
+    if source:
+        payload, _ = load_payload(source)
+        if isinstance(payload, dict):
+            return payload, degraded_reasons
+        if isinstance(payload, list):
+            return {"earnings": payload, "market": payload}, degraded_reasons
+        return {"earnings": [], "market": []}, ["unsupported source payload"]
+
+    effective_provider = provider
+    if provider == "auto":
+        effective_provider = "finnhub" if finnhub_api_key else "file"
+    if effective_provider == "finnhub" and finnhub_api_key:
+        return _load_finnhub_payload(run_date, finnhub_api_key), degraded_reasons
+
+    degraded_reasons.append("no market data source configured")
+    return {"earnings": [], "market": [], "indexes": [], "rates": [], "fx": []}, degraded_reasons
+
+
+def normalize_market_events(payload: dict[str, Any], run_date: date) -> list[dict[str, Any]]:
+    """Normalize a narrow market payload into context events."""
+    events: list[dict[str, Any]] = []
+    for row in payload.get("market", []):
+        event = _normalize_market_event(row, run_date)
+        if event is not None:
+            events.append(event)
+    if events:
+        return sorted(events, key=lambda item: item["headline"])
+
+    for row in payload.get("indexes", []):
+        event = _normalize_market_event(row, run_date)
+        if event is not None:
+            events.append(event)
+    for row in payload.get("rates", []):
+        event = _normalize_market_event(row, run_date, category="rates")
+        if event is not None:
+            events.append(event)
+    for row in payload.get("fx", []):
+        event = _normalize_market_event(row, run_date, category="fx")
+        if event is not None:
+            events.append(event)
+    return sorted(events, key=lambda item: item["headline"])
+
+
+def enrich_event_relationships(
+    event: dict[str, Any],
+    universe: list[dict[str, Any]],
+    adjacency_map: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Re-apply relationship tagging during prep."""
+    security_id = canonical_security_id(event.get("security_id") or event.get("ticker"))
+    event["security_id"] = security_id
+    event.setdefault("relationship", relationship_for_security(security_id, universe, adjacency_map))
+    event.setdefault("group", group_for_event(event))
+    return event
+
+
+def build_event_key(event: dict[str, Any]) -> str:
+    """Build a deterministic dedupe key for an event."""
+    return "|".join(
+        [
+            str(event.get("source_name") or event.get("source", "")),
+            str(event.get("security_id", "")),
+            str(event.get("headline", "")),
+            str(event.get("event_date", "")),
+        ]
+    )
+
+
+def group_prepared_events(events: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Group prepared events into candidate brief sections."""
+    grouped: dict[str, list[dict[str, Any]]] = {
+        "company-specific": [],
+        "read-through": [],
+        "macro-policy": [],
+        "market-context": [],
+    }
+    for event in events:
+        grouped.setdefault(event["group"], []).append(event)
+    for group_name, group_events in grouped.items():
+        grouped[group_name] = sorted(
+            group_events,
+            key=lambda item: (item.get("relationship", ""), item.get("security_id", ""), item.get("headline", "")),
+        )
+    return grouped
+
+
+def relationship_for_security(
+    security_id: str,
+    universe: list[dict[str, Any]],
+    adjacency_map: list[dict[str, Any]],
+) -> str:
+    """Resolve monitored vs adjacent vs market relationship tags."""
+    monitored_ids = {str(item.get("security_id", "")) for item in universe}
+    if security_id in monitored_ids:
+        return "monitored"
+    adjacent_ids = {str(item.get("adjacent", "")) for item in adjacency_map}
+    if security_id in adjacent_ids:
+        return "adjacent"
+    return "market"
+
+
+def group_for_event(event: dict[str, Any]) -> str:
+    """Assign an event to a prep section."""
+    source_name = str(event.get("source_name") or event.get("source", "")).lower()
+    relationship = str(event.get("relationship", "")).lower()
+    if source_name in {"macro"}:
+        return "macro-policy"
+    if source_name in {"market"}:
+        return "market-context"
+    if relationship == "adjacent":
+        return "read-through"
+    return "company-specific"
+
+
+def load_manifest(run_paths: RunPaths) -> dict[str, Any]:
+    """Read the run manifest."""
+    return load_json(run_paths.manifest, default=_manifest_seed(run_paths))
+
+
+def update_manifest_source(run_paths: RunPaths, source_name: str, details: dict[str, Any]) -> None:
+    """Update one source section in the run manifest."""
+    manifest = load_manifest(run_paths)
+    manifest.setdefault("sources", {})[source_name] = details
+    manifest.setdefault("outputs", {}).update(_default_manifest_outputs(run_paths))
+    manifest["updated_at"] = now_utc_iso()
+    degraded_modes = {
+        reason
+        for source_details in manifest.get("sources", {}).values()
+        for reason in source_details.get("degraded_reasons", [])
+    }
+    manifest["degraded_modes"] = sorted(degraded_modes)
+    write_json(run_paths.manifest, manifest)
+
+
+def render_event_markdown(title: str, events: list[dict[str, Any]]) -> str:
+    """Render a flat event list as markdown."""
+    lines = [f"# {title}", ""]
+    if not events:
+        lines.append("No events collected.")
+        return "\n".join(lines) + "\n"
+    for event in events:
+        parts = [
+            event.get("event_date", ""),
+            event.get("relationship", ""),
+            event.get("security_id", ""),
+            event.get("headline", ""),
+        ]
+        extra = event.get("reference_url") or event.get("source_url") or ""
+        lines.append(f"- {' | '.join(part for part in parts if part)}{f' | {extra}' if extra else ''}")
+    return "\n".join(lines) + "\n"
+
+
+def render_grouped_events_markdown(grouped: dict[str, list[dict[str, Any]]]) -> str:
+    """Render grouped prepared events."""
+    lines = ["# Grouped Events", ""]
+    for group_name in ("company-specific", "read-through", "macro-policy", "market-context"):
+        lines.append(f"## {group_name}")
+        group_events = grouped.get(group_name, [])
+        if not group_events:
+            lines.append("- None")
+        else:
+            for event in group_events:
+                lines.append(f"- {event.get('headline', '')} | {event.get('security_id', '')} | {event.get('source_name', '')}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_source_status_markdown(source_status: dict[str, Any]) -> str:
+    """Render source status summary."""
+    lines = ["# Source Status", ""]
+    if not source_status:
+        lines.append("- No sources recorded.")
+        return "\n".join(lines) + "\n"
+    for name, details in sorted(source_status.items()):
+        line = f"- {name}: status={details.get('status', '')} | events={details.get('event_count', details.get('missed_event_count', 0))}"
+        degraded_reasons = details.get("degraded_reasons", [])
+        if degraded_reasons:
+            line += f" | degraded={', '.join(str(reason) for reason in degraded_reasons)}"
+        lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def render_audit_markdown(audit_payload: dict[str, Any]) -> str:
+    """Render audit findings as markdown."""
+    lines = [
+        "# Audit",
+        "",
+        f"- Missed events: {len(audit_payload.get('missed_events', []))}",
+        f"- Source failures: {len(audit_payload.get('source_failures', {}))}",
+        f"- Uncovered monitored securities: {len(audit_payload.get('uncovered_monitored', []))}",
+        "",
+        "## Missed Events",
+    ]
+    missed_events = audit_payload.get("missed_events", [])
+    if not missed_events:
+        lines.append("- None")
+    else:
+        for item in missed_events:
+            event = item.get("event", {})
+            lines.append(f"- {item.get('source', '')} | {event.get('security_id', '')} | {event.get('headline', '')}")
+    lines.extend(["", "## Uncovered Monitored"])
+    uncovered = audit_payload.get("uncovered_monitored", [])
+    if not uncovered:
+        lines.append("- None")
+    else:
+        for security_id in uncovered:
+            lines.append(f"- {security_id}")
+    return "\n".join(lines) + "\n"
+
+
+def _manifest_seed(run_paths: RunPaths) -> dict[str, Any]:
+    created_at = now_utc_iso()
+    return {
+        "run_id": run_paths.run_date.isoformat(),
+        "date": run_paths.run_date.isoformat(),
+        "created_at": created_at,
+        "updated_at": created_at,
+        "sources": {},
+        "outputs": _default_manifest_outputs(run_paths),
+        "degraded_modes": [],
+    }
+
+
+def _default_manifest_outputs(run_paths: RunPaths) -> dict[str, Any]:
+    return {
+        "run_root": str(run_paths.root),
+        "notes_dir": str(run_paths.notes_dir),
+        "raw_dir": str(run_paths.raw_dir),
+        "structured_dir": str(run_paths.structured_dir),
+        "rendered_dir": str(run_paths.rendered_dir),
+        "raw": {
+            "filings": str(run_paths.raw_dir / "filings.json"),
+            "earnings": str(run_paths.raw_dir / "earnings.json"),
+            "macro": str(run_paths.raw_dir / "macro.json"),
+            "ir": str(run_paths.raw_dir / "ir.json"),
+            "market": str(run_paths.raw_dir / "market.json"),
+            "manifest": str(run_paths.manifest),
+        },
+        "structured": {
+            "universe": str(run_paths.structured_dir / "universe.json"),
+            "prepared_evidence": str(run_paths.structured_dir / "prepared-evidence.json"),
+            "audit": str(run_paths.structured_dir / "audit.json"),
+        },
+        "rendered": {
+            "filings": str(run_paths.rendered_dir / "filings.md"),
+            "earnings": str(run_paths.rendered_dir / "earnings.md"),
+            "macro": str(run_paths.rendered_dir / "macro.md"),
+            "ir": str(run_paths.rendered_dir / "ir.md"),
+            "market": str(run_paths.rendered_dir / "market.md"),
+            "evidence": str(run_paths.rendered_dir / "evidence.md"),
+            "grouped_events": str(run_paths.rendered_dir / "grouped-events.md"),
+            "source_status": str(run_paths.rendered_dir / "source-status.md"),
+            "audit": str(run_paths.rendered_dir / "audit.md"),
+        },
+        "notes": {
+            "morning_brief_report": str(run_paths.notes_dir / "morning-brief-report.md"),
+            "slack_brief": str(run_paths.notes_dir / "slack-brief.md"),
+        },
+        "manifest": str(run_paths.manifest),
+        "review_log": str(run_paths.review_log),
+    }
+
+
+def _load_raw_source(run_paths: RunPaths, name: str) -> dict[str, Any]:
+    path = run_paths.raw_dir / f"{name}.json"
+    return load_json(path, default={})
+
+
+def _read_review_log(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _normalize_filing_event(security: dict[str, Any], filing: dict[str, Any]) -> dict[str, Any]:
+    security_id = str(security.get("security_id") or security.get("ticker") or "").strip()
+    form = str(filing.get("form", "")).strip()
+    description = str(filing.get("description") or filing.get("primary_document") or "").strip()
+    headline = f"{security_id} filed {form}".strip()
+    if description:
+        headline = f"{headline}: {description}"
+    return {
+        "source": "filings",
+        "event_type": "filing",
+        "event_date": str(filing.get("filing_date", "")).strip(),
+        "security_id": security_id,
+        "ticker": str(security.get("ticker") or security_id),
+        "relationship": "monitored",
+        "headline": headline,
+        "form": form,
+        "reference_url": str(filing.get("url") or "").strip(),
+        "metadata": filing,
+    }
+
+
+def _normalize_earnings_event(
+    row: dict[str, Any],
+    run_date: date,
+    universe: list[dict[str, Any]],
+    adjacency_map: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    security_id = canonical_security_id(row.get("ticker") or row.get("symbol") or row.get("security_id") or row.get("company"))
+    relationship = relationship_for_security(security_id, universe, adjacency_map)
+    market_relevant = bool(row.get("market_relevant"))
+    if relationship == "market" and not market_relevant:
+        return None
+    event_date = _event_date(row, run_date)
+    report_status = str(row.get("status") or row.get("report_status") or "scheduled").strip().lower()
+    timing = str(row.get("timing") or row.get("report_time") or row.get("time") or "unknown").strip().lower()
+    headline = str(row.get("headline") or row.get("title") or f"{security_id} earnings {report_status}").strip()
+    return {
+        "source": "earnings",
+        "event_type": "earnings",
+        "event_date": event_date,
+        "security_id": security_id,
+        "ticker": str(row.get("ticker") or security_id),
+        "relationship": relationship,
+        "headline": headline,
+        "status": report_status,
+        "timing": timing,
+        "reference_url": str(row.get("url") or row.get("reference_url") or "").strip(),
+        "metadata": row,
+    }
+
+
+def _normalize_macro_event(row: dict[str, Any], run_date: date) -> dict[str, Any] | None:
+    event_date = _event_date(row, run_date)
+    if event_date != run_date.isoformat():
+        return None
+    headline = str(row.get("event_name") or row.get("title") or row.get("headline") or "").strip()
+    if not headline:
+        return None
+    return {
+        "source": "macro",
+        "event_type": "macro",
+        "event_date": event_date,
+        "security_id": "",
+        "relationship": "market",
+        "headline": headline,
+        "release_time": str(row.get("release_time") or row.get("time") or "").strip(),
+        "category": str(row.get("category") or "macro"),
+        "importance": str(row.get("importance") or row.get("importance_tag") or "standard"),
+        "source_url": str(row.get("url") or row.get("source_url") or "").strip(),
+        "metadata": row,
+    }
+
+
+def _normalize_market_event(
+    row: dict[str, Any],
+    run_date: date,
+    *,
+    category: str | None = None,
+) -> dict[str, Any] | None:
+    change_pct = _to_float(row.get("change_pct") or row.get("percent_change") or row.get("pct"))
+    material = bool(row.get("material")) or (change_pct is not None and abs(change_pct) >= 1.0)
+    if not material:
+        return None
+    symbol = str(row.get("symbol") or row.get("name") or row.get("pair") or "").strip()
+    headline = str(row.get("headline") or f"{symbol} moved {change_pct:.2f}%").strip() if change_pct is not None else str(row.get("headline") or symbol)
+    return {
+        "source": "market",
+        "event_type": "market",
+        "event_date": _event_date(row, run_date),
+        "security_id": symbol,
+        "relationship": "market",
+        "headline": headline,
+        "category": category or str(row.get("category") or "indexes"),
+        "change_pct": change_pct,
+        "reference_url": str(row.get("url") or "").strip(),
+        "metadata": row,
+    }
+
+
+def _parse_ir_feed(
+    feed_url: str,
+    feed_format: str,
+    run_date: date,
+    security_id: str,
+    entry: dict[str, Any],
+) -> list[dict[str, Any]]:
+    raw_text, _ = read_text_source(feed_url)
+    if feed_format in {"rss", "atom", "xml"}:
+        return _parse_ir_xml(raw_text, run_date, security_id, entry)
+    if feed_format == "json":
+        payload = json.loads(raw_text)
+        items = payload if isinstance(payload, list) else payload.get("items", [])
+        return [
+            {
+                "source": "ir",
+                "event_type": "ir",
+                "event_date": _event_date(item, run_date),
+                "security_id": security_id,
+                "relationship": "monitored",
+                "headline": str(item.get("title") or item.get("headline") or "").strip(),
+                "reference_url": str(item.get("url") or item.get("link") or "").strip(),
+                "metadata": item,
+            }
+            for item in items
+            if _event_date(item, run_date) == run_date.isoformat() and str(item.get("title") or item.get("headline") or "").strip()
+        ]
+    if feed_format == "html":
+        return _parse_ir_html(raw_text, run_date, security_id)
+    raise ValueError(f"unsupported IR feed format: {feed_format}")
+
+
+def _parse_ir_xml(raw_text: str, run_date: date, security_id: str, entry: dict[str, Any]) -> list[dict[str, Any]]:
+    root = ElementTree.fromstring(raw_text)
+    items = root.findall(".//item") or root.findall(".//entry")
+    events: list[dict[str, Any]] = []
+    for item in items:
+        title = _xml_text(item, "title")
+        link = _xml_text(item, "link")
+        if not link:
+            link = item.findtext("{http://www.w3.org/2005/Atom}link") or ""
+            if not link:
+                link_node = item.find("{http://www.w3.org/2005/Atom}link")
+                link = link_node.attrib.get("href", "") if link_node is not None else ""
+        published = _xml_text(item, "pubDate") or _xml_text(item, "published") or _xml_text(item, "updated")
+        item_date = _coerce_event_date(published) or run_date.isoformat()
+        if item_date != run_date.isoformat() or not title:
+            continue
+        events.append(
+            {
+                "source": "ir",
+                "event_type": "ir",
+                "event_date": item_date,
+                "security_id": security_id,
+                "ticker": str(entry.get("ticker") or security_id),
+                "relationship": "monitored",
+                "headline": title,
+                "reference_url": link,
+                "metadata": {"published": published},
+            }
+        )
+    return events
+
+
+def _parse_ir_html(raw_text: str, run_date: date, security_id: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for match in re.finditer(r"<a[^>]+href=[\"']([^\"']+)[\"'][^>]*>(.*?)</a>", raw_text, flags=re.IGNORECASE | re.DOTALL):
+        title = re.sub(r"<[^>]+>", " ", match.group(2)).strip()
+        if not title:
+            continue
+        events.append(
+            {
+                "source": "ir",
+                "event_type": "ir",
+                "event_date": run_date.isoformat(),
+                "security_id": security_id,
+                "relationship": "monitored",
+                "headline": title,
+                "reference_url": match.group(1),
+                "metadata": {},
+            }
+        )
+    return events[:10]
+
+
+def _load_finnhub_payload(run_date: date, api_key: str) -> dict[str, Any]:
+    base_url = "https://finnhub.io/api/v1"
+    session = requests.Session()
+    earnings_response = session.get(
+        f"{base_url}/calendar/earnings",
+        params={"from": run_date.isoformat(), "to": run_date.isoformat(), "token": api_key},
+        timeout=30,
+    )
+    earnings_response.raise_for_status()
+    earnings_payload = earnings_response.json()
+
+    indexes: list[dict[str, Any]] = []
+    for symbol in DEFAULT_INDEX_SYMBOLS:
+        response = session.get(f"{base_url}/quote", params={"symbol": symbol, "token": api_key}, timeout=30)
+        response.raise_for_status()
+        quote = response.json()
+        indexes.append(
+            {
+                "symbol": symbol,
+                "change_pct": quote.get("dp"),
+                "headline": f"{symbol} moved {quote.get('dp', 0):.2f}%",
+                "material": abs(float(quote.get("dp", 0) or 0)) >= 1.0,
+            }
+        )
+    return {
+        "earnings": earnings_payload.get("earningsCalendar", earnings_payload.get("earnings", [])),
+        "indexes": indexes,
+        "rates": [],
+        "fx": [],
+    }
+
+
+def _ensure_index(path: Path, title: str, body: str) -> None:
+    if path.exists():
+        return
+    path.write_text(f"# {title}\n\n{body}\n", encoding="utf-8")
+
+
+def _xml_text(node: ElementTree.Element, tag_name: str) -> str:
+    value = node.findtext(tag_name)
+    if value:
+        return value.strip()
+    for child in node:
+        if child.tag.endswith(tag_name) and child.text:
+            return child.text.strip()
+    return ""
+
+
+def _event_date(row: dict[str, Any], fallback_date: date) -> str:
+    candidates = [
+        row.get("date"),
+        row.get("event_date"),
+        row.get("report_date"),
+        row.get("published"),
+        row.get("timestamp"),
+    ]
+    for candidate in candidates:
+        coerced = _coerce_event_date(candidate)
+        if coerced:
+            return coerced
+    return fallback_date.isoformat()
+
+
+def _coerce_event_date(value: Any) -> str | None:
+    if value in {None, ""}:
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        pass
+    for fmt in ("%a, %d %b %Y %H:%M:%S %z", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(raw, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    if value in {None, ""}:
+        return None
+    try:
+        return float(str(value).replace("%", "").replace(",", "").strip())
+    except ValueError:
+        return None

--- a/src/harness/portfolio_state.py
+++ b/src/harness/portfolio_state.py
@@ -1,0 +1,768 @@
+"""Portfolio state persistence for the morning brief workflow."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from io import StringIO
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+import yaml
+
+
+EMPTY_JSON_ARRAY = "[]\n"
+EMPTY_JSONL = ""
+
+
+@dataclass(slots=True)
+class PortfolioPaths:
+    """Filesystem layout for portfolio state."""
+
+    workspace_root: Path
+
+    @property
+    def root(self) -> Path:
+        return self.workspace_root / "data" / "portfolio"
+
+    @property
+    def current(self) -> Path:
+        return self.root / "current"
+
+    @property
+    def history(self) -> Path:
+        return self.root / "history"
+
+    @property
+    def holdings(self) -> Path:
+        return self.current / "holdings.json"
+
+    @property
+    def watchlist(self) -> Path:
+        return self.current / "watchlist.json"
+
+    @property
+    def universe(self) -> Path:
+        return self.current / "universe.json"
+
+    @property
+    def adjacency_map(self) -> Path:
+        return self.current / "adjacent-map.json"
+
+    @property
+    def adjacency_rendered(self) -> Path:
+        return self.current / "adjacent-map.md"
+
+    @property
+    def thesis_cards(self) -> Path:
+        return self.current / "thesis-cards.json"
+
+    @property
+    def thesis_rendered(self) -> Path:
+        return self.current / "thesis-cards.md"
+
+    @property
+    def ir_registry(self) -> Path:
+        return self.current / "ir-registry.json"
+
+    @property
+    def macro_registry(self) -> Path:
+        return self.current / "macro-registry.json"
+
+    @property
+    def rendered(self) -> Path:
+        return self.current / "rendered.md"
+
+    @property
+    def transactions(self) -> Path:
+        return self.root / "transactions.json"
+
+    @property
+    def sync_log(self) -> Path:
+        return self.history / "sync-log.jsonl"
+
+    @property
+    def universe_history(self) -> Path:
+        return self.history / "universe-history.jsonl"
+
+    @property
+    def metadata_history(self) -> Path:
+        return self.history / "metadata-history.jsonl"
+
+    @property
+    def rendered_history(self) -> Path:
+        return self.history / "rendered-history.md"
+
+
+def portfolio_paths(workspace_root: Path) -> PortfolioPaths:
+    """Return normalized portfolio paths."""
+    return PortfolioPaths(workspace_root=workspace_root.resolve())
+
+
+def ensure_portfolio_layout(workspace_root: Path) -> PortfolioPaths:
+    """Create the portfolio directory tree and default files when absent."""
+    paths = portfolio_paths(workspace_root)
+    paths.current.mkdir(parents=True, exist_ok=True)
+    paths.history.mkdir(parents=True, exist_ok=True)
+
+    _ensure_index(
+        paths.root / "INDEX.md",
+        title="Portfolio Data",
+        body="Persistent holdings, watchlist, adjacency, thesis, and history state.",
+    )
+    _ensure_index(
+        paths.current / "INDEX.md",
+        title="Current Portfolio State",
+        body="Latest synced holdings and locally curated monitoring metadata.",
+    )
+    _ensure_index(
+        paths.history / "INDEX.md",
+        title="Portfolio History",
+        body="Compact sync and metadata logs for portfolio state changes.",
+    )
+
+    for json_path in (
+        paths.holdings,
+        paths.watchlist,
+        paths.universe,
+        paths.adjacency_map,
+        paths.thesis_cards,
+        paths.ir_registry,
+        paths.transactions,
+    ):
+        if not json_path.exists():
+            json_path.write_text(EMPTY_JSON_ARRAY, encoding="utf-8")
+    for jsonl_path in (paths.sync_log, paths.universe_history, paths.metadata_history):
+        if not jsonl_path.exists():
+            jsonl_path.write_text(EMPTY_JSONL, encoding="utf-8")
+    if not paths.macro_registry.exists():
+        write_json(paths.macro_registry, _default_macro_registry())
+    if not paths.adjacency_rendered.exists():
+        paths.adjacency_rendered.write_text(render_adjacency_markdown([]), encoding="utf-8")
+    if not paths.thesis_rendered.exists():
+        paths.thesis_rendered.write_text(render_thesis_markdown([]), encoding="utf-8")
+    if not paths.rendered.exists():
+        paths.rendered.write_text("# Portfolio State\n\nNo sync has been run yet.\n", encoding="utf-8")
+    if not paths.rendered_history.exists():
+        paths.rendered_history.write_text("# Portfolio History\n\nNo history entries yet.\n", encoding="utf-8")
+    return paths
+
+
+def sync_portfolio(
+    workspace_root: Path,
+    *,
+    as_of: date,
+    holdings_source: str | None = None,
+    transactions_source: str | None = None,
+    watchlist_source: str | None = None,
+    sheet_id: str | None = None,
+    holdings_gid: str | None = None,
+    transactions_gid: str | None = None,
+) -> dict[str, Any]:
+    """Sync holdings and transactions into portfolio state."""
+    paths = ensure_portfolio_layout(workspace_root)
+    previous_universe = load_json(paths.universe, default=[])
+
+    resolved_holdings_source = holdings_source or _google_sheet_csv_url(sheet_id, holdings_gid)
+    resolved_transactions_source = transactions_source or _google_sheet_csv_url(sheet_id, transactions_gid)
+
+    holdings_rows = load_tabular_rows(resolved_holdings_source) if resolved_holdings_source else load_json(paths.holdings, default=[])
+    transactions_rows = (
+        load_tabular_rows(resolved_transactions_source) if resolved_transactions_source else load_json(paths.transactions, default=[])
+    )
+    if not holdings_rows:
+        raise ValueError("no holdings source was provided and no existing holdings state was found")
+
+    watchlist_rows = load_tabular_rows(watchlist_source) if watchlist_source else load_json(paths.watchlist, default=[])
+
+    holdings = _dedupe_records(normalize_holdings(holdings_rows))
+    watchlist = _dedupe_records(normalize_watchlist(watchlist_rows))
+    universe = build_universe(holdings, watchlist)
+    transactions = normalize_transactions(transactions_rows)
+
+    write_json(paths.holdings, holdings)
+    write_json(paths.watchlist, watchlist)
+    write_json(paths.universe, universe)
+    write_json(paths.transactions, transactions)
+
+    change_summary = _universe_delta(previous_universe, universe)
+    rendered = render_portfolio_summary(
+        as_of=as_of,
+        holdings=holdings,
+        watchlist=watchlist,
+        universe=universe,
+        transactions=transactions,
+        adjacency=load_json(paths.adjacency_map, default=[]),
+        thesis_cards=load_json(paths.thesis_cards, default=[]),
+    )
+    paths.rendered.write_text(rendered, encoding="utf-8")
+
+    append_jsonl(
+        paths.sync_log,
+        {
+            "timestamp": now_utc_iso(),
+            "as_of": as_of.isoformat(),
+            "sources": {
+                "holdings": resolved_holdings_source or str(paths.holdings),
+                "transactions": resolved_transactions_source or str(paths.transactions),
+                "watchlist": watchlist_source or str(paths.watchlist),
+            },
+            "counts": {
+                "holdings": len(holdings),
+                "watchlist": len(watchlist),
+                "universe": len(universe),
+                "transactions": len(transactions),
+            },
+            "changes": change_summary,
+        },
+    )
+    if change_summary["added"] or change_summary["removed"]:
+        append_jsonl(
+            paths.universe_history,
+            {
+                "timestamp": now_utc_iso(),
+                "as_of": as_of.isoformat(),
+                **change_summary,
+            },
+        )
+    append_jsonl(
+        paths.metadata_history,
+        {
+            "timestamp": now_utc_iso(),
+            "event": "portfolio-sync",
+            "rendered_path": str(paths.rendered),
+            "counts": {"adjacency": len(load_json(paths.adjacency_map, default=[])), "thesis_cards": len(load_json(paths.thesis_cards, default=[]))},
+        },
+    )
+    update_history_render(paths)
+    return {
+        "as_of": as_of.isoformat(),
+        "holdings_count": len(holdings),
+        "watchlist_count": len(watchlist),
+        "universe_count": len(universe),
+        "transactions_count": len(transactions),
+        "rendered_path": paths.rendered,
+        "sources": {
+            "holdings": resolved_holdings_source,
+            "transactions": resolved_transactions_source,
+            "watchlist": watchlist_source or str(paths.watchlist),
+        },
+    }
+
+
+def add_adjacency_entry(
+    workspace_root: Path,
+    *,
+    monitored: str,
+    adjacent: str,
+    relationship_type: str,
+    note: str | None = None,
+    priority: str | None = None,
+) -> dict[str, Any]:
+    """Create or replace one adjacency entry."""
+    paths = ensure_portfolio_layout(workspace_root)
+    entries = load_json(paths.adjacency_map, default=[])
+    monitored_id = canonical_security_id(monitored)
+    adjacent_id = canonical_security_id(adjacent)
+    normalized_relationship_type = relationship_type.strip()
+
+    if not monitored_id or not adjacent_id:
+        raise ValueError("both monitored and adjacent identifiers are required")
+    if not normalized_relationship_type:
+        raise ValueError("relationship type is required")
+
+    replacement = {
+        "monitored": monitored_id,
+        "adjacent": adjacent_id,
+        "relationship_type": normalized_relationship_type,
+        "note": (note or "").strip(),
+        "priority": (priority or "").strip(),
+        "updated_at": now_utc_iso(),
+    }
+    filtered = [
+        entry
+        for entry in entries
+        if not (
+            str(entry.get("monitored", "")).upper() == monitored_id
+            and str(entry.get("adjacent", "")).upper() == adjacent_id
+            and str(entry.get("relationship_type", "")).strip().lower() == normalized_relationship_type.lower()
+        )
+    ]
+    filtered.append(replacement)
+    filtered.sort(key=lambda item: (item["monitored"], item["adjacent"], item["relationship_type"]))
+    write_json(paths.adjacency_map, filtered)
+    paths.adjacency_rendered.write_text(render_adjacency_markdown(filtered), encoding="utf-8")
+    append_jsonl(
+        paths.metadata_history,
+        {"timestamp": now_utc_iso(), "event": "adjacency-add", "entry": replacement},
+    )
+    update_history_render(paths)
+    return replacement
+
+
+def remove_adjacency_entry(
+    workspace_root: Path,
+    *,
+    monitored: str,
+    adjacent: str,
+    relationship_type: str | None = None,
+) -> dict[str, Any]:
+    """Remove adjacency entries for a monitored-adjacent pair."""
+    paths = ensure_portfolio_layout(workspace_root)
+    entries = load_json(paths.adjacency_map, default=[])
+    monitored_id = canonical_security_id(monitored)
+    adjacent_id = canonical_security_id(adjacent)
+    normalized_relationship_type = (relationship_type or "").strip().lower()
+    if not monitored_id or not adjacent_id:
+        raise ValueError("both monitored and adjacent identifiers are required")
+    kept = [
+        entry
+        for entry in entries
+        if not (
+            str(entry.get("monitored", "")).upper() == monitored_id
+            and str(entry.get("adjacent", "")).upper() == adjacent_id
+            and (
+                not normalized_relationship_type
+                or str(entry.get("relationship_type", "")).strip().lower() == normalized_relationship_type
+            )
+        )
+    ]
+    removed_count = len(entries) - len(kept)
+    write_json(paths.adjacency_map, kept)
+    paths.adjacency_rendered.write_text(render_adjacency_markdown(kept), encoding="utf-8")
+    append_jsonl(
+        paths.metadata_history,
+        {
+            "timestamp": now_utc_iso(),
+            "event": "adjacency-remove",
+            "monitored": monitored_id,
+            "adjacent": adjacent_id,
+            "relationship_type": normalized_relationship_type,
+            "removed_count": removed_count,
+        },
+    )
+    update_history_render(paths)
+    return {
+        "removed_count": removed_count,
+        "monitored": monitored_id,
+        "adjacent": adjacent_id,
+        "relationship_type": normalized_relationship_type,
+    }
+
+
+def set_thesis_card(
+    workspace_root: Path,
+    *,
+    security: str,
+    summary: str,
+    expectations: list[str],
+    disconfirming_signals: list[str],
+) -> dict[str, Any]:
+    """Create or replace one thesis card."""
+    paths = ensure_portfolio_layout(workspace_root)
+    security_id = canonical_security_id(security)
+    normalized_summary = summary.strip()
+    if not security_id:
+        raise ValueError("security identifier is required")
+    if not normalized_summary:
+        raise ValueError("summary is required")
+    cards = load_json(paths.thesis_cards, default=[])
+    replacement = {
+        "security_id": security_id,
+        "thesis_summary": normalized_summary,
+        "key_expectations": [item for item in (part.strip() for part in expectations) if item],
+        "disconfirming_signals": [item for item in (part.strip() for part in disconfirming_signals) if item],
+        "updated_at": now_utc_iso(),
+    }
+    filtered = [card for card in cards if str(card.get("security_id", "")).upper() != security_id]
+    filtered.append(replacement)
+    filtered.sort(key=lambda item: item["security_id"])
+    write_json(paths.thesis_cards, filtered)
+    paths.thesis_rendered.write_text(render_thesis_markdown(filtered), encoding="utf-8")
+    append_jsonl(
+        paths.metadata_history,
+        {"timestamp": now_utc_iso(), "event": "thesis-set", "security_id": security_id},
+    )
+    update_history_render(paths)
+    return replacement
+
+
+def render_portfolio_summary(
+    *,
+    as_of: date,
+    holdings: list[dict[str, Any]],
+    watchlist: list[dict[str, Any]],
+    universe: list[dict[str, Any]],
+    transactions: list[dict[str, Any]],
+    adjacency: list[dict[str, Any]],
+    thesis_cards: list[dict[str, Any]],
+) -> str:
+    """Render current portfolio state as deterministic markdown."""
+    holding_lines = [f"- `{item['security_id']}` | {item.get('company_name', 'Unknown')} | {item.get('weight', '')}" for item in holdings]
+    watchlist_lines = [f"- `{item['security_id']}` | {item.get('company_name', 'Unknown')}" for item in watchlist]
+    recent_transactions = transactions[:10]
+    transaction_lines = [
+        f"- {item.get('trade_date', '')} | `{item.get('security_id', '')}` | {item.get('action', '')} | {item.get('quantity', '')}"
+        for item in recent_transactions
+    ]
+    return "\n".join(
+        [
+            "# Portfolio State",
+            "",
+            f"- As of: {as_of.isoformat()}",
+            f"- Holdings: {len(holdings)}",
+            f"- Watchlist: {len(watchlist)}",
+            f"- Universe: {len(universe)}",
+            f"- Transactions: {len(transactions)}",
+            f"- Adjacency mappings: {len(adjacency)}",
+            f"- Thesis cards: {len(thesis_cards)}",
+            "",
+            "## Holdings",
+            *(holding_lines or ["- None"]),
+            "",
+            "## Watchlist",
+            *(watchlist_lines or ["- None"]),
+            "",
+            "## Recent Transactions",
+            *(transaction_lines or ["- None"]),
+        ]
+    ).rstrip() + "\n"
+
+
+def render_adjacency_markdown(entries: list[dict[str, Any]]) -> str:
+    """Render adjacency entries as markdown."""
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for entry in sorted(entries, key=lambda item: (item.get("monitored", ""), item.get("adjacent", ""))):
+        grouped.setdefault(str(entry.get("monitored", "")), []).append(entry)
+    lines = ["# Adjacency Map", ""]
+    if not grouped:
+        lines.append("No adjacency mappings configured.")
+        return "\n".join(lines) + "\n"
+    for monitored, members in grouped.items():
+        lines.append(f"## {monitored}")
+        for member in members:
+            note = f" | {member['note']}" if member.get("note") else ""
+            priority = f" | priority={member['priority']}" if member.get("priority") else ""
+            lines.append(f"- `{member['adjacent']}` | {member['relationship_type']}{priority}{note}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_thesis_markdown(cards: list[dict[str, Any]]) -> str:
+    """Render thesis cards as markdown."""
+    lines = ["# Thesis Cards", ""]
+    if not cards:
+        lines.append("No thesis cards configured.")
+        return "\n".join(lines) + "\n"
+    for card in sorted(cards, key=lambda item: item.get("security_id", "")):
+        expectations = [f"- {item}" for item in card.get("key_expectations", [])] or ["- None"]
+        disconfirming = [f"- {item}" for item in card.get("disconfirming_signals", [])] or ["- None"]
+        lines.extend(
+            [
+                f"## {card['security_id']}",
+                "",
+                card.get("thesis_summary", "").strip() or "(no thesis summary)",
+                "",
+                "### Key Expectations",
+                *expectations,
+                "",
+                "### Disconfirming Signals",
+                *disconfirming,
+                "",
+                f"Updated: {card.get('updated_at', '')}",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_universe(holdings: list[dict[str, Any]], watchlist: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Combine holdings and watchlist into a monitored universe."""
+    merged: dict[str, dict[str, Any]] = {}
+    for row in holdings + watchlist:
+        security_id = str(row["security_id"])
+        current = dict(merged.get(security_id, {}))
+        current.update(row)
+        sources = sorted(set(current.get("sources", [])) | {str(row.get("source_kind", "monitored"))})
+        current["sources"] = sources
+        merged[security_id] = current
+    return [merged[key] for key in sorted(merged)]
+
+
+def normalize_holdings(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize holdings rows into canonical portfolio records."""
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        record = _normalize_security_row(row, source_kind="holding")
+        if record["security_id"]:
+            normalized.append(record)
+    return normalized
+
+
+def normalize_watchlist(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize watchlist rows into canonical portfolio records."""
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        record = _normalize_security_row(row, source_kind="watchlist")
+        if record["security_id"]:
+            normalized.append(record)
+    return normalized
+
+
+def normalize_transactions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize transaction rows."""
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        ticker = _clean_ticker(row.get("ticker") or row.get("symbol") or row.get("security_id") or row.get("security"))
+        company_name = _clean_name(row.get("company") or row.get("name") or row.get("security"))
+        security_id = canonical_security_id(ticker or company_name)
+        trade_date = _stringify_date(row.get("date") or row.get("trade_date") or row.get("timestamp"))
+        if not security_id:
+            continue
+        normalized.append(
+            {
+                "security_id": security_id,
+                "ticker": ticker,
+                "company_name": company_name,
+                "trade_date": trade_date,
+                "action": str(row.get("action") or row.get("side") or row.get("transaction") or "").strip().lower(),
+                "quantity": _maybe_number(row.get("quantity") or row.get("shares")),
+                "price": _maybe_number(row.get("price")),
+                "notes": str(row.get("notes") or row.get("memo") or "").strip(),
+            }
+        )
+    normalized.sort(key=lambda item: (item.get("trade_date", ""), item["security_id"]), reverse=True)
+    return normalized
+
+
+def load_tabular_rows(source: str | None) -> list[dict[str, Any]]:
+    """Load list-like data from JSON, YAML, or CSV."""
+    if not source:
+        return []
+    payload, suffix = load_payload(source)
+    if isinstance(payload, list):
+        return [dict(item) for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("rows", "items", "holdings", "transactions", "watchlist", "events"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [dict(item) for item in value if isinstance(item, dict)]
+    if suffix == ".csv" and isinstance(payload, str):
+        return list(csv.DictReader(StringIO(payload)))
+    raise ValueError(f"unsupported tabular source: {source}")
+
+
+def load_payload(source: str) -> tuple[Any, str]:
+    """Load a structured payload from a local file or URL."""
+    raw_text, suffix = read_text_source(source)
+    normalized_suffix = suffix.lower()
+    if normalized_suffix == ".csv":
+        return list(csv.DictReader(StringIO(raw_text))), normalized_suffix
+    if normalized_suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(raw_text) or [], normalized_suffix
+    if normalized_suffix == ".jsonl":
+        return [json.loads(line) for line in raw_text.splitlines() if line.strip()], normalized_suffix
+    return json.loads(raw_text), normalized_suffix
+
+
+def read_text_source(source: str) -> tuple[str, str]:
+    """Read text from a local path or HTTP URL."""
+    parsed = urlparse(source)
+    if parsed.scheme in {"http", "https"}:
+        response = requests.get(source, timeout=30)
+        response.raise_for_status()
+        suffix = Path(parsed.path).suffix or _suffix_from_content_type(response.headers.get("content-type", ""))
+        return response.text, suffix or ".json"
+    candidate = Path(source).expanduser()
+    text = candidate.read_text(encoding="utf-8")
+    return text, candidate.suffix or ".json"
+
+
+def write_json(path: Path, payload: Any) -> None:
+    """Write deterministic JSON to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path, *, default: Any) -> Any:
+    """Load JSON with a default when the file is missing."""
+    if not path.exists():
+        return default
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return default
+    return json.loads(text)
+
+
+def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    """Append one JSON record to a log file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file when present."""
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def update_history_render(paths: PortfolioPaths) -> None:
+    """Render a compact markdown history summary."""
+    sync_entries = read_jsonl(paths.sync_log)[-10:]
+    metadata_entries = read_jsonl(paths.metadata_history)[-10:]
+    lines = ["# Portfolio History", "", "## Recent Syncs"]
+    if not sync_entries:
+        lines.append("- None")
+    else:
+        for entry in reversed(sync_entries):
+            counts = entry.get("counts", {})
+            lines.append(
+                f"- {entry.get('as_of', '')} | holdings={counts.get('holdings', 0)} | universe={counts.get('universe', 0)}"
+            )
+    lines.extend(["", "## Recent Metadata Changes"])
+    if not metadata_entries:
+        lines.append("- None")
+    else:
+        for entry in reversed(metadata_entries):
+            lines.append(f"- {entry.get('timestamp', '')} | {entry.get('event', '')}")
+    paths.rendered_history.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def canonical_security_id(value: Any) -> str:
+    """Return a stable uppercase security identifier."""
+    ticker = _clean_ticker(value)
+    if ticker:
+        return ticker
+    name = _clean_name(value)
+    if not name:
+        return ""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug.upper()
+
+
+def now_utc_iso() -> str:
+    """Return an ISO-8601 UTC timestamp."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def parse_iso_date(raw: str | None) -> date:
+    """Parse an ISO date string, defaulting to today when absent."""
+    if not raw:
+        return date.today()
+    return date.fromisoformat(raw)
+
+
+def _normalize_security_row(row: dict[str, Any], *, source_kind: str) -> dict[str, Any]:
+    ticker = _clean_ticker(row.get("ticker") or row.get("symbol"))
+    company_name = _clean_name(row.get("company") or row.get("name") or row.get("security"))
+    security_id = canonical_security_id(row.get("security_id") or ticker or company_name or row.get("cusip"))
+    return {
+        "security_id": security_id,
+        "ticker": ticker,
+        "company_name": company_name,
+        "cusip": str(row.get("cusip") or "").strip(),
+        "weight": _maybe_number(row.get("weight") or row.get("portfolio_weight")),
+        "shares": _maybe_number(row.get("shares") or row.get("quantity")),
+        "notes": str(row.get("notes") or "").strip(),
+        "source_kind": source_kind,
+    }
+
+
+def _dedupe_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not record.get("security_id"):
+            continue
+        deduped[str(record["security_id"])] = record
+    return [deduped[key] for key in sorted(deduped)]
+
+
+def _universe_delta(previous: list[dict[str, Any]], current: list[dict[str, Any]]) -> dict[str, list[str]]:
+    previous_ids = {str(item.get("security_id", "")) for item in previous}
+    current_ids = {str(item.get("security_id", "")) for item in current}
+    return {
+        "added": sorted(current_ids - previous_ids),
+        "removed": sorted(previous_ids - current_ids),
+    }
+
+
+def _maybe_number(value: Any) -> float | int | None:
+    if value in {None, "", "null"}:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    raw = str(value).strip().replace(",", "").replace("%", "")
+    if not raw:
+        return None
+    try:
+        if raw.isdigit():
+            return int(raw)
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _stringify_date(value: Any) -> str:
+    if value in {None, ""}:
+        return ""
+    if isinstance(value, date):
+        return value.isoformat()
+    raw = str(value).strip()
+    try:
+        return datetime.fromisoformat(raw).date().isoformat()
+    except ValueError:
+        return raw
+
+
+def _clean_ticker(value: Any) -> str:
+    raw = str(value or "").strip().upper()
+    raw = raw.replace("/", "-")
+    if not raw or raw in {"NONE", "NAN", "NULL"}:
+        return ""
+    return raw
+
+
+def _clean_name(value: Any) -> str:
+    raw = str(value or "").strip()
+    return "" if raw.upper() in {"NONE", "NAN", "NULL"} else raw
+
+
+def _ensure_index(path: Path, *, title: str, body: str) -> None:
+    if path.exists():
+        return
+    path.write_text(f"# {title}\n\n{body}\n", encoding="utf-8")
+
+
+def _google_sheet_csv_url(sheet_id: str | None, gid: str | None) -> str | None:
+    if not sheet_id or not gid:
+        return None
+    return f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid={gid}"
+
+
+def _suffix_from_content_type(content_type: str) -> str:
+    lowered = content_type.lower()
+    if "csv" in lowered:
+        return ".csv"
+    if "yaml" in lowered or "yml" in lowered:
+        return ".yaml"
+    if "jsonl" in lowered:
+        return ".jsonl"
+    return ".json"
+
+
+def _default_macro_registry() -> dict[str, Any]:
+    return {
+        "sources": [
+            {"name": "BLS", "category": "macro", "url": "https://www.bls.gov/schedule/news_release/"},
+            {"name": "BEA", "category": "macro", "url": "https://www.bea.gov/news/schedule"},
+            {"name": "Federal Reserve", "category": "policy", "url": "https://www.federalreserve.gov/newsevents.htm"},
+            {"name": "Treasury", "category": "policy", "url": "https://home.treasury.gov/news/press-releases"},
+        ]
+    }

--- a/src/minerva/sec.py
+++ b/src/minerva/sec.py
@@ -1,5 +1,10 @@
 """SEC EDGAR helpers that aggregate multi-step edgartools workflows."""
 
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
 import pandas as pd
 from edgar import Company
 
@@ -85,3 +90,66 @@ def get_10k_items(
             result[item_num] = ""
 
     return result
+
+
+def get_recent_filings(
+    ticker_or_cik: str,
+    *,
+    forms: list[str] | None = None,
+    since: date | str | None = None,
+    until: date | str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """List recent filings for a company in a date window.
+
+    Returns a normalized list of small filing records so higher-level CLI
+    orchestration can filter and persist SEC activity without duplicating
+    edgartools traversal logic.
+    """
+    normalized_since: date | None = _coerce_date(since)
+    normalized_until: date | None = _coerce_date(until)
+    company: Company = Company(ticker_or_cik)
+    filings = company.get_filings(form=forms or ["8-K", "10-K", "10-Q"]).latest(limit)
+
+    records: list[dict[str, Any]] = []
+    for filing in _iter_filings(filings):
+        filing_date: date | None = _coerce_date(getattr(filing, "filing_date", getattr(filing, "date", None)))
+        if normalized_since and filing_date and filing_date < normalized_since:
+            continue
+        if normalized_until and filing_date and filing_date > normalized_until:
+            continue
+        records.append(
+            {
+                "ticker_or_cik": str(ticker_or_cik),
+                "form": str(getattr(filing, "form", getattr(filing, "form_type", "")) or ""),
+                "filing_date": filing_date.isoformat() if filing_date else "",
+                "accession_number": str(getattr(filing, "accession_number", "") or ""),
+                "primary_document": str(getattr(filing, "primary_document", "") or ""),
+                "description": str(getattr(filing, "description", getattr(filing, "title", "")) or ""),
+                "url": str(
+                    getattr(filing, "filing_url", getattr(filing, "url", getattr(filing, "homepage_url", ""))) or ""
+                ),
+            }
+        )
+    return records
+
+
+def _iter_filings(filings: Any) -> list[Any]:
+    if filings is None:
+        return []
+    if isinstance(filings, list):
+        return filings
+    try:
+        return list(filings)
+    except TypeError:
+        return [filings]
+
+
+def _coerce_date(value: date | str | None) -> date | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return datetime.fromisoformat(str(value)).date()

--- a/tests/fixtures/morning_brief/filings.json
+++ b/tests/fixtures/morning_brief/filings.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "Investor presentation",
+    "filing_date": "2026-04-08",
+    "form": "8-K",
+    "ticker": "NVDA",
+    "url": "https://example.com/nvda-8k"
+  },
+  {
+    "description": "Quarterly report",
+    "filing_date": "2026-04-08",
+    "form": "10-Q",
+    "ticker": "MSFT",
+    "url": "https://example.com/msft-10q"
+  }
+]

--- a/tests/fixtures/morning_brief/holdings.csv
+++ b/tests/fixtures/morning_brief/holdings.csv
@@ -1,0 +1,3 @@
+ticker,company,weight,shares
+NVDA,NVIDIA Corp,5.5,100
+MSFT,Microsoft Corp,4.2,80

--- a/tests/fixtures/morning_brief/macro-events.json
+++ b/tests/fixtures/morning_brief/macro-events.json
@@ -1,0 +1,10 @@
+[
+  {
+    "category": "macro",
+    "event_name": "CPI release",
+    "importance": "high",
+    "release_time": "08:30 ET",
+    "source_url": "https://example.com/cpi-calendar",
+    "date": "2026-04-08"
+  }
+]

--- a/tests/fixtures/morning_brief/market-data.json
+++ b/tests/fixtures/morning_brief/market-data.json
@@ -1,0 +1,34 @@
+{
+  "earnings": [
+    {
+      "headline": "NVDA earnings scheduled after the close",
+      "status": "scheduled",
+      "ticker": "NVDA",
+      "timing": "after-close",
+      "url": "https://example.com/nvda-earnings"
+    },
+    {
+      "headline": "TSM reported stronger AI packaging demand",
+      "status": "reported",
+      "ticker": "TSM",
+      "timing": "before-open",
+      "url": "https://example.com/tsm-earnings"
+    }
+  ],
+  "indexes": [
+    {
+      "change_pct": -1.4,
+      "headline": "S&P 500 sold off after tariff headlines",
+      "material": true,
+      "symbol": "SPY"
+    }
+  ],
+  "rates": [
+    {
+      "change_pct": 0.12,
+      "headline": "US 10Y yield rose 12 bps",
+      "material": true,
+      "name": "US10Y"
+    }
+  ]
+}

--- a/tests/fixtures/morning_brief/nvda-ir.xml
+++ b/tests/fixtures/morning_brief/nvda-ir.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>NVIDIA IR</title>
+    <item>
+      <title>NVIDIA Announces AI Factory Networking Update</title>
+      <link>https://example.com/nvda-ir-update</link>
+      <pubDate>Wed, 08 Apr 2026 08:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/morning_brief/transactions.csv
+++ b/tests/fixtures/morning_brief/transactions.csv
@@ -1,0 +1,3 @@
+date,ticker,action,quantity,price,notes
+2026-04-08,NVDA,buy,5,950,Added after AI roadmap event
+2026-04-07,MSFT,sell,2,410,Trimmed ahead of earnings

--- a/tests/fixtures/morning_brief/watchlist.json
+++ b/tests/fixtures/morning_brief/watchlist.json
@@ -1,0 +1,12 @@
+[
+  {
+    "company": "Advanced Micro Devices",
+    "notes": "GPU read-through watchlist",
+    "ticker": "AMD"
+  },
+  {
+    "company": "Snowflake",
+    "notes": "Data infra watchlist",
+    "ticker": "SNOW"
+  }
+]

--- a/tests/test_harness/test_morning_brief.py
+++ b/tests/test_harness/test_morning_brief.py
@@ -1,0 +1,257 @@
+"""Tests for the morning-brief portfolio state, evidence pipeline, and wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from harness.commands import brief
+from harness.config import HarnessSettings
+from harness.morning_brief import (
+    append_review_log,
+    audit_evidence,
+    collect_earnings,
+    collect_filings,
+    collect_ir,
+    collect_macro,
+    collect_market,
+    ensure_daily_run_layout,
+    load_manifest,
+    prepare_evidence,
+)
+from harness.portfolio_state import (
+    add_adjacency_entry,
+    load_json,
+    set_thesis_card,
+    sync_portfolio,
+)
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "morning_brief"
+RUN_DATE = date(2026, 4, 8)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class MorningBriefTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmpdir.name)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_portfolio_sync_and_curation_render_state(self) -> None:
+        summary = sync_portfolio(
+            self.workspace,
+            as_of=RUN_DATE,
+            holdings_source=str(FIXTURE_DIR / "holdings.csv"),
+            transactions_source=str(FIXTURE_DIR / "transactions.csv"),
+            watchlist_source=str(FIXTURE_DIR / "watchlist.json"),
+        )
+        adjacency = add_adjacency_entry(
+            self.workspace,
+            monitored="NVDA",
+            adjacent="TSM",
+            relationship_type="supply-chain",
+            note="Packaging and foundry read-through",
+            priority="high",
+        )
+        thesis = set_thesis_card(
+            self.workspace,
+            security="NVDA",
+            summary="AI demand remains the core portfolio driver.",
+            expectations=["Blackwell ramps", "Networking attach stays elevated"],
+            disconfirming_signals=["Cloud capex slows materially"],
+        )
+
+        self.assertEqual(summary["holdings_count"], 2)
+        self.assertEqual(summary["watchlist_count"], 2)
+        self.assertEqual(summary["universe_count"], 4)
+        self.assertEqual(adjacency["adjacent"], "TSM")
+        self.assertEqual(thesis["security_id"], "NVDA")
+
+        rendered = (self.workspace / "data" / "portfolio" / "current" / "rendered.md").read_text(encoding="utf-8")
+        history = (self.workspace / "data" / "portfolio" / "history" / "rendered-history.md").read_text(encoding="utf-8")
+        universe = load_json(self.workspace / "data" / "portfolio" / "current" / "universe.json", default=[])
+
+        self.assertIn("## Holdings", rendered)
+        self.assertIn("`NVDA` | NVIDIA Corp", rendered)
+        self.assertIn("## Recent Metadata Changes", history)
+        self.assertEqual({item["security_id"] for item in universe}, {"AMD", "MSFT", "NVDA", "SNOW"})
+
+    def test_brief_pipeline_writes_manifest_outputs_and_review_log(self) -> None:
+        sync_portfolio(
+            self.workspace,
+            as_of=RUN_DATE,
+            holdings_source=str(FIXTURE_DIR / "holdings.csv"),
+            transactions_source=str(FIXTURE_DIR / "transactions.csv"),
+            watchlist_source=str(FIXTURE_DIR / "watchlist.json"),
+        )
+        add_adjacency_entry(
+            self.workspace,
+            monitored="NVDA",
+            adjacent="TSM",
+            relationship_type="supply-chain",
+            note="Packaging read-through",
+            priority="high",
+        )
+        set_thesis_card(
+            self.workspace,
+            security="NVDA",
+            summary="AI demand remains the core portfolio driver.",
+            expectations=["Blackwell ramps"],
+            disconfirming_signals=["Cloud capex slows materially"],
+        )
+
+        ir_registry = self.workspace / "ir-registry.json"
+        ir_registry.write_text(
+            json.dumps(
+                [
+                    {
+                        "security_id": "NVDA",
+                        "ticker": "NVDA",
+                        "feeds": [
+                            {
+                                "format": "xml",
+                                "url": str(FIXTURE_DIR / "nvda-ir.xml"),
+                            }
+                        ],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        collect_filings(self.workspace, run_date=RUN_DATE, source=str(FIXTURE_DIR / "filings.json"))
+        collect_earnings(self.workspace, run_date=RUN_DATE, source=str(FIXTURE_DIR / "market-data.json"))
+        collect_macro(self.workspace, run_date=RUN_DATE, source=str(FIXTURE_DIR / "macro-events.json"))
+        collect_ir(self.workspace, run_date=RUN_DATE, registry_path=ir_registry)
+        collect_market(self.workspace, run_date=RUN_DATE, source=str(FIXTURE_DIR / "market-data.json"))
+        prepare_evidence(self.workspace, run_date=RUN_DATE)
+        audit_evidence(self.workspace, run_date=RUN_DATE)
+        append_review_log(self.workspace, run_date=RUN_DATE, notes="fixture-backed validation")
+
+        run_paths = ensure_daily_run_layout(self.workspace, RUN_DATE)
+        manifest = load_manifest(run_paths)
+        prepared = load_json(run_paths.structured_dir / "prepared-evidence.json", default={})
+        review_entries = [
+            json.loads(line)
+            for line in run_paths.review_log.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+        self.assertTrue(
+            {"filings", "earnings", "macro", "ir", "market", "prep", "audit", "review-log"}.issubset(manifest["sources"])
+        )
+        self.assertTrue(manifest["outputs"]["notes"]["morning_brief_report"].endswith("notes/morning-brief-report.md"))
+        self.assertTrue(manifest["outputs"]["raw"]["filings"].endswith("data/raw/filings.json"))
+        self.assertTrue(
+            manifest["outputs"]["structured"]["prepared_evidence"].endswith("data/structured/prepared-evidence.json")
+        )
+        self.assertTrue(manifest["outputs"]["rendered"]["grouped_events"].endswith("data/rendered/grouped-events.md"))
+        self.assertTrue(Path(manifest["outputs"]["structured"]["prepared_evidence"]).exists())
+        self.assertTrue(Path(manifest["outputs"]["rendered"]["audit"]).exists())
+        self.assertTrue(Path(manifest["outputs"]["notes"]["slack_brief"]).exists())
+        self.assertTrue(
+            any(event["headline"] == "TSM reported stronger AI packaging demand" for event in prepared["grouped_events"]["read-through"])
+        )
+        self.assertTrue(any(event["headline"] == "CPI release" for event in prepared["grouped_events"]["macro-policy"]))
+        self.assertTrue(any(event["source_name"] == "market" for event in prepared["grouped_events"]["market-context"]))
+        self.assertEqual(review_entries[-1]["notes"], "fixture-backed validation")
+
+    def test_brief_dispatch_allows_fixture_backed_filings_without_edgar(self) -> None:
+        sync_portfolio(
+            self.workspace,
+            as_of=RUN_DATE,
+            holdings_source=str(FIXTURE_DIR / "holdings.csv"),
+            transactions_source=str(FIXTURE_DIR / "transactions.csv"),
+            watchlist_source=str(FIXTURE_DIR / "watchlist.json"),
+        )
+        settings = HarnessSettings(workspace_root=self.workspace)
+
+        def _should_not_run(_: HarnessSettings) -> str | None:
+            raise AssertionError("EDGAR identity should not be required when --source is provided")
+
+        with patch("harness.commands.brief._configure_edgar", _should_not_run):
+            result = brief.dispatch(
+                ["filings", "--date", RUN_DATE.isoformat(), "--source", str(FIXTURE_DIR / "filings.json")],
+                settings=settings,
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("event_count: 2", result.stdout.decode("utf-8"))
+
+    def test_wrapper_orchestrates_command_sequence_with_optional_sources(self) -> None:
+        workspace_root = self.workspace / "workspace"
+        call_log = self.workspace / "calls.log"
+        fake_minerva = self.workspace / "fake-minerva.sh"
+        fake_minerva.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$*\" >> \"$MINERVA_CALL_LOG\"\n",
+            encoding="utf-8",
+        )
+        fake_minerva.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "MINERVA_CALL_LOG": str(call_log),
+                "MINERVA_RUNNER": str(fake_minerva),
+                "MINERVA_SKIP_STATUS_CHECK": "1",
+                "MINERVA_WITH_POST_WRITE": "1",
+                "MINERVA_WORKSPACE_ROOT": str(workspace_root),
+                "MINERVA_PORTFOLIO_HOLDINGS_SOURCE": str(FIXTURE_DIR / "holdings.csv"),
+                "MINERVA_PORTFOLIO_TRANSACTIONS_SOURCE": str(FIXTURE_DIR / "transactions.csv"),
+                "MINERVA_PORTFOLIO_WATCHLIST_SOURCE": str(FIXTURE_DIR / "watchlist.json"),
+                "MINERVA_BRIEF_FILINGS_SOURCE": str(FIXTURE_DIR / "filings.json"),
+                "MINERVA_BRIEF_EARNINGS_SOURCE": str(FIXTURE_DIR / "market-data.json"),
+                "MINERVA_BRIEF_MACRO_SOURCE": str(FIXTURE_DIR / "macro-events.json"),
+                "MINERVA_BRIEF_IR_REGISTRY": str(self.workspace / "ir-registry.json"),
+                "MINERVA_BRIEF_MARKET_SOURCE": str(FIXTURE_DIR / "market-data.json"),
+            }
+        )
+        Path(env["MINERVA_BRIEF_IR_REGISTRY"]).write_text("[]\n", encoding="utf-8")
+
+        result = subprocess.run(
+            ["bash", str(REPO_ROOT / "scripts" / "run_morning_brief_v1.sh"), RUN_DATE.isoformat()],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            f"prepared_evidence: {workspace_root}/reports/daily-news/{RUN_DATE.isoformat()}/data/structured/prepared-evidence.json",
+            result.stdout,
+        )
+        self.assertIn(
+            f"manifest: {workspace_root}/reports/daily-news/{RUN_DATE.isoformat()}/data/raw/manifest.json",
+            result.stdout,
+        )
+        self.assertTrue((workspace_root / "reports" / "daily-news" / RUN_DATE.isoformat()).is_dir())
+        self.assertEqual(
+            call_log.read_text(encoding="utf-8").splitlines(),
+            [
+                f"portfolio sync --date {RUN_DATE.isoformat()} --holdings-source {FIXTURE_DIR / 'holdings.csv'} --transactions-source {FIXTURE_DIR / 'transactions.csv'} --watchlist-source {FIXTURE_DIR / 'watchlist.json'}",
+                f"brief filings --date {RUN_DATE.isoformat()} --source {FIXTURE_DIR / 'filings.json'}",
+                f"brief earnings --date {RUN_DATE.isoformat()} --provider auto --source {FIXTURE_DIR / 'market-data.json'}",
+                f"brief macro --date {RUN_DATE.isoformat()} --source {FIXTURE_DIR / 'macro-events.json'}",
+                f"brief ir --date {RUN_DATE.isoformat()} --registry {self.workspace / 'ir-registry.json'}",
+                f"brief market --date {RUN_DATE.isoformat()} --provider auto --source {FIXTURE_DIR / 'market-data.json'}",
+                f"brief prep --date {RUN_DATE.isoformat()}",
+                f"brief audit --date {RUN_DATE.isoformat()}",
+                f"brief review-log --date {RUN_DATE.isoformat()}",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the portfolio and morning-brief harness command surface
- add the wrapper script, fixture-backed tests, and deterministic evidence artifacts
- align the design doc and daily-news storage layout with the implemented harness

## Validation
- UV_CACHE_DIR=/Users/charlie-buffet/Documents/project-minerva/.worktrees/feat-morning-brief-v1-high/.uv-cache uv run pytest tests/test_harness/test_morning_brief.py -q
- fixture-backed direct and wrapper end-to-end runs under .tmp/e2e-direct-renamed and .tmp/e2e-wrapper-renamed
