### PR TITLE
fix: restore evidence and analysis CLI registration

### DIFF
--- a/src/harness/cli.py
+++ b/src/harness/cli.py
@@ -9,8 +9,10 @@ from typing import Callable
 import typer
 
 from harness.commands import register_commands
+from harness.commands import analysis as analysis_commands
 from harness.commands import analyze as analyze_commands
 from harness.commands import brief as brief_commands
+from harness.commands import evidence as evidence_commands
 from harness.commands import extract as extract_commands
 from harness.commands import fileinfo as fileinfo_commands
 from harness.commands import plot as plot_commands
@@ -188,7 +190,7 @@ def dispatch_command(argv: list[str], stdin: bytes = b"", settings: HarnessSetti
             stderr=(
                 "What went wrong: an empty command segment was provided.\n"
                 "What to do instead: provide a command name before any arguments.\n"
-                "Available alternatives: sec, portfolio, brief, valuation, analyze, plot, extract, fileinfo, research"
+                "Available alternatives: sec, evidence, portfolio, brief, valuation, analyze, analysis, plot, extract, fileinfo, research"
             ),
             exit_code=1,
         )
@@ -196,6 +198,9 @@ def dispatch_command(argv: list[str], stdin: bytes = b"", settings: HarnessSetti
     command: str = argv[0]
     dispatchers: dict[str, Callable[[list[str], HarnessSettings, bytes], CommandResult]] = {
         "sec": lambda full_argv, current_settings, current_stdin: sec_commands.dispatch(
+            full_argv[1:], settings=current_settings, stdin=current_stdin
+        ),
+        "evidence": lambda full_argv, current_settings, current_stdin: evidence_commands.dispatch(
             full_argv[1:], settings=current_settings, stdin=current_stdin
         ),
         "portfolio": lambda full_argv, current_settings, current_stdin: portfolio_commands.dispatch(
@@ -208,6 +213,9 @@ def dispatch_command(argv: list[str], stdin: bytes = b"", settings: HarnessSetti
             full_argv[1:], settings=current_settings, stdin=current_stdin
         ),
         "analyze": lambda full_argv, current_settings, current_stdin: analyze_commands.dispatch(
+            full_argv[1:], settings=current_settings, stdin=current_stdin
+        ),
+        "analysis": lambda full_argv, current_settings, current_stdin: analysis_commands.dispatch(
             full_argv[1:], settings=current_settings, stdin=current_stdin
         ),
         "plot": lambda full_argv, current_settings, current_stdin: plot_commands.dispatch(

--- a/src/harness/commands/__init__.py
+++ b/src/harness/commands/__init__.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import typer
 
-from harness.commands import analyze, brief, extract, fileinfo, plot, portfolio, research, sec, valuation
+from harness.commands import analysis, analyze, brief, evidence, extract, fileinfo, plot, portfolio, research, sec, valuation
 
 
 def register_commands(app: typer.Typer) -> None:
     """Register all command groups on the root Typer app."""
     app.add_typer(sec.app, name="sec")
+    app.add_typer(evidence.app, name="evidence")
     app.add_typer(portfolio.app, name="portfolio")
     app.add_typer(brief.app, name="brief")
     app.add_typer(valuation.app, name="valuation")
     app.add_typer(analyze.app, name="analyze")
+    app.add_typer(analysis.app, name="analysis")
     app.add_typer(plot.app, name="plot")
     app.add_typer(extract.app, name="extract")
     app.add_typer(extract.extract_many_app, name="extract-many")


### PR DESCRIPTION
## Summary
- restore `evidence` and `analysis` command registration on the root Minerva CLI
- restore direct dispatch support for `minerva run` chains using those commands
- keep the newer main-branch brief, portfolio, and research changes intact

## Validation
- uv run minerva --help
- uv run pytest tests/test_harness/test_evidence.py tests/test_harness/test_morning_brief.py tests/test_harness/test_csv_normalization.py