### PR TITLE
docs: zettel-wiki design docs, upgrade plans, and trace analyses

### DIFF
--- a/docs/02-zettel-wiki-v3-design.md
+++ b/docs/02-zettel-wiki-v3-design.md
@@ -1,0 +1,754 @@
+# Zettel-Wiki v3 — Design Document
+
+**Date:** 2026-04-22
+**Status:** Approved — ready for implementation
+**Context:** Post-mortem of v2 AI-Media test run (trace: `analysis/01-zettel-wiki-v2-trace-analysis.md`)
+
+---
+
+## Principles
+
+These govern the wiki. Everything else follows from them.
+
+### Zettels first, structure emerges
+
+Zettels are extracted from raw evidence without reference to a pre-defined topic list. Structure notes are written _after_ extraction, organizing the natural clusters that emerged. If the evidence warrants a structure that surprises you, that's the method working.
+
+### Zettels are fixed, structure is fluid
+
+A zettel, once written, is a durable record — it captures one thought grounded in one source. Structure notes are living documents that reorganize as new zettels arrive. During ingest, existing structure notes are reviewed to understand the current landscape and identify what new structures should emerge. Structure notes can be split, merged, reorganized, promoted into folders, or retired. (See [Communicating with Zettelkastens](https://zettelkasten.de/introduction/) on organic growth.)
+
+### Raw evidence is primary
+
+Adhere to building zettels from raw evidence — filings, transcripts, product docs, case studies, competitor analyses. Notes, memos, and deep dives are outputs of prior analysis and are not zettel sources. A zettel whose source is a synthesis document is a failure, not an edge case.
+
+### Every connection explains why
+
+Links without context are noise. Every connection between zettels, or between a zettel and a structure note, includes inline prose explaining the relationship. "See also" is never sufficient.
+
+### Audit is a gate, not a suggestion
+
+After every ingest, the agent performs an audit pass — verifying coverage, evidence grounding, and link soundness. Ingest is not complete until audit passes.
+
+### Failed work is retried, not deferred
+
+When a batch fails, retry immediately — smaller batches, different chunking, adjusted approach. Known gaps are not acceptable in a completion report.
+
+### Depth varies naturally
+
+Zettels and structure notes have no word count constraints. Split when unwieldy.
+
+---
+
+## Content types
+
+### Zettel (atomic note)
+
+One thought per file. The smallest unit of knowledge in the wiki.
+
+- **Location:** `zettels/` (flat)
+- **ID:** Timestamp (`YYYYMMDDHHmm`)
+- **Grounding:** Every zettel traces back to a raw source.
+- **Connections:** Bidirectional links to related zettels with explicit "why" context.
+- **Tags:** 2–5 `#kebab-case` tags. Entry points, not taxonomy. Evolve organically.
+- **Durability:** Fixed once written. May be marked stale or superseded, not rewritten.
+
+### Structure note (wiki page)
+
+A navigable topic article that organizes and narrates a cluster of zettels. Coherent prose, not bullet lists.
+
+- **Location:** `pages/` (nested folders)
+- **ID:** Semantic filename (`apple.md`, `gpu-supply-chain.md`)
+- **Emergence:** Created when 3+ zettels cluster around a topic. Never pre-planned before extraction.
+- **Fluidity:** Living documents — reviewed during every ingest, split when unwieldy, reorganized as knowledge shifts. Structure notes can reference each other.
+
+### Multi-level wiki pages
+
+When a structure note covers distinct sub-topics, it evolves into a wiki folder:
+
+```
+pages/apple.md                          ← single page (early)
+
+pages/apple/                            ← wiki folder (after growth)
+  ├── apple.md                          ← hub page
+  ├── services-transition.md
+  └── capital-allocation/               ← nested folder
+        ├── capital-allocation.md
+        └── buyback-program.md
+```
+
+Multi-level nesting is expected. Every folder gets an `INDEX.md`.
+
+---
+
+## What changes from v2
+
+### Skill structure
+
+| v2 (9 files) | v3 (7 files) |
+|---|---|
+| `SKILL.md` — workflow routing + model assignments | `SKILL.md` — principles + content types + step routing |
+| `references/ingest.md` — 8-step recipe | `references/ingest.md` — principle-driven guidance |
+| `references/audit.md` — check-only, don't fix | `references/audit.md` — verify AND fix AND evolve (merged with maintain) |
+| `references/maintain.md` — separate fix + evolve | _(deleted — merged into audit)_ |
+| `references/query.md` — navigation recipe | `references/query.md` — principle-driven guidance |
+| `references/zettel-template.md` | `references/zettel-template.md` _(light edit)_ |
+| `references/page-template.md` | `references/page-template.md` _(updated)_ |
+| `references/schema.md` | `references/schema.md` _(updated)_ |
+
+### How the reference files change
+
+| v2 (rigid) | v3 (principle-driven) |
+|---|---|
+| "You are the ingest agent" | No agent framing — it's a step |
+| Model assignments per workflow | No model assignments |
+| Restates content type definitions | References SKILL.md — no redundancy |
+| "Step 1 → Step 2 → Step 3" | Organized by concern, not by sequence |
+| Quality checklist at the end | No checklist — principles cover it |
+| Prescribes exact method | Describes what, why, key decisions, and pitfalls |
+
+### Conceptual changes
+
+| v2 | v3 |
+|---|---|
+| 4 separate workflows with dedicated models | 3 steps — agent figures out the approach |
+| Separate agents per workflow | One agent, fluid switching |
+| Soft preference for raw evidence | Hard rule: raw evidence only |
+| Structure pre-planned before extraction | "Zettels first, structure emerges" |
+| Audit checks but doesn't fix | Audit verifies, fixes, and evolves |
+| Maintain as a separate workflow | Merged into audit |
+| Single-level wiki pages | Multi-level wiki folders |
+
+---
+
+## Implementation plan
+
+### Phase 1: Rewrite skill
+
+1. Write new `SKILL.md`
+2. Rewrite `references/ingest.md`
+3. Rewrite `references/audit.md` (merged with maintain)
+4. Rewrite `references/query.md`
+5. Delete `references/maintain.md`
+6. Update `references/page-template.md`
+7. Update `references/schema.md`
+8. Light-edit `references/zettel-template.md`
+
+### Phase 2: Test run
+
+Controlled ingest on a small evidence set (5–10 source files):
+- Verify: zettels created from raw evidence (not synthesis documents)
+- Verify: structure notes emerged from zettel clusters (not pre-planned)
+- Verify: audit pass happens after ingest
+- Verify: all zettels cross-linked with context
+
+---
+
+## Target file contents
+
+These are the actual files that will be written.
+
+### 1. SKILL.md
+
+````
+---
+name: zettel-wiki
+description: >
+  Build and maintain an agent-driven knowledge base using the Zettel-Wiki
+  pattern — a fusion of Karpathy's LLM Wiki and the Zettelkasten method.
+  The wiki is a persistent, compounding hypertext of interlinked markdown
+  files: structure notes (wiki pages) for navigable topic articles, and
+  Zettels (atomic notes) for individual thoughts and claims.
+---
+
+# Zettel-Wiki
+
+Agent-maintained knowledge base. Two content types, seven principles.
+
+Wiki root: `/Users/charlie-buffet/Documents/project-minerva/hard-disk/wiki/`
+
+## Principles
+
+### Zettels first, structure emerges
+
+Zettels are extracted from raw evidence without reference to a
+pre-defined topic list. Structure notes are written after extraction,
+organizing the natural clusters that emerged. If the evidence warrants
+a structure that surprises you, that's the method working.
+
+### Zettels are fixed, structure is fluid
+
+A zettel, once written, is a durable record — one thought grounded
+in one source. Structure notes are living documents that reorganize
+as new zettels arrive. During ingest, existing structure notes are
+reviewed to understand the current landscape and identify what new
+structures should emerge. Structure notes can be split, merged,
+reorganized, promoted into folders, or retired.
+
+### Raw evidence is primary
+
+Adhere to building zettels from raw evidence — filings, transcripts,
+product docs, case studies, competitor analyses. Notes, memos, and
+deep dives are outputs of prior analysis and are not zettel sources.
+A zettel whose source is a synthesis document is a failure, not an
+edge case.
+
+### Every connection explains why
+
+Links without context are noise. Every connection between zettels,
+or between a zettel and a structure note, includes inline prose
+explaining the relationship. "See also" is never sufficient.
+Connections are bidirectional — update both sides.
+
+### Audit is a gate, not a suggestion
+
+After every ingest, verify coverage, evidence grounding, and link
+soundness. Fix issues found. Ingest is not complete until audit
+passes. This includes structural evolution: fixing orphans,
+proposing page splits, creating new structure notes from emergent
+zettel clusters.
+
+### Failed work is retried, not deferred
+
+When a batch fails, retry immediately — smaller batches, different
+chunking, adjusted approach. Known gaps are not acceptable in a
+completion report.
+
+### Depth varies naturally
+
+Zettels and structure notes have no word count constraints. A zettel
+can be three sentences or a full page. A structure note can link to
+3 zettels or 30. Split when unwieldy.
+
+## Content types
+
+### Zettel (atomic note)
+
+One thought per file. The smallest unit of knowledge.
+
+| Property | Detail |
+|---|---|
+| Location | `zettels/` (flat) |
+| ID | Timestamp: `YYYYMMDDHHmm` |
+| Grounding | Every zettel traces back to a raw source |
+| Connections | Bidirectional links to related zettels with explicit context |
+| Tags | 2–5 `#kebab-case` tags; entry points, not taxonomy |
+| Durability | Fixed once written; may be marked stale, not rewritten |
+
+A zettel is not an excerpt. It is processed knowledge — what the
+source says and why it matters.
+
+Template: `references/zettel-template.md`
+
+### Structure note (wiki page)
+
+A navigable topic article that organizes a cluster of zettels.
+Coherent prose with inline zettel links, not bullet lists.
+
+| Property | Detail |
+|---|---|
+| Location | `pages/` (nested folders) |
+| ID | Semantic filename: `apple.md`, `gpu-supply-chain.md` |
+| Emergence | Created when 3+ zettels cluster around a topic |
+| Fluidity | Living document — reorganized as knowledge shifts |
+| Cross-references | Structure notes can link to each other with context |
+
+Template: `references/page-template.md`
+
+#### Multi-level growth
+
+When a structure note covers distinct sub-topics, it evolves into
+a wiki folder. The hub page keeps the original filename inside the
+folder. Sub-pages and nested folders are allowed. Every folder gets
+an `INDEX.md`.
+
+## How the wiki grows
+
+### Ingest — `references/ingest.md`
+
+Process new sources into wiki knowledge. Creates zettels from raw
+evidence, cross-links them, reviews and updates structure notes.
+
+### Audit — `references/audit.md`
+
+Verify quality and evolve structure. Runs after every ingest
+(mandatory) and periodically for wiki-wide health.
+
+### Query — `references/query.md`
+
+Answer questions from wiki knowledge. Synthesizes answers with
+citations, files new zettels when the answer produces insight.
+
+## Infrastructure
+
+- `INDEX.md` — master catalog in every folder. Auto-maintained.
+- `LEDGER.md` — append-only activity log.
+
+Formats: `references/schema.md`
+````
+
+### 2. references/ingest.md
+
+````
+# Ingest — Zettel-Wiki
+
+Process raw sources into wiki knowledge. See SKILL.md for principles
+and content type definitions.
+
+## What ingest accomplishes
+
+New sources become wiki knowledge: zettels extracted from raw
+evidence, cross-linked with explicit context, organized into
+structure notes, with INDEX and LEDGER updated. Every zettel is
+grounded and connected before ingest is considered complete.
+
+## Sources
+
+Sources are files on disk (filings, transcripts, product docs,
+case studies), URLs, or conversation content. Never copy source
+files into the wiki — reference them via paths or URLs.
+
+Adhere to raw evidence. Filings, transcripts, product docs, and
+case studies are valid zettel sources. Notes, memos, and deep
+dives are not — they are outputs of prior analysis. If you catch
+yourself building a zettel from a synthesis document, stop and
+find the underlying raw source.
+
+## Extraction
+
+Read sources and identify discrete atomic insights. For each
+candidate, the key decisions:
+
+- **Knowledge or information?** Knowledge is contextualized,
+  connected, and answers "why does this matter?" Information is
+  a dead fact. Only knowledge becomes a zettel.
+- **Can it stand alone?** One thought per zettel. Two distinct
+  ideas = two zettels.
+- **Already captured?** Check `zettels/INDEX.md`. Same claim with
+  new evidence → enrich the existing zettel. Same topic, different
+  angle → new zettel linked to the existing one. True duplicate
+  → skip.
+
+For batch extraction at scale, spawn subagents with non-overlapping
+timestamp namespaces. Each worker gets a batch of source files and
+the zettel template. After all workers complete, the main agent
+reviews output and wires cross-batch connections — workers can
+only link within their own batch. If a worker batch fails, retry
+immediately with smaller batches.
+
+## Cross-linking
+
+Every new zettel gets at least one connection with explicit context
+explaining why the link exists. Connections are bidirectional —
+when linking A → B, update B → A too.
+
+Cross-linking is not optional. Zettels without connections are
+orphans and represent incomplete work. All zettels must be linked
+before ingest is considered complete.
+
+## Structure notes
+
+After extraction, review what emerged:
+
+- **Existing structure notes:** Read them. Understand the current
+  landscape. Update their narratives to incorporate new zettels.
+  Bump the `updated` field.
+- **New clusters:** When 3+ new zettels cluster around a topic
+  that has no structure note, create one. Let the topic emerge
+  from the zettels — don't pre-define it.
+- **Growth:** When a structure note now covers distinct sub-topics,
+  consider evolving it into a wiki folder with sub-pages.
+
+Structure notes are fluid. Reorganize them as needed — the current
+structure is not sacred.
+
+## Completing ingest
+
+Update all affected INDEX.md files. Append a LEDGER entry with
+source, files created, and files updated.
+
+Then flow into audit. Ingest is not done until audit passes.
+
+## Pitfalls
+
+- Pre-planning structure note topics before extraction. Let
+  structure emerge.
+- Using notes or deep dives as zettel sources instead of raw
+  evidence.
+- Accepting batch failures as "known gaps" instead of retrying.
+- Cross-linking only a few zettels and deferring the rest.
+- Copying source text verbatim instead of processing it into
+  knowledge.
+````
+
+### 3. references/audit.md
+
+````
+# Audit — Zettel-Wiki
+
+Verify wiki quality and evolve wiki structure. See SKILL.md for
+principles and content type definitions.
+
+Audit runs after every ingest (mandatory) and periodically or
+on request for wiki-wide health.
+
+## What audit accomplishes
+
+Recent ingest verified for quality. Issues found and fixed. Wiki
+structure evolved — orphans linked, pages split when unwieldy, new
+structure notes created from zettel clusters, redundant zettels
+merged. INDEX files consistent. LEDGER updated.
+
+## Quality verification
+
+### Coverage
+
+Were the right sources processed? Compare the source corpus against
+what was actually ingested. High-value files (filings, transcripts,
+product docs) should not be skipped without reason. Metadata files,
+manifests, and download logs are fine to skip.
+
+### Evidence grounding
+
+Does every zettel trace back to a raw source? Flag zettels citing
+synthesis documents instead of raw evidence. Spot-check claims
+against cited sources when something feels uncertain.
+
+### Link soundness
+
+Are connections bidirectional? Does every connection include context
+explaining why? Are there obvious missing connections between
+related zettels?
+
+## Structural evolution
+
+### Orphan zettels
+
+Zettels with no inbound links — nothing points to them. Read the
+orphan, understand its content, and add connections from the most
+relevant structure notes and related zettels. Add the link with
+explicit context.
+
+### Context-free links
+
+Links that say "see [ID]" or "related to" without explaining why.
+Read both sides, understand the relationship, add a one-sentence
+explanation.
+
+### Contradictions
+
+Contradictions are expected — the world has genuine disagreements.
+Don't resolve unless one claim is clearly wrong (superseded by a
+newer source).
+
+For legitimate contradictions: link the conflicting zettels to each
+other, explain what contradicts and how the tension reads, update
+any structure notes that reference both.
+
+For clear errors: mark the incorrect zettel as superseded, link to
+the correction, update structure notes that relied on the wrong claim.
+
+### Page splits and folder promotion
+
+When a structure note covers clearly distinct sub-topics, propose
+evolving it into a wiki folder with sub-pages. The original file
+becomes the hub page. Multi-level nesting is expected.
+
+Flag significant restructuring to the user. Fix routine issues
+autonomously.
+
+### Zettel clusters without a structure note
+
+Groups of 3+ related zettels that share connections but have no
+structure note organizing them. Create a structure note — write
+coherent narrative linking to the zettels.
+
+### Redundant zettels
+
+Near-duplicates covering the same ground. Merge into the richer
+version. Add any unique evidence from the weaker one. Update all
+inbound links to point to the survivor.
+
+### Stale content
+
+Zettels whose claims have been superseded by newer information.
+Use judgment — time-bound claims need freshness checks more than
+evergreen definitions. Add a staleness note and link to the newer
+zettel if one exists.
+
+## Batch operations
+
+For large-scale cross-linking or orphan resolution, spawn subagents.
+Give each worker a batch of zettels plus the full zettel catalog for
+reference. Workers add connections; the main agent verifies quality
+after completion.
+
+## Autonomy vs. flagging
+
+Fix autonomously: orphan links, broken links, missing INDEX entries,
+context-free connections, INDEX regeneration, small structure note
+updates.
+
+Flag to user: significant page splits, major folder reorganization,
+contradictions that require domain judgment, suggestions for sources
+to seek out.
+
+## Completing audit
+
+Update all affected INDEX.md files. Append a LEDGER entry
+summarizing what was verified, what was fixed, and what was
+flagged.
+
+## Pitfalls
+
+- Checking without fixing. Audit both verifies and remediates.
+- Silently resolving contradictions instead of linking both sides.
+- Skipping audit after ingest because "it looked fine."
+- Flagging everything to the user instead of fixing routine issues
+  autonomously.
+````
+
+### 4. references/query.md
+
+````
+# Query — Zettel-Wiki
+
+Answer questions using wiki knowledge. See SKILL.md for principles
+and content type definitions.
+
+## What query accomplishes
+
+Questions answered with specific zettel citations. Contradictions
+acknowledged. Gaps identified. When the synthesis produces a new
+insight not already captured, it is filed as a new zettel —
+the wiki compounds.
+
+## Navigation
+
+Start from the top and drill down:
+
+1. Read `wiki/INDEX.md` — the master catalog.
+2. Identify relevant structure notes in `pages/`.
+3. Read those structure notes. Note the zettels they link to.
+4. Read the relevant zettels. Follow their connections to find
+   related zettels the structure note didn't reference.
+5. Keep following links until the picture is complete.
+
+Structure notes are the best starting point — they organize by
+topic and link down to evidence. If a topic has no structure note,
+scan `zettels/INDEX.md` for relevant titles or tags. Cross-domain
+connections between zettels are often where the most interesting
+answers live.
+
+## Synthesis
+
+Compose answers that:
+
+- Cite specific zettels by ID or inline link. Not vague references
+  to "the wiki."
+- Cite raw sources when evidence traceability matters — follow the
+  zettel's Evidence section back to the original document.
+- Synthesize across zettels. Connect the dots, explain relationships,
+  build arguments — don't just list what each zettel says.
+- Acknowledge contradictions when zettels disagree. Present both
+  perspectives with the context the wiki provides.
+- State gaps clearly. If the wiki doesn't have enough to fully
+  answer, say so and suggest what source would fill the gap.
+
+## Compounding
+
+When the synthesis reveals a new insight — a connection, pattern,
+or conclusion not already captured in any existing zettel — file it:
+
+- Create a new zettel following the template.
+- Link it to the zettels that informed the insight.
+- Update reciprocal connections.
+- Consider whether it warrants updating or creating a structure note.
+- Update INDEX and LEDGER.
+
+Not every answer deserves a new zettel. File only when the insight
+is durable and would be valuable for future queries.
+
+## Pitfalls
+
+- Answering from general knowledge instead of wiki content.
+- Vague citations ("the wiki suggests...") instead of specific
+  zettel references.
+- Hiding contradictions instead of presenting both sides.
+- Filing trivial or obvious observations as new zettels.
+````
+
+### 5. references/page-template.md
+
+````
+# Structure Note Template
+
+Use this format for structure notes (wiki pages) in `pages/`.
+
+    ---
+    title: "Topic Title"
+    created: YYYY-MM-DD
+    updated: YYYY-MM-DD
+    ---
+
+    # [Title]
+
+    [Coherent narrative that reads like a Wikipedia article.
+    Inline links to zettels that back each claim:
+    "Apple's services revenue [exceeded hardware](../../zettels/202604160930.md)
+    in Q2 2025, marking a structural shift."
+
+    The page organizes and narrates — zettels are the evidence
+    underneath. Every factual claim links to the supporting zettel
+    or raw source.]
+
+    ## Related
+
+    - [Related Structure Note](path/to/page.md) — [Why this note
+      is related — not just "see also" but the specific connection.]
+
+## Rules
+
+- **Semantic filename:** lowercase kebab-case.
+- **Reads like a Wikipedia article.** Coherent narrative, not
+  bullet lists. Organize by logical sections, not by source.
+- **Inline zettel links.** Every factual claim links to the
+  zettel that backs it.
+- **Related section.** Links to other structure notes with
+  context explaining the relationship.
+- **Updated field.** Bump `updated` when content changes.
+- **Fluidity.** Structure notes are living documents —
+  reorganized, split, merged as the wiki evolves.
+- **Multi-level growth.** When a page covers distinct sub-topics,
+  evolve it into a wiki folder. The original file becomes the hub
+  page inside the folder. Sub-pages and nested folders are allowed.
+  Every folder gets an INDEX.md.
+- **Depth varies naturally.** No word count constraints.
+````
+
+### 6. references/schema.md
+
+````
+# Zettel-Wiki Schema
+
+Conventions for the wiki at
+`/Users/charlie-buffet/Documents/project-minerva/hard-disk/wiki/`.
+
+## Naming
+
+- Structure notes: lowercase kebab-case semantic filenames
+  (`apple.md`, `gpu-supply-chain.md`)
+- Zettels: timestamp IDs in `YYYYMMDDHHmm` format
+  (`202604160930.md`)
+- Folders: lowercase kebab-case (`companies/`, `concepts/`)
+- Infrastructure files: ALL CAPS (`INDEX.md`, `LEDGER.md`)
+
+## Wiki folders
+
+When a structure note evolves into a folder, the hub page keeps
+the same filename inside the folder:
+`pages/apple.md` → `pages/apple/apple.md`
+
+Sub-pages use semantic filenames. Nested folders are allowed.
+Every folder gets an INDEX.md.
+
+## INDEX.md format
+
+Every folder gets an INDEX.md with a markdown table of
+immediate children:
+
+    | Name | Notes |
+    |---|---|
+    | `apple.md` | Apple — business model, competitive position |
+    | `nvidia.md` | NVIDIA — GPU supply, AI infra |
+
+The root INDEX.md is the master entry point.
+
+## LEDGER.md format
+
+Append-only chronological activity log:
+
+    ## [YYYY-MM-DD HH:MM] action | Title
+
+    - **Source**: path or URL
+    - **Created**: list of new files
+    - **Updated**: list of modified files
+
+## Tag conventions
+
+- Tags use `#kebab-case`: `#platform-economics`, `#apple`
+- Tags are entry points, not a taxonomy — don't overthink them
+- Tags evolve organically
+````
+
+### 7. references/zettel-template.md
+
+````
+# Zettel Template
+
+Use this format for new zettels in `zettels/`.
+
+    ---
+    id: "YYYYMMDDHHmm"
+    title: "Short descriptive title"
+    tags: ["#topic-one", "#topic-two"]
+    created: YYYY-MM-DD
+    source: "path/to/raw/source/file or URL"
+    ---
+
+    # [Title]
+
+    [Body: one thought, claim, or insight in your own processed words.
+    Not a copy-paste — synthesized, contextualized.
+    Answers "why does this matter?" and "how does this connect?"
+    Stands alone as a single atomic thought.]
+
+    ## Connections
+
+    → [ID](ID.md) — [Why this connection matters. Not just "related to"
+    but the specific nature of the link.]
+
+    ## Related
+
+    - [Structure Note Title](../pages/path/to/page.md)
+
+    ## Evidence
+
+    - [Source Title](path/to/raw/source) — [specific location: page,
+      section, paragraph, table]
+
+## Rules
+
+- **One thought per file.** Two ideas = two zettels.
+- **Timestamp ID:** `YYYYMMDDHHmm`. If creating multiple in the
+  same minute, increment by one minute.
+- **Title:** Short, descriptive, standalone.
+- **Tags:** 2–5 hashtags. Don't over-tag.
+- **Source:** Path to raw source or URL. Omit for conversation
+  or synthesis insights.
+- **Body:** Processed knowledge. Synthesize, contextualize. Don't
+  just excerpt the source.
+- **Connections:** Bidirectional. Update both sides. Every
+  connection has explicit context explaining why.
+- **Related:** Links to structure notes this zettel supports.
+- **Evidence:** Specific citations back to raw sources.
+````
+
+### File to delete
+
+- `references/maintain.md`
+
+---
+
+## Resolved design decisions
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Skill structure | 7 files: SKILL.md + 3 step files + 3 reference files | Detailed guidance without rigidity. Principles in SKILL.md, approach in step files, format in templates. |
+| Reference file style | Organized by concern, not numbered steps | Guard against rigidity. Describe what/why/decisions/pitfalls, not recipes. |
+| Model assignments | None | Agent uses its own model. Workspace conventions handle batch work. |
+| Architecture instructions | None in skill | Agent knows from workspace conventions when to parallelize. |
+| Audit vs. maintain | Merged into audit | One step for verification + structural evolution. |
+| Multi-company parallelism | One company at a time | Simplicity. |
+| Cross-page links | Structure notes can reference each other | Useful for navigation. |
+| Tag hygiene | Tags evolve organically | Guard against rigidity and redundancy. |

--- a/docs/13-zettel-wiki-v2-upgrade-plan.md
+++ b/docs/13-zettel-wiki-v2-upgrade-plan.md
@@ -1,0 +1,194 @@
+# Zettel-Wiki v2 — Upgrade Plan
+
+**Date:** 2026-04-21
+**Context:** Post-mortem from v1 test run (see `hard-disk/reports/00-companies/00-ai-media/wiki/TRACE-ANALYSIS.md`)
+**Skill location:** `~/.openclaw/skills/zettel-wiki/`
+
+---
+
+## Problems identified in v1
+
+1. **Agent over-indexed on "testing."** Read 4 synthesized notes (823 lines) and ignored ~292 raw source files.
+2. **No subagents used.** Entire wiki built in a single sequential session.
+3. **Source priority inverted.** Ingested notes (already distilled) instead of raw evidence.
+4. **Links pre-planned, never verified.** All links designed in a think step, never read back to check.
+5. **No coverage accounting.** No report of what was read vs. skipped.
+
+---
+
+## Config changes
+
+### Subagent limits
+
+| Setting | Current | Proposed | Schema bounds |
+|---|---|---|---|
+| `maxConcurrent` | 8 | 20 | positive integer, no upper bound |
+| `maxChildrenPerAgent` | 5 (default) | 10 | 1–20 |
+| `maxSpawnDepth` | 1 (default) | 1 (keep for now) | 1–5 |
+
+`maxSpawnDepth` controls nesting: at 1, subagents cannot spawn their own subagents. At 2, you get the orchestrator pattern (main → orchestrator → workers). Keeping at 1 for now since the main agent can orchestrate waves directly.
+
+Commands:
+```
+openclaw config set agents.defaults.subagents.maxConcurrent 20
+openclaw config set agents.defaults.subagents.maxChildrenPerAgent 10
+```
+
+Update the constraint table in `shared/AGENTS.md` to reflect new values.
+
+---
+
+## Skill changes — guiding principles
+
+The v1 skill was too procedural in places. The revision should:
+- **Lead with principles, not procedures.** The agent is smart enough to figure out execution. Tell it *what matters*, not *how many files triggers a subagent*.
+- **Let the agent decide when and how to use subagents.** No rigid thresholds. The agent assesses scope and chooses its approach.
+- **Avoid redundant instructions.** Say things once, in the right place.
+- **Keep responsibilities crisp.** Ingest creates (including cross-links). Audit verifies. Maintain evolves. Query reads.
+
+---
+
+## File-by-file changes
+
+### 1. `SKILL.md` — top-level router
+
+**Changes:**
+- Four workflows: Ingest → Audit → Query → Maintain
+- New principle: *Raw sources first.* Build knowledge from raw evidence. Notes and memos orient; they're not primary sources.
+- Model guidance per workflow (Ingest/Query on Opus 4.6, Audit/Maintain on GPT-5.4)
+- Audit description:
+
+> Verify ingestion quality: source coverage, link soundness, evidence
+> grounding. Runs during and after ingest as a quality gate. Can also
+> be triggered manually.
+
+### 2. `references/ingest.md`
+
+**Changes:**
+
+a. *Source priority* — add to "Read and extract":
+> Prefer raw evidence over synthesized notes. Raw sources (filings,
+> transcripts, product docs, case studies) are primary. Notes and
+> memos help orient but build zettels from underlying evidence.
+
+b. *Coverage principle* — replace the rigid "Scale assessment" step with a principle:
+> After surveying sources, account for coverage. The goal is to
+> process the corpus thoroughly, not selectively. If the scope is
+> large, use subagents. State what was processed, what was skipped,
+> and why. Unexplained gaps in coverage are a failure mode.
+
+This is a principle, not a workflow step. The agent decides *how* to handle scale — inline, subagents, batches, whatever makes sense. The principle just says: coverage matters, account for it.
+
+c. *Cross-linking is ingest's job* — clarify in Step 5 (Link bidirectionally):
+> Cross-linking is the ingest agent's responsibility, including
+> connections between zettels created by different subagents. When
+> using parallel subagents, the main agent wires cross-batch links
+> after subagents complete. The audit agent verifies link quality
+> but does not create links.
+
+d. *Coverage report* — add to quality checklist:
+> - [ ] Coverage: files surveyed vs. processed vs. skipped (with reasons)
+
+### 3. `references/audit.md` — NEW
+
+Simplified role: **verify, don't create.**
+
+```
+# Audit Agent — Zettel-Wiki
+
+You are the audit agent. Your job: verify ingestion quality.
+You check, flag, and recommend — you don't create or fix.
+
+## Checks
+
+### 1. Coverage
+Were the right sources processed? Flag high-value files that
+were skipped without justification.
+
+### 2. Link soundness
+Are connections between zettels and pages well-formed?
+- Do bidirectional links actually exist in both directions?
+- Does every connection include context explaining why?
+- Are there obvious missing connections between related zettels?
+Flag gaps for the ingest agent to address.
+
+### 3. Evidence grounding
+Does every zettel trace back to a raw source?
+- Flag zettels citing synthesized notes instead of raw evidence
+- Flag unsupported claims (assertions with no source reference)
+- Spot-check uncertain claims against cited sources
+
+## Output
+Summary with: coverage stats, link issues found, grounding
+flags, recommended actions.
+
+## Boundary with Maintain
+Audit checks recent ingest quality. Maintain handles wiki-wide
+structural health (orphans, staleness, page splits, restructuring).
+If you find structural issues, note them but don't fix — that's
+Maintain's job.
+```
+
+### 4. `references/maintain.md`
+
+**Changes:**
+- Add boundary note: *"Audit verifies recent ingest quality. Maintain operates on the whole wiki over time."*
+- Scope the "missing cross-domain connections" check to legacy content that pre-dates the audit workflow. For recent ingests, the ingest agent owns cross-linking and audit verifies it.
+
+---
+
+## Responsibility model
+
+```
+Ingest: Create zettels from raw sources, build all links
+   ↓
+Audit: Verify coverage, link soundness, evidence grounding
+   ↓ (periodically)
+Maintain: Wiki-wide structural health and evolution
+   ↓ (on question)
+Query: Answer from wiki knowledge
+```
+
+**Ingest** creates and links. **Audit** verifies. **Maintain** evolves. **Query** reads.
+
+---
+
+## Files to create/modify
+
+| File | Action |
+|---|---|
+| `SKILL.md` | Add Audit workflow, raw-sources-first principle |
+| `references/ingest.md` | Source priority, coverage principle, cross-link ownership |
+| `references/audit.md` | New — verify-only audit agent |
+| `references/maintain.md` | Boundary clarification, scope cross-link check |
+| `shared/AGENTS.md` | Update subagent constraint table |
+
+---
+
+## Decisions (resolved)
+
+1. **Wiki root:** Fixed — keep hardcoded at the default location.
+2. **Model assignments by workflow:**
+
+| Workflow | Model | Rationale |
+|---|---|---|
+| Ingest | `anthropic/claude-opus-4-6` | Deep extraction needs strong reasoning |
+| Audit | `openai/gpt-5.4` | Verification is analytical but less creative |
+| Maintain | `openai/gpt-5.4` | Structural checks, same profile as audit |
+| Query | `anthropic/claude-opus-4-6` | Synthesis and narrative need strong reasoning |
+
+3. **Config:** Approved. Set `maxConcurrent: 20`, `maxChildrenPerAgent: 10`.
+
+---
+
+## Status
+
+- [x] Plan reviewed and approved by Anton (2026-04-21)
+- [x] Config changes applied (`maxConcurrent: 20`, `maxChildrenPerAgent: 10`)
+- [x] `SKILL.md` updated (4 workflows, model assignments, raw-sources-first principle)
+- [x] `references/ingest.md` updated (source priority, cross-link ownership, coverage checklist)
+- [x] `references/audit.md` created (verify-only: coverage, link soundness, grounding)
+- [x] `references/maintain.md` updated (boundary clarification, scoped cross-link check)
+- [x] `shared/AGENTS.md` constraint table updated (synced to both workspaces)
+- [ ] Gateway restart (needed for config to take effect)
+- [ ] v2 test run executed

--- a/docs/15-collect-evidence-research-upgrade-plan.md
+++ b/docs/15-collect-evidence-research-upgrade-plan.md
@@ -1,0 +1,168 @@
+# Collect-Evidence → Research-and-Collect Upgrade Plan
+
+**Date:** 2026-04-23
+**Origin:** Oracle deep-dive session — Anton's feedback on research gaps exposed structural weaknesses in the collect-evidence skill.
+
+## Context
+
+During the Oracle research build, the evidence base started at 38 sources (almost entirely Oracle's own SEC filings) and required two waves of 14 subagents across multiple rounds of feedback to reach 75 registered sources covering 10 research dimensions. The skill's instructions didn't prevent the initial thin state or guide toward comprehensive research — we had to discover the gaps through conversation.
+
+Key problems:
+1. The skill produced a "minimum-viable" evidence base that looked complete by source count but was thin on every non-SEC dimension.
+2. Competitive landscape, news, customer intelligence, credit analysis, and structured data were all zero.
+3. The research plan had to be built from scratch in real-time instead of being guided by the skill.
+4. Multiple rounds of feedback were needed before the research was genuinely comprehensive.
+
+## What changes
+
+### 1. Rename: `collect-evidence` → `research-and-collect`
+
+The name should signal that this is active investigative research, not just document retrieval. "Collect-evidence" sounds like pulling files off a shelf. What we actually do is closer to: map the competitive landscape, investigate counterparty risk, gather industry data, and build analytical datasets.
+
+Update the skill `name` and `description` fields in frontmatter accordingly.
+
+### 2. Add shared reference: `references/deep-dive-checklist.md`
+
+**Already created** at `~/.openclaw/workspace/skills/collect-evidence/references/deep-dive-checklist.md`.
+
+This file contains:
+- The full deep-dive checklist (extracted from `analyze-business`)
+- 10 research dimensions that map checklist sections → specific evidence collection needs
+- Each dimension gets a coverage grade: strong / adequate / thin / missing
+
+Both `collect-evidence` (renamed) and `analyze-business` should reference this shared doc. The collect side reads it to know what evidence to gather. The analyze side reads it to structure the analysis. Same checklist, two uses.
+
+**Action for `analyze-business`:** Replace the inline checklist with a `read` directive pointing to the shared reference. Keep the analysis-specific guidance (workflow, brainstorm timing, etc.) in the analyze skill; move only the checklist definition to the shared file.
+
+### 3. Restructure the workflow into phases
+
+Current workflow is linear and SEC-first. New workflow should be:
+
+```
+Phase 0: Audit & plan
+  - Check what exists
+  - Read the deep-dive checklist
+  - Map the competitive landscape (identify competitors by business line)
+  - Identify key customers, suppliers, and ecosystem actors
+  - Produce a research plan with all 10 dimensions
+
+Phase 1: Deterministic baseline (broadened)
+  - SEC filings for the company (10-K, 10-Q, 8-K, proxy, earnings releases)
+  - SEC financials (XBRL income, balance, cash flow)
+  - Earnings transcripts (all available quarters)
+  - Competitor financial filings (income + balance for each competitor)
+  - Institutional ownership data (if available programmatically)
+
+Phase 2: Deep research (all dimensions in parallel)
+  - Industry & market data (market share, TAM, spending surveys)
+  - Customer & demand intelligence (key customer health, buyer surveys)
+  - Supply chain & cost structure (supplier dynamics, input costs)
+  - Financial & credit (ratings, debt structure, analyst consensus, comps)
+  - Management & governance (compensation, insider activity, board)
+  - External coverage (news, analyst research, bear/bull theses)
+  - Risk-specific evidence (regulatory, counterparty, operational)
+
+  Use browser for thorough search alongside web_search/web_fetch.
+  Use minerva research for deep discovery.
+  Use subagents for parallel collection across dimensions.
+
+Phase 3: Build structured datasets
+  - Key financials summary table
+  - Competitive comparison tables
+  - Segment/revenue breakdown time series
+  - Ratio trends and derived metrics
+  - Any other analytical tables the analysis will need
+
+Phase 4: Verify & grade
+  - Run inventory
+  - Grade each of the 10 research dimensions
+  - Any dimension graded "missing" blocks completion
+  - Any dimension graded "thin" gets one more targeted pass
+  - Produce the handoff report
+```
+
+### 4. Add the Research Dimension Framework to SKILL.md
+
+The 10 research dimensions (already in the reference doc) should also appear in SKILL.md as a mandatory checklist the agent works through. The skill should instruct:
+
+- Before starting collection, read `references/deep-dive-checklist.md` to load the full dimension framework
+- After collection, grade each dimension explicitly
+- Do not declare the evidence base ready if any critical dimension is "missing"
+
+### 5. Add competitive mapping as an explicit early step
+
+The single biggest gap was: we never mapped who the competitors were. The skill should require:
+
+- Early in Phase 0, identify all competitors by business line
+- For multi-segment companies, map competitors separately per segment
+- Pull financial filings for each competitor in Phase 1
+- This is deterministic work that should happen automatically, not as an afterthought
+
+### 6. Add browser-based research emphasis
+
+The current skill mentions browser in passing. The new skill should emphasize:
+
+- Always consider browser-based research for news, paywalled content, and interactive sources
+- Browser searches often surface content that `web_search` API misses
+- For thorough research, combine `web_search` (fast, broad) with browser (deep, interactive)
+
+### 7. Add parallel execution guidance
+
+The skill should guide on using subagents for parallel research:
+
+- Research dimensions are largely independent — collect them in parallel
+- Batch subagents: up to 10 concurrent (per maxChildrenPerAgent)
+- Each subagent handles one dimension or a coherent sub-batch
+- Verify outputs exist on disk after subagent completion (subagents may report success without saving files)
+
+### 8. Add counterparty/customer research mandate
+
+For any company with material customer concentration:
+
+- Identify the top 3-5 customers or counterparties
+- Assess their financial health independently
+- For contractual obligations (like Oracle's RPO), verify the counterparty can pay
+- This is especially critical for infrastructure/B2B companies with long-term contracts
+
+### 9. Add structured data build as explicit step
+
+The skill should require building derived analytical datasets, not just collecting raw sources:
+
+- Key financials summary (income/balance/cash flow with ratios)
+- Competitive comparison tables
+- Segment breakdown time series
+- Any metric time series the analysis will need
+- Store in `data/structured/` with an INDEX.md
+
+### 10. Strengthen completion criteria
+
+Current criteria check source counts. New criteria should check:
+
+- All 10 research dimensions graded
+- No critical dimension is "missing"
+- At least one structured analytical dataset exists
+- Competitor filings collected for identified competitors
+- News/external coverage is non-zero
+- If counterparty concentration exists, counterparty health is assessed
+
+## File changes summary
+
+| File | Action | Notes |
+|------|--------|-------|
+| `collect-evidence/SKILL.md` | Rewrite | Rename skill, restructure workflow, add dimension framework, add browser/parallel/counterparty guidance |
+| `collect-evidence/references/deep-dive-checklist.md` | Already created | Shared checklist + research dimensions |
+| `analyze-business/SKILL.md` | Update | Replace inline checklist with read directive to shared reference; keep analysis workflow intact |
+| Skill folder rename | `collect-evidence/` → `research-and-collect/` | Rename the directory |
+
+## Migration notes
+
+- The existing `collect-evidence` skill is referenced in `AGENTS.md` (both local and shared) — update references after rename
+- The `analyze-business` skill references `collect-evidence` by name in its workflow — update to new name
+- Minerva CLI commands don't change — only the skill instructions change
+- Existing company evidence trees are unaffected — the skill operates on the same folder structure
+
+## Open questions
+
+1. Should the shared checklist live in the `collect-evidence` (or renamed) skill's references, or in a shared location like `~/.openclaw/skills/` that both skills can access?
+2. Should the research dimension grades be persisted as a file in the evidence tree (e.g., `data/meta/dimension-grades.md`)?
+3. Should `minerva evidence` CLI be extended to support dimension-level coverage checking, or is this purely an agent-side concern?

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,7 @@
 | `11-minerva-evidence-starter-live-tested-guide.md` | file | Live-tested starter walkthrough of the current `minerva evidence` workflow, including real command behavior, workflow design, and measurement gaps. |
 | `12-minerva-evidence-v2-zero-based-redesign.md` | file | Zero-based redesign for a smaller, more agentic evidence workflow built around `init`, `add-source`, `review`, and `analysis context`. |
 | `14-evidence-v2-quickstart.md` | file | Quickstart guide for the V2 evidence workflow: commands, workspace layout, migration, and SEC per-section file notes. |
+| `15-collect-evidence-research-upgrade-plan.md` | file | Upgrade plan: rename collect-evidence → research-and-collect, add shared deep-dive checklist, 10 research dimensions, competitive mapping, parallel execution, and structured data build. |
 
 ## Notes
 - Docs hold higher-level designs, reports, and durable reference writeups.

--- a/docs/analysis/00-zettel-wiki-v1-trace-analysis.md
+++ b/docs/analysis/00-zettel-wiki-v1-trace-analysis.md
@@ -1,0 +1,281 @@
+# Trace Analysis: AI-Media Zettel-Wiki Construction
+**Date:** 2026-04-18
+**Session ID:** `1e08af00-3488-49b5-a4ba-5aeddf8acc89`
+
+## 1. Session Overview
+- **Start Time:** 2026-04-17 13:43:09 UTC
+- **End Time:** 2026-04-17 13:56:44 UTC
+- **Total Duration:** 13 minutes, 35 seconds
+- **Message Counts:**
+    - **User:** 1 (Initial prompt via Slack)
+    - **Assistant:** 13 Turns
+    - **Tool Calls:** 64 total
+- **Model Used:** `anthropic/claude-opus-4-6`
+- **Estimated Cost:** $0.00 (Log reported 0 cost, though substantial token usage occurred)
+
+---
+
+## 2. Execution Timeline
+
+| Timestamp (UTC) | Tool | Key Parameters / Input | Lines Read | % of File | Outcome / Reasoning Summary |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 13:43:09 | `read` | `~/.openclaw/skills/zettel-wiki/SKILL.md` | 98 / 97 | 100% | Skill discovery and rule verification. |
+| 13:43:09 | `exec` | `find ... -type f \| head -80` | — | — | Initial file survey of the AI Media folder. |
+| 13:43:17 | `exec` | `find ... \| grep -v '.DS_Store' \| wc -l` | — | — | Determined 296 files total in the source directory. |
+| 13:43:17 | `exec` | `find ... \| tail -80` | — | — | Surveyed the research and notes folders. |
+| 13:43:29 | `think` | Task strategy & batched ingest plan. | — | — | Decided to prioritize synthesized notes over raw data for the initial wiki. |
+| 13:43:32 | `read` | `references/ingest.md` | 123 / 122 | 100% | Loaded ingest workflow conventions. |
+| 13:43:32 | `read` | `references/schema.md` | 56 / 55 | 100% | Loaded naming conventions. |
+| 13:43:32 | `read` | `references/page-template.md` | 38 / 37 | 100% | Loaded page template. |
+| 13:43:32 | `read` | `references/zettel-template.md` | 48 / 47 | 100% | Loaded zettel template. |
+| 13:43:55 | `read` | `00-ai-media/INDEX.md` | 11 / 10 | 100% | Mapped root folder structure. |
+| 13:43:55 | `read` | `00-notes/INDEX.md` | 22 / 21 | 100% | Mapped notes landscape. |
+| 13:43:55 | `read` | `02-research/INDEX.md` | 21 / 20 | 100% | Mapped research landscape. |
+| 13:43:55 | `read` | `01-data/02-structured/INDEX.md` | 19 / 18 | 100% | Mapped structured data landscape. |
+| 13:43:58 | `read` | `00-notes/2026-03-25-ai-media-deep-dive.md` | *390 / 389* | *100%* | Extracted core synthesis for the wiki structure. |
+| 13:44:24 | `think` | Wiki structure and page planning. | — | — | Identified 10 thematic clusters and ~30 atomic zettel ideas. |
+| 13:44:31 | `read` | `2026-03-23-ai-media-key-metrics-update.md` | 42 / 41 | 100% | Metric data extraction. |
+| 13:44:31 | `read` | `2026-03-25-ai-media-taleb-fragility-memo.md` | *256 / 255* | *100%* | Risk and fragility analysis extraction. |
+| 13:44:31 | `read` | `2026-03-27-aim-market-implied-expectations.md` | 135 / 134 | 100% | Valuation and market expectations extraction. |
+| 13:45:04 | `think` | Finalizing the zettel and page list. | — | — | Confirmed 30 specific zettels and 10 pages for the test run. |
+| 13:45:12 | `message` | Slack update to Anton. | — | — | Reported progress and planned structure. |
+| 13:45:16 | `exec` | `mkdir -p .../wiki/{pages,zettels}` | — | — | Created the wiki directory structure. |
+| 13:46:52 | `write` | `LEDGER.md` + 8 Zettels (`0943`-`0950`) | — | — | First batch of zettel construction. |
+| 13:48:24 | `write` | 8 Zettels (`0951`-`0958`) | — | — | Second batch: Customers, Regulation, and Enterprise conditions. |
+| 13:50:11 | `write` | 8 Zettels (`0959`-`0966`) | — | — | Third batch: Hardware, ARR, AI-Industry dynamics, and Valuation. |
+| 13:51:36 | `write` | 6 Zettels (`0967`-`0972`) | — | — | Final batch: Distribution weaknesses and Evidence gaps. |
+| 13:53:50 | `write` | 6 Pages (`overview`, `transition`, `stickiness`, `hardware`, `competition`, `customer-base`) | — | — | Core narrative page construction. |
+| 13:55:12 | `write` | 4 Pages (`enterprise-gov`, `valuation`, `fragility`, `regulatory`) | — | — | Supplemental narrative page construction. |
+| 13:55:49 | `write` | `INDEX.md`, `pages/INDEX.md`, `zettels/INDEX.md` | — | — | Automated indexing pass. |
+| 13:55:59 | `write` | `LEDGER.md` (Update) | — | — | Recorded the full ingest session. |
+| 13:56:15 | `exec` | `du -sh` and `find . -type f` | — | — | Verification pass of the created files. |
+| 13:56:26 | `exec` | `grep` and `wc -l` | — | — | Verified bidirectional linking and zettel counts. |
+| 13:56:41 | `message` | Completion update to Anton. | — | — | Final report on the built wiki. |
+
+> **Note:** Every `read` call was a full-file read (100%). The agent never used `offset`/`limit` parameters to do partial reads. "Lines Read" shows `returned / actual` — the +1 difference is the `read` tool counting a trailing newline as an extra line.
+
+---
+
+## 3. Content Ingestion Map
+
+| Order | Source File | Lines Read | % of File | Size | Knowledge Extracted |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 1 | `00-notes/2026-03-25-ai-media-deep-dive.md` | *390 / 389* | *100%* | *30 KB* | Core thesis, company metrics, customer map, stickiness evidence, and valuation baseline. |
+| 2 | `00-notes/2026-03-23-ai-media-key-metrics-update.md` | 42 / 41 | 100% | 2.7 KB | ARR run-rate ($30m), gross margin expansion (42% to 70%), and LEXI minute scaling. |
+| 3 | `00-notes/2026-03-25-ai-media-taleb-fragility-memo.md` | *256 / 255* | *100%* | *19.5 KB* | Risk of AI model commoditization, concentration risk (top-20 = 80%), and hardware vs. software transition fragility. |
+| 4 | `00-notes/2026-03-27-aim-market-implied-expectations.md` | 135 / 134 | 100% | 6.6 KB | Market pricing comparison (A$0.22 vs $0.23 intrinsic) and reverse DCF implications. |
+
+**Total content docs read:** 823 lines / 58.8 KB across 4 source documents.
+
+### Skill & Infrastructure Reads
+
+| File | Lines | Size | Purpose |
+| :--- | :--- | :--- | :--- |
+| File | Lines Read | % of File | Size | Purpose |
+| :--- | :--- | :--- | :--- | :--- |
+| `SKILL.md` | 98 / 97 | 100% | 3.9 KB | Main skill instructions |
+| `references/ingest.md` | 123 / 122 | 100% | 4.8 KB | Ingest workflow conventions |
+| `references/schema.md` | 56 / 55 | 100% | 1.7 KB | Naming conventions |
+| `references/page-template.md` | 38 / 37 | 100% | 1.7 KB | Page template |
+| `references/zettel-template.md` | 48 / 47 | 100% | 1.9 KB | Zettel template |
+| `00-ai-media/INDEX.md` | 11 / 10 | 100% | 0.4 KB | Root folder mapping |
+| `00-notes/INDEX.md` | 22 / 21 | 100% | 2.7 KB | Notes folder mapping |
+| `02-research/INDEX.md` | 21 / 20 | 100% | 1.0 KB | Research folder mapping |
+| `01-data/02-structured/INDEX.md` | 19 / 18 | 100% | 0.8 KB | Structured data mapping |
+
+**Total infrastructure reads:** 436 lines / 18.9 KB across 9 files.
+**Grand total reads:** 1,259 lines / 77.7 KB across 13 `read` calls.
+
+---
+
+## 4. Wiki Output Map
+
+| Path | Description |
+| :--- | :--- |
+| `wiki/pages/ai-media-overview.md` | Central entry point; summarizes the tech transition and workflow thesis. |
+| `wiki/pages/technology-transition.md` | Details the services-to-SaaS shift, margin expansion, and LEXI adoption. |
+| `wiki/pages/workflow-stickiness.md` | Analyzes network effects (iCap) and metadata integration (SCTE-35/104). |
+| `wiki/pages/hardware-control-point.md` | Covers encoder appliances, the 2H26 refresh cycle, and HaaS. |
+| `wiki/pages/competitive-landscape.md` | Direct teardowns of ENCO, SyncWords, Evertz, and Verbit. |
+| `wiki/pages/customer-base.md` | Concentration analysis and named customer evidence (Seven, Google, Vic Parliament). |
+| `wiki/pages/enterprise-government.md` | Defines the four specific conditions where AIM beats bundled platforms. |
+| `wiki/pages/valuation-and-expectations.md` | Conservative DCF framework and reverse market-implied math. |
+| `wiki/pages/fragility-and-risks.md` | Taleb-style stress test: distribution weaknesses and evidence gaps. |
+| `wiki/pages/regulatory-environment.md` | ACMA/FCC/EAA compliance tailwinds and the risk of enforcement. |
+| `wiki/zettels/` | 30 atomic notes covering specific evidence points (e.g., #202604170946 on iCap resentment). |
+| `wiki/INDEX.md` | Master catalog of the wiki structure. |
+| `wiki/LEDGER.md` | Permanent audit log of the construction session. |
+
+---
+
+## 5. Think Steps
+
+### Step 1: Initial Strategy (Turn 4)
+> "Let me understand the task:
+> 1. Anton wants me to use the zettel-wiki skill to create a wiki for the AI Media company research folder
+> 2. The wiki should live at `00-ai-media/wiki/` (not the default wiki root)
+> 3. I should only read files within `00-ai-media/`
+> 4. This is a test of the zettel-wiki v1 skill
+> 
+> The zettel-wiki skill has a default wiki root of `/Users/charlie-buffet/Documents/project-minerva/hard-disk/wiki/` but Anton wants it at `00-ai-media/wiki/` instead.
+> 
+> There are ~296 files in this folder. The main content areas are:
+> - `01-data/02-structured/` - raw data: filings, product docs, customer evidence, competitors, news, key metrics, valuation
+> - `02-research/` - research outputs: hardware moat, switching costs, gap analysis, brainstorm, contexts, manifests
+> - `00-notes/` - analytical notes and memos
+> 
+> This is an ingest workflow - I need to process these sources into wiki knowledge. Let me read the ingest reference file and the schema/templates.
+> 
+> But wait - 296 files is a LOT. I need to think about how to approach this efficiently. I should:
+> 1. Read the ingest, schema, and template references
+> 2. Create the wiki structure at `00-ai-media/wiki/`
+> 3. Process the sources in batches - maybe using parallel subagents per the \"extraction at scale\" rule
+> 
+> Let me first read the reference files, then plan the approach."
+
+### Step 2: Content Prioritization (Turn 6)
+> "Okay, now I have a clear picture. Let me plan this:
+> **Task:** Create a zettel-wiki at `00-ai-media/wiki/` by ingesting the ~296 files in the `00-ai-media/` folder.
+> 
+> **Key adaptations from the standard zettel-wiki skill:**
+> 1. Wiki root is `00-ai-media/wiki/` instead of the default `hard-disk/wiki/`
+> 2. Only read files within `00-ai-media/`
+> 3. This is a test run
+> 
+> **Approach:**
+> Given ~296 files, I need to be strategic. Let me look at the folder structure:
+> 
+> 1. `01-data/02-structured/` - Source data:
+>    - `00-filings/` - Company filings (annual reports, results, presentations) 
+>    - `03-product-docs/` - Product manuals, datasheets
+>    - `04-customer-evidence/` - Case studies, customer quotes
+>    - `05-competitors/` - Competitor analysis
+>    - `06-news/` - News articles
+>    - `08-key-metrics/` - Financial metrics and charts
+>    - `10-valuation/` - Valuation assumptions
+>    - `source-catalogs/` - Download manifests (metadata, not content)
+> 
+> 2. `02-research/` - Research outputs:
+>    - Various research threads: hardware moat, switching costs, market expectations, etc.
+>    - Contexts, gap analysis, brainstorm refresh, customer map
+> 
+> 3. `00-notes/` - Analytical notes and memos
+> 
+> The research and notes folders are likely the richest for wiki content since they're already synthesized. The raw filings and data are evidence/source material that Zettels would link to but wouldn't necessarily each get their own Zettel.
+> 
+> **Strategy:**
+> 1. Create the wiki folder structure: `wiki/pages/`, `wiki/zettels/`, `wiki/INDEX.md`, `wiki/LEDGER.md`
+> 2. Start with the highest-value, most-synthesized files first: `00-notes/` and `02-research/` folders
+> 3. Then process `01-data/02-structured/` for supplemental evidence
+> 
+> Given the scale (296 files), I should use parallel subagents for extraction per the shared AGENTS.md rule. But since this is a test, maybe I should start with a manageable scope to demonstrate the pattern works, then expand.
+> 
+> Actually, let me re-read Anton's message: \"For testing, please make a separate wiki page in the same folder: 00-ai-media/wiki\". This is a test. I should do a thorough but focused initial ingest. Let me:
+> 
+> 1. Create the wiki structure
+> 2. Read the key synthesized files (notes, research summaries) to understand the knowledge landscape
+> 3. Create wiki pages for the major topics
+> 4. Create Zettels for the atomic insights
+> 5. Link everything together
+> 
+> Let me start by reading the INDEX files and key summary documents to understand what's there, then plan the wiki pages and Zettels."
+
+### Step 3: Architecture Finalization (Turn 8)
+> "Excellent. That deep dive is incredibly comprehensive. Now I have a strong grasp of the knowledge landscape. Let me plan the wiki structure.
+> 
+> **Wiki pages (topics for `pages/`):**
+> The deep dive reveals clear thematic clusters:
+> 1. `ai-media.md` - Top-level company overview page
+> 2. `workflow-stickiness.md` - The workflow and switching costs thesis  
+> 3. `hardware-control-point.md` - Hardware encoder moat and future
+> 4. `competitive-landscape.md` - Competitors and outside-in views
+> 5. `customer-base.md` - Named customers, concentration, segments
+> 6. `enterprise-government.md` - Enterprise/government buyer criteria
+> 7. `technology-transition.md` - Services-to-SaaS transition, LEXI growth
+> 8. `valuation.md` - Valuation framework and market expectations
+> 9. `cross-sell-optionality.md` - LEXI Voice, Translate, SubSilo
+> 10. `regulatory-environment.md` - ACMA, FCC, EAA compliance drivers
+> 
+> **Zettels (atomic insights):**
+> From the deep dive and the research I can already identify many atomic claims. But to do this properly, I should also read the underlying research files. Given scale, let me use parallel subagents for the extraction.
+> 
+> Actually, let me think about this differently. This is a TEST of the zettel-wiki v1 skill. Anton wants to see the pattern working. I should:
+> 1. Create the wiki infrastructure (`wiki/pages/`, `wiki/zettels/`, `INDEX.md`, `LEDGER.md`)
+> 2. Do a thorough initial ingest from the most important sources
+> 3. Create well-linked pages and zettels
+> 
+> The deep dive alone contains enough material for a solid initial wiki. I can then spawn subagents to process the underlying research files for additional zettels.
+> 
+> Let me be strategic: 
+> - Build the structure first
+> - Create the main wiki pages from the deep dive (which synthesizes everything)
+> - Then read the individual research files to create detailed zettels that support the pages
+> - Use subagents for parallel extraction from the data files"
+
+### Step 4: Batch Construction Logic (Turn 11)
+> "I now have a comprehensive understanding of the knowledge base. Let me plan the wiki structure and then build it.
+> 
+> **Wiki Pages (in `pages/`):**
+> 1. `ai-media-overview.md` ... 10. `regulatory-environment.md`
+> 
+> **Zettels (in `zettels/`):**
+> I'll create ~25-30 atomic notes covering key insights. Let me identify them:
+> 1. AIM's gross margin expanded ... 30. Vitac resilience.
+> 
+> That's 30 zettels. Perfect scope for a test.
+> For timestamps, I'll use 202604170943 as the starting point (current time) and increment.
+> 
+> Let me build this. I'll create all the infrastructure files first, then pages, then zettels, linking as I go. This is going to be a lot of file creation, so I'll batch efficiently."
+
+---
+
+## 6. Cost & Token Summary
+
+| Turn | Input Tokens | Output Tokens | Cache Read | Cache Write |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | 3 | 178 | 0 | 22433 |
+| 2 | 1 | 212 | 22433 | 6035 |
+| 3 | 1 | 417 | 28468 | 4472 |
+| 4 | 1 | 228 | 32940 | 443 |
+| 5 | 1 | 313 | 36618 | 859 |
+| 6 | 1 | 118 | 37477 | 1795 |
+| 7 | 1 | 1179 | 39272 | 7978 |
+| 8 | 1 | 311 | 47250 | 1205 |
+| 9 | 1 | 1217 | 48455 | 8406 |
+| 10 | 1 | 391 | 56861 | 1243 |
+| 11 | 1 | 134 | 58104 | 453 |
+| 12 | 1 | 5315 | 58557 | 148 |
+| 13 | 1 | 5504 | 64693 | 5605 |
+| 14 | 1 | 4159 | 70298 | 6109 |
+| 15 | 1 | 5973 | 76407 | 4616 |
+| 16 | 1 | 1721 | 87441 | 3847 |
+| 17 | 1 | 621 | 91288 | 1940 |
+| 18 | 1 | 309 | 93228 | 679 |
+| 19 | 1 | 212 | 93907 | 893 |
+| 20 | 1 | 256 | 94800 | 362 |
+| 21 | 1 | 557 | 95162 | 620 |
+| **Total** | **23** | **29,024** | **1,133,059** | **78,141** |
+
+---
+
+## 7. Subagent Usage
+
+*No subagents were spawned during this session.* The main agent handled the entire wiki build — skill reading, content ingestion, planning, file creation, indexing, verification, and reporting — in a single sequential session without delegating to subagents.
+
+This is notable because the `zettel-wiki` skill references three subagent roles (Ingest, Query, Maintain) and the shared `AGENTS.md` recommends parallel subagents for extraction at scale. The agent made a deliberate choice (documented in Think Step 2) to skip the parallel extraction pattern because:
+1. This was a "test" run — demonstrating the pattern end-to-end mattered more than throughput.
+2. Only 4 synthesized docs were being ingested (not the full 296 raw files).
+3. The scope was manageable within a single agent's context window.
+
+For a production-scale ingest of the ~296 raw source files, parallel subagents would likely be necessary.
+
+---
+
+## 8. Observations
+
+1. **Strategic Scaling:** The agent correctly identified that processing 296 raw files individually would be inefficient for a "test" run. It used the existing high-level synthesis (the Deep Dive) as an "accelerant" to build a robust structural skeleton for the wiki, assuming that granular sub-extractions can fill in the gaps later.
+2. **Structural Integrity:** Despite the high volume of file writes (40+ files), the agent maintained perfect bidirectional link integrity. Every zettel created had a corresponding "who connects back to me" check in the final turns.
+3. **Adaptive Wiki Root:** The agent successfully overrode its default `SKILL.md` settings (which pointed to a global wiki root) to create a project-local wiki at `00-ai-media/wiki/` as requested.
+4. **Knowledge vs Information:** The agent adhered to the Zettelkasten principle of "Knowledge, not information," ensuring that zettels weren't just excerpts but processed insights that answered "why does this matter?"
+5. **Prompt-Skill Synergy:** The trace shows the agent moving seamlessly between its general engineering persona and the specialized "Ingest Agent" persona defined in the `zettel-wiki` skill.
+6. **Efficiency:** The total execution time of ~13 minutes for a 40-file interlinked knowledge base demonstrates the massive productivity gain of agentic workflow automation over manual wiki construction.

--- a/docs/analysis/01-zettel-wiki-v2-trace-analysis.md
+++ b/docs/analysis/01-zettel-wiki-v2-trace-analysis.md
@@ -1,0 +1,550 @@
+# Trace Analysis: AI-Media Zettel-Wiki v2 Construction + Maintenance
+
+**Date:** 2026-04-22
+**Session ID (main):** `33b0d442-4c68-4e59-a1b9-779ccfa3b72f`
+**Thread:** Slack `#all-minerva` — "Test Zettel-Wiki v2 - Charlie"
+
+---
+
+## 1. Session Overview
+
+- **Agent:** Charlie (agent ID: `main`)
+- **Start Time:** 2026-04-21 17:48:29 UTC (13:48 EDT)
+- **End Time (Phase 2):** 2026-04-21 20:24:46 UTC (16:24 EDT)
+- **Total Wall Time:** 2h 36m (active work ~20 min across two phases)
+- **Phase 1 (Ingest):** 13:48–14:02 EDT (14 minutes)
+- **Phase 2 (Maintenance):** 16:18–16:24 EDT (6 minutes)
+- **Model (main):** `anthropic/claude-opus-4-6`
+- **Model (subagents):** `google/gemini-3-flash-preview` (gemini-flash)
+- **Main Session Turns:** 77 assistant turns (Phase 1: 54, Phase 2: 23)
+- **Main Session Tool Calls:** 130
+- **Subagent Sessions:** 16 (8 extraction + 8 cross-linking)
+- **Total Tool Calls (all sessions):** ~456
+- **User Messages:** 2 (initial ingest request + maintenance request)
+- **Slack Updates Sent:** 4 (2 per phase: progress + completion)
+
+> **Note:** A Phase 3 occurred at 04:16 UTC (00:16 EDT) where the agent attempted to start the trace analysis itself after being tagged, but this was redirected to Steve.
+
+---
+
+## 2. Execution Timeline
+
+### Phase 1: Ingest (17:48–18:02 UTC)
+
+| Timestamp (UTC) | Tool | Key Parameters / Input | Lines Read | % of File | Outcome / Reasoning Summary |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 17:48:32 | `read` | `~/.openclaw/skills/zettel-wiki/SKILL.md` | 122 / 121 | 100% | Skill discovery and rule verification. |
+| 17:48:32 | `exec` | `find ... -type f \| head -80` | — | — | Initial file survey of the AI Media folder. |
+| 17:48:37 | `exec` | `find ... \| wc -l` | — | — | Determined 296 files total in the source directory. |
+| 17:48:37 | `exec` | `find ... -name '*.md' \| wc -l` | — | — | Identified 173 content-rich files (markdown/text). |
+| 17:48:37 | `exec` | `find ... -maxdepth 1` | — | — | Surveyed root folder structure. |
+| 17:48:40 | `read` | `00-ai-media/INDEX.md` | 11 / 10 | 100% | Mapped top-level folder organization. |
+| 17:48:40 | `exec` | `find .../01-data -maxdepth 2` | — | — | Detailed survey of the structured data folder. |
+| 17:48:49 | `think` | Task strategy and planning. | — | — | Decided to survey raw sources and read reference files before building. |
+| 17:48:52 | `read` | `references/ingest.md` | 137 / 136 | 100% | Loaded ingest workflow conventions. |
+| 17:48:52 | `read` | `references/schema.md` | 56 / 55 | 100% | Loaded naming and ID conventions. |
+| 17:48:56 | `read` | `references/zettel-template.md` | 48 / 47 | 100% | Loaded zettel markdown template. |
+| 17:48:56 | `read` | `references/page-template.md` | 38 / 37 | 100% | Loaded wiki page markdown template. |
+| 17:49:12 | `think` | Architecture and batching plan. | — | — | Planned parallel extraction by source category; decided on 8 batches. |
+| 17:49:18 | `message` | Slack update to Anton. | — | — | "On it. Setting up a wiki… 173 text files across filings, product docs…" |
+| 17:49:24 | `read` | `01-data/02-structured/INDEX.md` | 19 / 18 | 100% | Mapped structured data subfolders. |
+| 17:49:24 | `read` | `.../00-filings/INDEX.md` | 36 / 35 | 100% | Surveyed company filing history (26 files). |
+| 17:49:24 | `read` | `.../03-product-docs/INDEX.md` | 20 / 19 | 100% | Surveyed product documentation. |
+| 17:49:24 | `read` | `.../04-customer-evidence/INDEX.md` | 17 / 16 | 100% | Surveyed customer case studies and quotes. |
+| 17:49:24 | `read` | `.../05-competitors/INDEX.md` | 16 / 15 | 100% | Surveyed competitive landscape files. |
+| 17:49:24 | `read` | `.../06-news/INDEX.md` | 16 / 15 | 100% | Surveyed recent news coverage. |
+| 17:49:30 | `read` | `00-notes/INDEX.md` | 22 / 21 | 100% | Surveyed analytical notes and memos. |
+| 17:49:30 | `read` | `02-research/INDEX.md` | 21 / 20 | 100% | Surveyed research workstreams. |
+| 17:49:30 | `exec` | `find 00-notes/` | — | — | Verified file counts in the notes folder. |
+| 17:49:30 | `exec` | `find 02-research/` | — | — | Verified file counts in the research folder. |
+| 17:50:04 | `think` | Finalizing extraction strategy. | — | — | Categorized 62 source files into 8 batches for parallel processing. |
+| 17:50:08 | `exec` | `find 01-data/02-structured/` | — | — | Verification pass of primary evidence folders. |
+| 17:50:08 | `exec` | `mkdir -p wiki/{pages,zettels}` | — | — | Created the project-local wiki directory structure. |
+| 17:50:11 | `read` | `00-notes/2026-03-25-ai-media-deep-dive.md` | *390 / 389* | *100%* | Extracted core synthesis to guide wiki page structure. |
+| 17:50:46 | `think` | Wiki page planning. | — | — | Defined 9 thematic pages; mapped expected zettel clusters to each. |
+| 17:50:57 | `write` ×4 | `wiki/INDEX.md`, `LEDGER.md`, pages/INDEX, zettels/INDEX | — | — | Initialized wiki infrastructure and index files. |
+| 17:51:00 | `read` | `08-key-metrics/aim_key_metrics.md` | 67 / 66 | 100% | Loaded financial and operational benchmarks. |
+| 17:51:48 | `think` | Subagent task calibration. | — | — | Finalized 8 batch assignments with timestamp ranges; chose gemini-flash. |
+| 17:53:22 | `sessions_spawn` ×8 | 8 extraction subagents (gemini-flash) | — | — | All 8 spawned simultaneously with non-overlapping timestamp namespaces. |
+| 17:53:32 | `sessions_yield` | Wait for subagent completions. | — | — | Paused main session for parallel extraction. |
+| 17:53:52 | `think` | Mid-extraction triage. | — | — | Detected batch 4 failure (raw text dump, no zettels); decided to proceed. |
+| 17:54:04 | `think` | Progress check. | — | — | 4 zettels on disk from early completions; confirmed batch 4 gap. |
+| 17:54:09–17:56:09 | `sessions_yield` ×7 | Waiting for remaining batches. | — | — | Progressive completions: batch 2, 7, 1, 8, 6, 3, then 5. |
+| 17:56:29 | `exec` ×2 | `ls wiki/zettels \| wc -l` + full listing | — | — | Verified 117 zettels on disk. |
+| 17:56:50 | `think` | Post-extraction consolidation. | — | — | All 8 batches done; 117 zettels; batch 4 gap confirmed; planned page synthesis. |
+| 17:56:55 | `read` ×4 | Sample zettels: `202604211400`, `202604211613`, `202604211703`, `202604211635` | ~90 total | 100% | Audited subagent output for quality and atomicity. |
+| 17:57:02 | `exec` | Build complete zettel catalog (titles + IDs) | — | — | Extracted all 117 zettel titles for page synthesis. |
+| 17:57:28 | `think` | Wiki page synthesis planning. | — | — | Mapped 117 zettels into 9 thematic clusters; designed page narratives. |
+| 17:58:22 | `write` ×3 | `ai-media.md`, `saas-transition.md`, `icap-network.md` | — | — | First 3 wiki pages: overview, financial transition, network effects. |
+| 17:59:31 | `write` ×3 | `hardware-control-point.md`, `lexi-suite.md`, `workflow-stickiness.md` | — | — | Next 3 pages: hardware moat, product suite, switching costs. |
+| 18:00:26 | `write` ×3 | `competitive-landscape.md`, `regulatory-tailwinds.md`, `enterprise-government.md` | — | — | Final 3 pages: competition, regulation, enterprise. |
+| 18:00:36 | `write` | `pages/INDEX.md` | — | — | Updated the wiki page directory. |
+| 18:00:49 | `exec` | Build `zettels/INDEX.md` from frontmatter | — | — | Generated zettel catalog with IDs and titles. |
+| 18:00:58 | `write` | `wiki/INDEX.md` (updated) | — | — | Updated master wiki index with all pages and counts. |
+| 18:01:11 | `write` | `wiki/LEDGER.md` (ingest entry) | — | — | Recorded Phase 1 construction session in audit log. |
+| 18:01:15 | `read` ×2 | Zettels `202604211411`, `202604211452` | ~44 total | 100% | Read zettels for demo cross-linking. |
+| 18:01:24–18:02:01 | `edit` ×6 | Cross-linked 6 central zettels | — | — | Added Connections sections with "why" context to highest-value zettels. |
+| 18:02:10 | `edit` | `zettels/INDEX.md` update | — | — | Updated zettel index after cross-links. |
+| 18:02:17 | `exec` | `find wiki -type f -name '*.md' \| wc -l` | — | — | Verification: 130 files in wiki structure. |
+| 18:02:23 | `exec` | Cross-link verification (`grep` on 6 zettels) | — | — | Confirmed all 6 demo cross-links present. |
+| 18:02:42 | `message` | Completion report to Anton. | — | — | "Done. Wiki built at 00-ai-media/wiki/. 117 zettels, 9 pages…" |
+
+### Phase 2: Maintenance (20:18–20:24 UTC)
+
+| Timestamp (UTC) | Tool | Key Parameters / Input | Lines Read | % of File | Outcome / Reasoning Summary |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 20:18:25 | `read` | `references/maintain.md` | 209 / 208 | 100% | Loaded wiki maintenance and evolution rules. |
+| 20:18:56 | `think` | Maintenance strategy. | — | — | Planned two-phase pass: correctness (orphan resolution) + evolution (coverage check). |
+| 20:19:02 | `message` | Update to Anton (Phase 2). | — | — | "Starting the full maintenance pass…" |
+| 20:19:06 | `exec` | Build master zettel summary | — | — | Cataloged all 117 zettels: IDs + titles for cross-linking reference. |
+| 20:19:37 | `think` | Duplicate detection. | — | — | Identified 6 duplicate clusters (EAA ×3, R&D ×2, AI quality ×3, revenue ×2, board ×2, margin ×3). |
+| 20:19:45 | `exec` | Build compact zettel catalog | — | — | Created master reference for subagent consumption. |
+| 20:19:52 | `exec` | Identify unlinked zettels | — | — | 111 of 117 zettels still have empty Connection sections. |
+| 20:20:19 | `write` | `zettel-crosslink-catalog.md` | — | — | Shared reference file with all zettel IDs, titles, and wiki page list. |
+| 20:21:41 | `sessions_spawn` ×8 | 8 cross-linking subagents (gemini-flash) | — | — | Each gets ~14 zettels + full catalog; spawned simultaneously. |
+| 20:21:50 | `sessions_yield` | Wait for completions. | — | — | — |
+| 20:22:27–20:24:00 | `sessions_yield` ×7 | Progressive batch completions. | — | — | Batches complete: 1, 5, 3, 4, 2, 6, 7, then 8. |
+| 20:24:09 | `exec` | Count connected zettels | — | — | 117/117 confirmed with non-empty Connection sections. |
+| 20:24:14 | `exec` | Quality sample check | — | — | Verified connection context quality on random samples. |
+| 20:24:31 | `edit` | `LEDGER.md` (maintenance entry) | — | — | Recorded Phase 2 maintenance session + duplicate clusters. |
+| 20:24:42 | `message` | Completion report to Anton. | — | — | "Full maintenance pass complete. 117/117 cross-linked. 6 duplicate clusters flagged." |
+
+> **Note:** Every `read` call was a full-file read (100%). The agent never used `offset`/`limit` parameters for partial reads. "Lines Read" shows `returned / actual` — the +1 difference is the `read` tool counting a trailing newline as an extra line.
+
+---
+
+## 3. Content Ingestion Map
+
+### Main Session Content Reads
+
+| Order | Source File | Lines Read | Knowledge Extracted |
+| :--- | :--- | :--- | :--- |
+| 1 | `00-notes/2026-03-25-ai-media-deep-dive.md` | *390 / 389* | Core synthesis: thesis, company metrics, customer map, stickiness evidence, valuation baseline. |
+| 2 | `01-data/02-structured/08-key-metrics/aim_key_metrics.md` | 67 / 66 | ARR run-rate, gross margin trajectory, LEXI minute scaling, unit economics. |
+
+**Total main session content reads:** 457 lines / ~33 KB across 2 source documents.
+
+### Main Session Quality Audit Reads (post-extraction)
+
+| Order | File | Lines Read | Purpose |
+| :--- | :--- | :--- | :--- |
+| 3 | `wiki/zettels/202604211400.md` | 21 | Quality check: FCF inflection zettel |
+| 4 | `wiki/zettels/202604211613.md` | 19 | Quality check: practitioner lock-in zettel |
+| 5 | `wiki/zettels/202604211703.md` | 26 | Quality check: iCap toll bridge zettel |
+| 6 | `wiki/zettels/202604211635.md` | 22 | Quality check: ENCO competitor zettel |
+| 7 | `wiki/zettels/202604211411.md` | 22 | Cross-linking: infrastructure orchestration zettel |
+| 8 | `wiki/zettels/202604211452.md` | 22 | Cross-linking: encoder moat zettel |
+
+### Main Session Skill & Infrastructure Reads
+
+| File | Lines Read | % of File | Purpose |
+| :--- | :--- | :--- | :--- |
+| `SKILL.md` | 122 / 121 | 100% | Main skill instructions |
+| `references/ingest.md` | 137 / 136 | 100% | Ingest workflow conventions |
+| `references/schema.md` | 56 / 55 | 100% | Naming conventions |
+| `references/zettel-template.md` | 48 / 47 | 100% | Zettel template |
+| `references/page-template.md` | 38 / 37 | 100% | Page template |
+| `references/maintain.md` | 209 / 208 | 100% | Maintenance workflow |
+| `00-ai-media/INDEX.md` | 11 / 10 | 100% | Root folder mapping |
+| `01-data/02-structured/INDEX.md` | 19 / 18 | 100% | Structured data mapping |
+| `00-filings/INDEX.md` | 36 / 35 | 100% | Filings catalog |
+| `03-product-docs/INDEX.md` | 20 / 19 | 100% | Product docs catalog |
+| `04-customer-evidence/INDEX.md` | 17 / 16 | 100% | Customer evidence catalog |
+| `05-competitors/INDEX.md` | 16 / 15 | 100% | Competitors catalog |
+| `06-news/INDEX.md` | 16 / 15 | 100% | News catalog |
+| `00-notes/INDEX.md` | 22 / 21 | 100% | Notes catalog |
+| `02-research/INDEX.md` | 21 / 20 | 100% | Research catalog |
+
+**Total infrastructure reads:** 788 lines across 15 files.
+**Grand total main session reads:** ~1,377 lines across 23 `read` calls.
+
+### Subagent Extraction Reads
+
+| Subagent (Session ID) | Batch | Source Files Read | Key Sources |
+| :--- | :--- | :--- | :--- |
+| `d207e115` | Recent filings | 5 | 1HFY26 results, presentation, appendix 4D, FY25 announcement, investor pres |
+| `8ec22b7d` | FY25 H1/AGM | 4 | FY25 results, AGM address, 1H25 presentation, appendix 4G |
+| `673f8f1f` | FY24 filings | 3 | FY24 annual report, results presentation, 1HFY24 presentation |
+| `83767019` | FY21-23 filings | 2 | FY21 annual report, FY21 results presentation (**FAILED**) |
+| `a5181535` | Product docs | 10 | HD492 manual, LEXI DR manual, Falcon guide, gov solutions, all LEXI one-pagers |
+| `91c7d975` | Customers + metrics | 8 | Seven Network renewal, Reddit threads, PlayBox case study, Amagi case study, key metrics |
+| `8fd4b768` | Competitors | 6 | Verbit overview, 3Play encoder workflow, ENCO enCaption5, Evertz suite, SyncWords |
+| `9caa3384` | News + transcripts | 9 | Slator Google contract, LEXI 3.0 launch, UN languages, Strawman interview, IBC EAA |
+
+**Total unique source files read across all subagents:** 47
+**Combined with main session reads:** 62 unique source documents processed.
+
+---
+
+## 4. Wiki Output Map
+
+| Path | Description |
+| :--- | :--- |
+| `wiki/INDEX.md` | Master catalog of the wiki structure |
+| `wiki/LEDGER.md` | Permanent audit log (ingest session + maintenance session) |
+| `wiki/pages/INDEX.md` | Page catalog |
+| `wiki/pages/ai-media.md` | Company overview and thesis framing |
+| `wiki/pages/saas-transition.md` | Revenue mix shift, margin expansion, ARR, FCF inflection |
+| `wiki/pages/icap-network.md` | Delivery network, network effects, tolling, ~80% US market share |
+| `wiki/pages/hardware-control-point.md` | Encoders, SDI/IP transition, HaaS model |
+| `wiki/pages/lexi-suite.md` | Full LEXI product family (Live, Recorded, Voice, DR, AI, Brew) |
+| `wiki/pages/workflow-stickiness.md` | Switching costs evidence for and against |
+| `wiki/pages/competitive-landscape.md` | Cloud-native challengers, ENCO, Evertz, platform bundlers |
+| `wiki/pages/regulatory-tailwinds.md` | EAA, ADA Title II, ACMA, FCC mandates |
+| `wiki/pages/enterprise-government.md` | Buyer criteria, diversification beyond broadcast |
+| `wiki/zettels/INDEX.md` | Zettel catalog (117 entries) |
+| `wiki/zettels/20260421*.md` | 117 atomic knowledge notes |
+
+**Total files created:** 130 (117 zettels + 9 wiki pages + 4 infrastructure files).
+
+### Zettel Distribution by Source Category
+
+| Source Category | Files Read | Zettels | Zettel Range | Subagent |
+| :--- | :--- | :--- | :--- | :--- |
+| Recent filings (1HFY26, FY25 latest) | 5 | 12 | `202604211400`–`202604211411` | `d207e115` |
+| FY25 H1/AGM filings | 4 | 12 | `202604211425`–`202604211436` | `8ec22b7d` |
+| FY24 filings | 3 | 25 | `202604211450`–`202604211514` | `673f8f1f` |
+| FY21-23 filings | 2 | **0** ✗ | — | `83767019` |
+| Product documentation | 10 | 25 | `202604211545`–`202604211609` | `a5181535` |
+| Customer evidence + metrics | 8 | 20 | `202604211610`–`202604211629` | `91c7d975` |
+| Competitors | 6 | 8 | `202604211635`–`202604211642` | `8fd4b768` |
+| News + transcripts | 9 | 15 | `202604211655`–`202604211709` | `9caa3384` |
+| **Total** | **47** | **117** | | |
+
+---
+
+## 5. Think Steps
+
+### Step 1: Task Strategy (17:48:49 UTC)
+> "Anton wants me to use the zettel-wiki skill to process the 00-ai-media folder's contents. But instead of using the default wiki root at `hard-disk/wiki/`, he wants me to create the wiki in `00-ai-media/wiki/` (a separate wiki page within the same company folder). He also says to not read folders outside 00-ai-media.
+>
+> Let me plan the approach:
+> 1. I need to read the skill's reference files (ingest.md, schema.md, templates) to understand the exact format
+> 2. Survey all the source material in 00-ai-media
+> 3. Create the wiki structure at `00-ai-media/wiki/` with pages/ and zettels/ subdirectories
+> 4. Process the raw sources into zettels and wiki pages
+>
+> This is a big job with ~173 text files. Let me read the ingest workflow reference, then plan how to tackle this efficiently. Given the volume, I'll likely need to use parallel subagents for extraction."
+
+### Step 2: Architecture Planning (17:49:12 UTC)
+> "Now I have a clear picture. Let me plan the approach:
+> 1. The wiki root for this test will be `00-ai-media/wiki/` instead of the default `hard-disk/wiki/`
+> 2. I need to create the wiki structure: `wiki/`, `wiki/pages/`, `wiki/zettels/`, `wiki/INDEX.md`, `wiki/LEDGER.md`
+> 3. I should not read outside `00-ai-media/`
+>
+> The source material is organized across:
+> - `01-data/02-structured/00-filings/` — company filings (results, presentations, annual reports)
+> - `01-data/02-structured/02-transcripts/` — earnings transcripts
+> - `01-data/02-structured/03-product-docs/` — product documentation
+> - `01-data/02-structured/04-customer-evidence/` — customer case studies and evidence
+> - `01-data/02-structured/05-competitors/` — competitive landscape
+> - `01-data/02-structured/06-news/` — news articles
+> - `01-data/02-structured/08-key-metrics/` — key metrics and data
+> - `01-data/02-structured/10-valuation/` — valuation data
+> - `00-notes/` — working notes and writeups
+> - `02-research/` — research workspaces
+>
+> With 173 text files, this is a lot of material. The skill says 'prefer raw evidence over synthesized notes.' So primary sources should be filings, transcripts, product docs, customer evidence, competitors, and news. The notes and research folders are secondary.
+>
+> Given the volume, I should use parallel subagents for extraction."
+
+### Step 3: Extraction Strategy (17:50:04 UTC)
+> "Now I have a clear picture. Let me plan the extraction strategy.
+>
+> The material breaks into these categories:
+> - `01-data/02-structured/00-filings/` — 26 files
+> - `01-data/02-structured/03-product-docs/` — 10 files
+> - `01-data/02-structured/04-customer-evidence/` — 7 files
+> - `01-data/02-structured/05-competitors/` — 6 files
+> - `01-data/02-structured/06-news/` — 6 files
+> - `01-data/02-structured/02-transcripts/` — ? files
+> - `01-data/02-structured/08-key-metrics/` — metrics tables
+>
+> Plan: Set up wiki structure, read the deep dive for orientation, then spawn subagents in batches across source categories. Each subagent writes zettels directly; I handle INDEX updates, wiki pages, and cross-linking after."
+
+### Step 4: Wiki Page Architecture (17:50:46 UTC)
+> "Key themes for wiki pages:
+> 1. ai-media-overview.md — Company overview, business model, revenue mix
+> 2. lexi-product-suite.md — LEXI product family
+> 3. icap-network.md — iCap delivery network, network effects
+> 4. hardware-encoders.md — Hardware control point, EEG encoders
+> 5. workflow-stickiness.md — Switching costs, workflow integration
+> 6. competitive-landscape.md — Competitors and positioning
+> 7. customer-base.md — Named customers, concentration, segments
+> 8. enterprise-government.md — Enterprise and government market
+> 9. financial-performance.md — Revenue growth, margin expansion
+> 10. valuation.md — Valuation framework
+> 11. cloud-transition-risk.md — Cloud vs hardware competition
+> 12. regulatory-tailwinds.md — ACMA, FCC, EAA mandates
+>
+> For subagent batching: each subagent reads its assigned files, creates zettel files in `wiki/zettels/`, returns a summary. Timestamp allocation per batch to avoid collisions."
+
+### Step 5: Subagent Batch Design (17:51:48 UTC)
+> "I'll create 8 subagents, each with a clear batch of files and timestamp range:
+>
+> 1. Recent filings (1HFY26 + FY25 latest) — 5 files, ts 202604211400-202604211424
+> 2. FY25 H1 + AGM — 5 files, ts 202604211425-202604211449
+> 3. FY24 filings — 7 files, ts 202604211450-202604211514
+> 4. FY21-23 filings — 9 files, ts 202604211515-202604211544
+> 5. Product docs — 10 files, ts 202604211545-202604211609
+> 6. Customer evidence + key metrics — 8 files, ts 202604211610-202604211634
+> 7. Competitors — 6 files, ts 202604211635-202604211654
+> 8. News + unique transcripts — 9 files, ts 202604211655-202604211719
+>
+> Model choice: gemini-flash for subagents (extraction-heavy, cost-efficient). Main session handles synthesis."
+
+### Step 6: Mid-Extraction Triage (17:53:52 UTC)
+> "Batch 4 (FY21-23 filings) completed, but the result looks like it just dumped the raw text of the FY21 presentation rather than creating zettels. Let me check if the subagent actually wrote zettel files to disk. I should NOT send an update yet — I need to wait for all 8 subagents and then consolidate."
+
+### Step 7: Progress Assessment (17:54:04 UTC)
+> "Only 4 zettel files have been written so far, and batch 4 (FY21-23) appears to have just dumped raw text instead of creating zettels. The batch 4 completion event shows it ran for only 9 seconds and consumed 90K tokens mostly on input — it seems like it read the files but didn't create zettels. Let me wait for more completions."
+
+### Step 8: Post-Extraction Consolidation (17:56:50 UTC)
+> "All 8 batches done. I have 117 zettels on disk:
+> - Batch 1 (recent filings): 12 zettels ✓
+> - Batch 2 (FY25 H1/AGM): 12 zettels ✓
+> - Batch 3 (FY24): 25 zettels ✓
+> - Batch 4 (FY21-23): 0 zettels ✗ (failed — returned raw text)
+> - Batch 5 (product docs): 25 zettels ✓
+> - Batch 6 (customers + metrics): 20 zettels ✓
+> - Batch 7 (competitors): 8 zettels ✓
+> - Batch 8 (news + transcripts): 15 zettels ✓
+>
+> Total: 117 zettels. Solid base even without batch 4."
+
+### Step 9: Page Synthesis Planning (17:57:28 UTC)
+> "I have 117 zettels with good quality. Now I need to create wiki pages. The main themes I see from scanning all zettel titles:
+> 1. SaaS transition / financial performance — 21 zettels
+> 2. iCap network — 12 zettels
+> 3. Hardware & encoders — 11 zettels
+> 4. LEXI product suite — 39 zettels (largest cluster)
+> 5. Competitive landscape — 8 zettels
+> 6. Workflow stickiness — 12 zettels
+> 7. Regulatory environment — 9 zettels
+> 8. Enterprise & government — 11 zettels
+>
+> Consolidated to 9 pages. Each should be 200-400 words with inline zettel links as coherent narratives."
+
+### Step 10: Maintenance Strategy (20:18:56 UTC)
+> "The maintenance pass has two phases:
+> 1. Correctness — fix orphans (111 of 117 still unlinked), detect duplicates, check links/INDEX consistency
+> 2. Evolution — oversized pages, zettel clusters without pages, missing cross-domain connections
+>
+> The big task is cross-linking 111 zettels. Plan: build a master zettel summary, then spawn 8 subagents each handling ~14 zettels, giving each the full catalog to find connections."
+
+### Step 11: Duplicate Detection (20:19:37 UTC)
+> "Duplicate/near-duplicate clusters identified:
+> 1. EAA Regulatory Tailwinds (3 zettels): 202604211405, 202604211433, 202604211700
+> 2. R&D Accounting (2 zettels): 202604211410, 202604211431
+> 3. AI Quality vs Human (3 zettels): 202604211435, 202604211454, 202604211618
+> 4. Revenue Transition (2 zettels): 202604211425, 202604211450
+> 5. Board Renewal (2 zettels): 202604211430, 202604211514
+> 6. Gross Margin (3 zettels): 202604211451, 202604211626, 202604211702
+>
+> Pragmatic decision: flag rather than merge. Cross-link them so they're navigable. Report to Anton for judgment."
+
+---
+
+## 6. Cost & Token Summary
+
+### Per-Turn Token Table (Main Session)
+
+| Turn | Input Tokens | Output Tokens | Cache Read | Cache Write |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | 3 | 158 | 0 | 24,450 |
+| 2 | 1 | 283 | 24,450 | 6,248 |
+| 3 | 1 | 153 | 30,698 | 571 |
+| 4 | 1 | 300 | 31,269 | 2,130 |
+| 5 | 1 | 120 | 33,399 | 326 |
+| 6 | 1 | 125 | 33,725 | 2,238 |
+| 7 | 1 | 785 | 35,963 | 1,188 |
+| 8 | 1 | 204 | 37,151 | 811 |
+| 9 | 1 | 517 | 37,962 | 266 |
+| 10 | 1 | 351 | 38,228 | 4,111 |
+| 11 | 1 | 1,520 | 42,339 | 6,094 |
+| 12 | 1 | 189 | 48,433 | 1,546 |
+| 13 | 1 | 131 | 49,979 | 1,006 |
+| 14 | 1 | 1,690 | 50,985 | 7,991 |
+| 15 | 1 | 615 | 58,976 | 1,716 |
+| 16 | 1 | 120 | 60,692 | 900 |
+| 17 | 1 | 2,905 | 61,592 | 2,584 |
+| 18 | 1 | 9,307 | 64,176 | 2,931 |
+| 19 | 1 | 287 | 67,107 | 11,019 |
+| 20 | 3 | 187 | 0 | 84,157 |
+| 21 | 1 | 94 | 84,157 | 214 |
+| 22 | 1 | 283 | 84,371 | 317 |
+| 23 | 1 | 141 | 84,688 | 309 |
+| 24 | 3 | 127 | 23,233 | 63,161 |
+| 25 | 3 | 125 | 23,233 | 64,592 |
+| 26 | 3 | 124 | 23,233 | 66,228 |
+| 27 | 3 | 122 | 23,233 | 67,913 |
+| 28 | 3 | 120 | 23,233 | 69,910 |
+| 29 | 3 | 111 | 23,233 | 71,902 |
+| 30 | 3 | 212 | 23,233 | 74,099 |
+| 31 | 1 | 892 | 97,332 | 5,420 |
+| 32 | 1 | 364 | 102,752 | 918 |
+| 33 | 1 | 195 | 103,670 | 2,127 |
+| 34 | 1 | 1,543 | 105,797 | 3,775 |
+| 35 | 1 | 2,527 | 109,572 | 1,569 |
+| 36 | 1 | 3,014 | 111,141 | 2,755 |
+| 37 | 1 | 2,413 | 113,896 | 3,245 |
+| 38 | 1 | 507 | 117,141 | 2,641 |
+| 39 | 1 | 305 | 119,782 | 565 |
+| 40 | 1 | 375 | 120,347 | 319 |
+| 41 | 1 | 555 | 120,666 | 430 |
+| 42 | 1 | 202 | 121,096 | 613 |
+| 43 | 1 | 378 | 121,709 | 1,251 |
+| 44 | 1 | 377 | 122,960 | 474 |
+| 45 | 1 | 385 | 123,434 | 477 |
+| 46 | 1 | 368 | 123,911 | 450 |
+| 47 | 1 | 316 | 124,361 | 433 |
+| 48 | 1 | 379 | 124,794 | 381 |
+| 49 | 1 | 457 | 125,175 | 444 |
+| 50 | 1 | 426 | 125,619 | 516 |
+| 51 | 1 | 249 | 126,135 | 640 |
+| 52 | 1 | 686 | 126,775 | 356 |
+| 53 | 0 | 0 | 0 | 0 |
+| 54 | 1 | 7 | 127,131 | 748 |
+| 55 | 3 | 79 | 0 | 128,655 |
+| 56 | 1 | 1,333 | 128,655 | 1,951 |
+| 57 | 1 | 237 | 130,606 | 1,359 |
+| 58 | 1 | 194 | 131,965 | 299 |
+| 59 | 1 | 1,529 | 132,264 | 4,646 |
+| 60 | 1 | 245 | 136,910 | 1,555 |
+| 61 | 1 | 271 | 138,465 | 4,463 |
+| 62 | 1 | 2,071 | 142,928 | 284 |
+| 63 | 1 | 8,107 | 143,212 | 2,104 |
+| 64 | 1 | 117 | 145,316 | 9,821 |
+| 65 | 3 | 99 | 0 | 155,820 |
+| 66 | 3 | 119 | 23,233 | 133,568 |
+| 67 | 3 | 115 | 23,233 | 134,501 |
+| 68 | 3 | 103 | 23,233 | 135,625 |
+| 69 | 3 | 97 | 23,233 | 136,570 |
+| 70 | 3 | 102 | 23,233 | 137,427 |
+| 71 | 3 | 96 | 23,233 | 138,422 |
+| 72 | 3 | 262 | 23,233 | 139,480 |
+| 73 | 1 | 262 | 162,713 | 295 |
+| 74 | 1 | 691 | 163,008 | 881 |
+| 75 | 1 | 555 | 163,889 | 791 |
+| 76 | 0 | 0 | 0 | 0 |
+| 77 | 1 | 7 | 164,680 | 617 |
+| **Total** | **130** | **60,371** | **8,793,511** | **2,127,949** |
+
+### Subagent Token Usage
+
+| Session ID | Batch | Input Tokens | Output Tokens | Cache Read | Total Tokens |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `d207e115` | Recent filings | 210,171 | 11,021 | 840,585 | 1,061,777 |
+| `8ec22b7d` | FY25 H1/AGM | 114,969 | 10,267 | 90,383 | 215,619 |
+| `673f8f1f` | FY24 filings | 421,193 | 18,127 | 2,667,083 | 3,106,403 |
+| `83767019` | FY21-23 (**FAIL**) | 88,528 | 1,436 | 16,407 | 106,371 |
+| `a5181535` | Product docs | 311,896 | 19,195 | 1,768,233 | 2,099,324 |
+| `91c7d975` | Customers + metrics | 207,520 | 14,814 | 764,427 | 986,761 |
+| `8fd4b768` | Competitors | 119,760 | 7,822 | 313,770 | 441,352 |
+| `9caa3384` | News + transcripts | 257,718 | 14,053 | 997,903 | 1,269,674 |
+| `acc3c90b` | Maintain batch 1 | 47,608 | 5,697 | 48,760 | 102,065 |
+| `f46b9aa1` | Maintain batch 2 | 150,253 | 9,049 | 603,662 | 762,964 |
+| `904a4d58` | Maintain batch 3 | 151,844 | 8,800 | 489,086 | 649,730 |
+| `5282eb8f` | Maintain batch 4 | 94,001 | 8,698 | 522,758 | 625,457 |
+| `9c905e2c` | Maintain batch 5 | 138,546 | 8,775 | 474,947 | 622,268 |
+| `e35c1c2e` | Maintain batch 6 | 158,327 | 10,768 | 534,224 | 703,319 |
+| `d323660d` | Maintain batch 7 | 153,759 | 10,224 | 602,454 | 766,437 |
+| `ce9764c9` | Maintain batch 8 | 200,163 | 13,081 | 1,030,986 | 1,244,230 |
+| **Subtotal** | | **2,826,256** | **171,827** | **11,765,668** | **14,763,751** |
+
+### Grand Totals
+
+| Metric | Main Session (Opus) | 16 Subagents (Flash) | Grand Total |
+| :--- | :--- | :--- | :--- |
+| Input tokens | 130 | 2,826,256 | 2,826,386 |
+| Output tokens | 60,371 | 171,827 | 232,198 |
+| Cache read | 8,793,511 | 11,765,668 | 20,559,179 |
+| Cache write | 2,127,949 | 0 | 2,127,949 |
+| **Total tokens** | **10,981,961** | **14,763,751** | **25,745,712** |
+
+---
+
+## 7. Subagent Usage
+
+### 7.1 Extraction Subagents (Phase 1)
+
+| Session ID | Label | Duration | Tool Calls | Files Read | Zettels Written | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `d207e115` | recent-filings | 1m 29s | 17 | 5 | 12 | ✅ |
+| `8ec22b7d` | fy25-h1-agm | 58s | 16 | 4 | 12 | ✅ |
+| `673f8f1f` | fy24-filings | 2m 31s | 28 | 3 | 25 | ✅ |
+| `83767019` | fy21-23-filings | 9s | 2 | 2 | 0 | ❌ |
+| `a5181535` | product-docs | 2m 48s | 35 | 10 | 25 | ✅ |
+| `91c7d975` | customers-metrics | 2m 5s | 28 | 8 | 20 | ✅ |
+| `8fd4b768` | competitors | 1m 16s | 14 | 6 | 8 | ✅ |
+| `9caa3384` | news-transcripts | 1m 56s | 24 | 9 | 15 | ✅ |
+| **Total** | | | **164** | **47** | **117** | **7/8** |
+
+### 7.2 Batch 4 Failure Analysis
+
+**Subagent `83767019` (FY21-23 filings)** was tasked with processing 9 historical filings but failed after 9 seconds:
+
+- **Symptoms:** Read 2 files (FY21 annual report + FY21 results presentation), consumed 88K input tokens, produced only 1,436 output tokens. No zettel files written. Final assistant turn was empty.
+- **Root cause:** The first two files were exceptionally large (one truncated at 147K characters). After reading ~210KB of text into the context window, the model likely hit a context limit or timeout during its thinking phase. The 9-second runtime confirms it never reached the extraction stage.
+- **Impact:** 9 source files unprocessed (FY21-FY23 era). The gap covers the pre-AI-transition period.
+- **Mitigation:** Not retried — the orchestrator detected the failure at 17:53:52 and made a pragmatic decision to proceed with 117 zettels from 7 successful batches.
+
+### 7.3 Cross-Linking Subagents (Phase 2)
+
+| Session ID | Label | Duration | Zettels Edited | Edits | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `acc3c90b` | maintain-batch-1 | 30s | 14 | 14 | ✅ |
+| `f46b9aa1` | maintain-batch-2 | 1m 16s | 14 | 14 | ✅ |
+| `904a4d58` | maintain-batch-3 | 1m 7s | 14 | 14 | ✅ |
+| `5282eb8f` | maintain-batch-4 | 1m 8s | 14 | 14 | ✅ |
+| `9c905e2c` | maintain-batch-5 | 1m 6s | 14 | 14 | ✅ |
+| `e35c1c2e` | maintain-batch-6 | 1m 19s | 14 | 14 | ✅ |
+| `d323660d` | maintain-batch-7 | 1m 16s | 13 | 13 | ✅ |
+| `ce9764c9` | maintain-batch-8 | 1m 49s | 14 | 14 | ✅ |
+| **Total** | | | **111** | **111** | **8/8** |
+
+**Cross-linking pattern:** Each subagent received the full 117-zettel catalog (ID + title + tags) plus the wiki page list as shared context, then read and edited its assigned batch of ~14 zettels. Two subagents (`acc3c90b`, `ce9764c9`) used `read` before `edit` (14 reads + 14 edits); the others used `edit` directly with `exec` for verification.
+
+---
+
+## 8. Observations
+
+### 8.1 Orchestration Pattern: Opus Conductor + Flash Orchestra
+The v2 run proved the orchestrator pattern at scale. Opus handled all strategic decisions (surveying, planning, page synthesis, quality audit, cross-link demo, duplicate detection), while Flash workers did the mechanical extraction and bulk cross-linking. The separation was clean — no cases where Flash was asked to make editorial judgments it couldn't handle, and no cases where Opus was bogged down with rote file-by-file extraction.
+
+### 8.2 Scale vs. v1: 15× Source Files in the Same Wall Time
+v1 processed 4 synthesized notes in 13m35s. v2 processed 62 raw evidence files in ~14 minutes (ingest) + 6 minutes (maintenance) = 20 minutes total. The parallel subagent architecture delivered a near-linear scaling improvement for extraction work.
+
+### 8.3 Token Economics: Flash Subagents Dominate Cost
+The 16 Flash subagents consumed 14.8M tokens vs. the Opus main session's 11.0M. But Flash tokens are ~10–20× cheaper per token than Opus. The actual cost split likely favors the orchestrated approach: most of the Opus tokens were cache reads (8.8M), not billable input/output.
+
+### 8.4 Cache Behavior: Session Resume Spikes
+The main session showed large cache write bursts on session resume (84K, 128K, 155K–166K tokens at turns 20, 55, 65). These correspond to OpenClaw reconstructing the session context after subagent completion events wake the main session. Subagents showed zero cache writes — one-shot sessions with no context persistence.
+
+### 8.5 Failure Handling: Pragmatic but No Retry
+Batch 4's failure was detected within ~20 seconds (think step at 17:53:52), but the orchestrator chose to proceed rather than retry. The 9-file gap was documented in the LEDGER and reported to the user. A production-grade orchestrator should include automatic retry with smaller batch sizes or per-file fallback for oversized documents.
+
+### 8.6 Cross-Linking Cost: O(catalog × batch)
+Each cross-linking subagent needed the full 117-zettel catalog in context (~3K tokens) plus its batch of ~14 zettels to read in full. This creates a base context cost that scales with catalog size. The shared catalog file was a good optimization, but for wikis with 500+ zettels, the cross-linking cost could become the dominant expense.
+
+### 8.7 Think Step Discipline: 13 Decision Points
+The orchestrator used `think` at every fork: task interpretation (2), batch planning (3), failure triage (2), post-extraction assessment (2), page synthesis (1), maintenance strategy (1), duplicate detection (1). This is 3.25× the v1's 4 think steps — proportional to the increased architectural complexity.
+
+### 8.8 Wiki Page Quality: Opus Synthesis Advantage
+All 9 wiki pages were written by the Opus orchestrator in turns 35–37 (~8K output tokens, ~4 minutes). The pages are coherent narratives with inline zettel links — not bullet-point summaries. This editorial synthesis is where Opus earns its cost: Flash subagents could not have produced the same narrative quality from 117 scattered zettels.
+
+### 8.9 Duplicate Clusters: Expected Artifact of Multi-Source Extraction
+Six duplicate clusters were identified — all caused by the same topic appearing in filings from different years (e.g., EAA regulation mentioned in FY25, 1HFY26, and IBC news). This is an expected artifact when extracting from chronological filings that repeat key themes. The orchestrator's decision to cross-link rather than merge was appropriate: the duplicates carry different temporal context (what the company said about EAA in FY24 vs. FY26).
+
+### 8.10 v1 → v2 Architecture Evolution
+
+| Aspect | v1 | v2 | Implication |
+| :--- | :--- | :--- | :--- |
+| Agent model | Single Opus | Opus + Flash | Cost/quality separation |
+| Source material | 4 synthesized notes | 62 raw files | Primary evidence, not secondary |
+| Subagents | 0 | 16 | Parallel throughput |
+| Zettels | 30 | 117 | 3.9× knowledge density |
+| Cross-links | Manual (single pass) | Automated (subagent pass) | Scalable maintenance |
+| Think steps | 4 | 13 | More decision complexity |
+| Total tokens | ~1.3M | ~25.7M | 19.8× (but mostly Flash) |
+| Wall time | 13m 35s | ~20m | Only 1.5× longer for 15× more work |

--- a/docs/analysis/02-zettel-wiki-v3-trace-analysis.md
+++ b/docs/analysis/02-zettel-wiki-v3-trace-analysis.md
@@ -1,0 +1,409 @@
+# Trace Analysis: AI-Media Zettel-Wiki v3 Construction
+
+**Date:** 2026-04-23
+**Session ID (main):** `5228c9c7-76ab-4ab9-b3b3-125f0dbaabb6`
+**Thread:** Slack `#all-minerva` — ":thread: Test Zettel-Wiki v3 - Charlie"
+
+---
+
+## 1. Session Overview
+
+- **Agent:** Charlie (agent ID: `main`)
+- **Start Time:** 2026-04-23 05:26:07 UTC (01:26 EDT)
+- **End Time:** 2026-04-23 05:36:57 UTC (01:36 EDT)
+- **Total Wall Time:** 10 minutes 50 seconds
+- **Model (main):** `anthropic/claude-opus-4-6`
+- **Model (subagents):** `google/gemini-3-flash-preview` (gemini-flash)
+- **Main Session Turns:** 61 assistant turns
+- **Main Session Tool Calls:** 67
+- **Subagent Sessions:** 15 (8 extraction + 7 structure notes)
+- **Total Tool Calls (all sessions):** ~328
+- **User Messages:** 1 (initial ingest request) + 14 subagent completion events
+- **Slack Updates Sent:** 2 (progress + completion)
+
+---
+
+## 2. Execution Timeline
+
+| Timestamp (UTC) | Tool | Key Parameters / Input | Outcome / Reasoning Summary |
+| :--- | :--- | :--- | :--- |
+| 05:26:11 | `read` | `~/.openclaw/skills/zettel-wiki/SKILL.md` | Skill discovery and rule verification. |
+| 05:26:11 | `exec` | `find ... -maxdepth 1` | Initial folder survey of 00-ai-media. |
+| 05:26:15 | `exec` | `find ... -type f -name '*.md'` | Full file listing of source corpus. |
+| 05:26:15 | `read` | `references/ingest.md` | Loaded ingest workflow conventions. |
+| 05:26:30 | `think` | Task strategy and source categorization. | Decided: raw evidence only from `01-data/02-structured/`. Skip `00-notes/` and `02-research/`. Plan 8 parallel subagents by source category. |
+| 05:26:35 | `read` ×4 | `zettel-template.md`, `page-template.md`, `schema.md`, `audit.md` | Loaded all skill reference files in parallel. |
+| 05:26:53 | `think` | Architecture and batching plan. | Designed 8 extraction batches with non-overlapping timestamp namespaces. Chose gemini-flash for subagents. |
+| 05:27:00 | `message` | Slack update to Anton. | "On it. Setting up a Zettel-Wiki at `00-ai-media/wiki/`…" |
+| 05:27:04 | `exec` | `mkdir -p wiki/{pages,zettels}` | Created wiki directory structure. |
+| 05:27:11 | `write` ×4 | `INDEX.md`, `LEDGER.md`, `pages/INDEX.md`, `zettels/INDEX.md` | Initialized wiki infrastructure files. |
+| 05:27:18 | `exec` | `ls` of all source category folders | Verified exact file counts and paths for batch assignment. |
+| 05:27:33 | `think` | Subagent batch design. | Finalized 8 batch assignments with file lists and timestamp ranges. |
+| 05:27:52 | `sessions_spawn` | `zettel-filings-early` (gemini-flash) | Batch 1: FY21–FY23 filings. Namespace 0200. |
+| 05:28:01 | `sessions_spawn` | `zettel-filings-mid` (gemini-flash) | Batch 2: 1H FY24 + FY24 filings. Namespace 0300. |
+| 05:28:12 | `sessions_spawn` | `zettel-filings-recent` (gemini-flash) | Batch 3: 1H FY25 + FY25 + 1H FY26. Namespace 0400. |
+| 05:28:24 | `sessions_spawn` | `zettel-transcripts` (gemini-flash) | Batch 4: All transcripts. Namespace 0500. |
+| 05:28:36 | `sessions_spawn` | `zettel-product-docs` (gemini-flash) | Batch 5: All product documentation. Namespace 0600. |
+| 05:28:48 | `sessions_spawn` | `zettel-customers` (gemini-flash) | Batch 6: Customer evidence + key metrics. Namespace 0700. |
+| 05:28:59 | `sessions_spawn` | `zettel-competitors` (gemini-flash) | Batch 7: Competitor analyses. Namespace 0800. |
+| 05:29:13 | `sessions_spawn` | `zettel-news-metrics` (gemini-flash) | Batch 8: News + key metrics + valuation. Namespace 0900. |
+| 05:29:18 | `sessions_yield` | Wait for completions. | Paused main session for parallel extraction. |
+| 05:29:26–05:31:44 | `sessions_yield` ×7 | Progressive completions. | Batches completed in order: filings-early, filings-mid, filings-recent, competitors, customers, product-docs, news-metrics, then transcripts. |
+| 05:31:44 | `exec` | `ls wiki/zettels \| wc -l` | Verified 109 zettels on disk. |
+| 05:31:47 | `exec` | Full zettel listing | Confirmed all files present and sorted. |
+| 05:32:01 | `think` | Post-extraction consolidation. | All 8 batches done, 0 failures. Planned 7 structure notes from zettel clusters. |
+| 05:32:05 | `exec` | Build zettel catalog (IDs + titles + tags) | Extracted frontmatter from all 109 zettels for cluster analysis. |
+| 05:32:41 | `think` | Structure note clustering and page design. | Identified 7 thematic clusters. Mapped specific zettel IDs to each cluster. Decided to use subagents for page writing + zettel backlink updates. |
+| 05:33:01 | `sessions_spawn` | `page-competitive-moat` (gemini-flash) | Structure note 1: Competitive Moat & Vertical Integration. |
+| 05:33:17 | `sessions_spawn` | `page-lexi-product` (gemini-flash) | Structure note 2: LEXI Product Suite & AI Technology. |
+| 05:33:28 | `sessions_spawn` | `page-business-model` (gemini-flash) | Structure note 3: Business Model Transformation. |
+| 05:33:38 | `sessions_spawn` | `page-financials` (gemini-flash) | Structure note 4: Financial Performance & Valuation. |
+| 05:33:50 | `sessions_spawn` | `page-global-expansion` (gemini-flash) | Structure note 5: Global Expansion & Go-to-Market. |
+| 05:34:00 | `sessions_spawn` | `page-customers` (gemini-flash) | Structure note 6: Customer & Market Evidence. |
+| 05:34:11 | `sessions_spawn` | `page-competitive-landscape` (gemini-flash) | Structure note 7: Competitive Landscape. |
+| 05:34:15 | `sessions_yield` | Wait for completions. | Paused main session for structure note writing. |
+| 05:34:25–05:35:20 | `sessions_yield` ×6 | Progressive completions. | All 7 pages completed within ~60 seconds of each other. |
+| 05:35:26 | `exec` | `ls wiki/pages/*.md` | Verified all 7 pages + INDEX present. |
+| 05:35:32 | `exec` | Build zettel INDEX from frontmatter | Generated full zettel catalog table. |
+| 05:35:42 | `exec` | Write zettel INDEX content | Wrote 109-row catalog to `zettels/INDEX.md`. |
+| 05:35:51 | `write` | `pages/INDEX.md` | Updated page directory with all 7 structure notes. |
+| 05:35:58 | `write` | `wiki/INDEX.md` | Updated master wiki index with final counts. |
+| 05:36:09 | `write` | `wiki/LEDGER.md` | Wrote construction session audit log. |
+| 05:36:14 | `exec` | Orphan audit (`grep` for missing Related sections) | Found 1 orphan: board governance zettel (202604230526). |
+| 05:36:18 | `read` | `zettels/202604230526.md` | Read orphan zettel to determine correct links. |
+| 05:36:23 | `edit` | `zettels/202604230526.md` | Fixed orphan: added Related links to competitive-moat and customer-evidence pages. |
+| 05:36:27 | `read` | `pages/competitive-moat.md` (limit 40) | Quality spot-check of structure note. |
+| 05:36:30 | `read` | `pages/financial-performance.md` (limit 30) | Quality spot-check of structure note. |
+| 05:36:33 | `read` | `00-ai-media/INDEX.md` | Read parent folder index for update. |
+| 05:36:39 | `edit` | `00-ai-media/INDEX.md` | Updated parent folder reference from v2 to v3 stats. |
+| 05:36:54 | `message` | Completion report to Anton. | "Done. Wiki built at `00-ai-media/wiki/`. 109 zettels, 7 structure notes…" |
+
+---
+
+## 3. Content Ingestion Map
+
+### Main Session Content Reads
+
+The main session read zero raw evidence files for extraction — all extraction was delegated to subagents. The main session read only:
+
+| File | Lines Read | Purpose |
+| :--- | :--- | :--- |
+| `SKILL.md` | 122 | Skill instructions |
+| `references/ingest.md` | 137 | Ingest workflow |
+| `references/zettel-template.md` | 48 | Zettel template |
+| `references/page-template.md` | 38 | Page template |
+| `references/schema.md` | 56 | Naming conventions |
+| `references/audit.md` | — | Audit workflow |
+| `zettels/202604230526.md` | ~25 | Orphan zettel audit |
+| `pages/competitive-moat.md` | 40 | Quality spot-check |
+| `pages/financial-performance.md` | 30 | Quality spot-check |
+| `00-ai-media/INDEX.md` | ~12 | Parent index update |
+
+**Total main session reads:** 10 `read` calls, all infrastructure/audit.
+
+### Subagent Extraction Reads
+
+| Subagent | Label | Source Files Read | Key Sources |
+| :--- | :--- | :--- | :--- |
+| `015cdda3` | filings-early | 6 | FY21 annual report, FY21 results, FY22 results pres, FY23 results, FY23 annual report |
+| `260fb7b2` | filings-mid | 4 | 1H FY24 results, 1H FY24 pres, FY24 results pres, FY24 results |
+| `56f243aa` | filings-recent | 6 | 1H25 pres, half-yearly report, FY25 results, 1H FY26 results, AGM address, appendix 4G |
+| `cde2dd3a` | transcripts | 7 | ASX small-mid cap conf (2021), FY22 investor pres, AI captioning webinar, Strawman H1 interview, AGM webcast, AGM address, AGM recording |
+| `01fc48bb` | product-docs | 10 | HD492 manual, LEXI DR manual, Falcon guide, gov solutions, LEXI AI/Brew/Cloud/Quick Facts/Recorded/Voice one-pagers |
+| `4db5bf8f` | customers | 7 | Seven Network renewal, Reddit threads (×3), PlayBox case study, ACMA breach report, Amagi case study |
+| `955dca40` | competitors | 0 (via task) | Verbit overview, 3Play encoder, ENCO enCaption5, Evertz suite, SyncWords, Verbit gov (source text embedded in task prompt) |
+| `28a0721b` | news-metrics | 0 (via task) | Slator Google contract, LEXI 3.0 launch, UN languages, LEXI Recorded launch, Strawman interview, IBC EAA (source text embedded in task prompt) |
+
+**Total unique source files read across all subagents:** ~40 files + task-embedded text for 2 batches.
+
+---
+
+## 4. Wiki Output Map
+
+| Path | Description |
+| :--- | :--- |
+| `wiki/INDEX.md` | Master catalog of the wiki structure |
+| `wiki/LEDGER.md` | Permanent audit log (construction session) |
+| `wiki/pages/INDEX.md` | Page catalog |
+| `wiki/pages/competitive-moat.md` | Competitive Moat & Vertical Integration — iCap, hardware control, switching costs, data flywheel |
+| `wiki/pages/lexi-product-suite.md` | LEXI Product Suite — LEXI 3.0/DR/Voice/Recorded/AI/Vision, Alta, technology features |
+| `wiki/pages/business-model-transformation.md` | Business Model Transformation — SaaS pivot, margins, HaaS, strategic cannibalization |
+| `wiki/pages/financial-performance.md` | Financial Performance & Valuation — ARR growth, EBITDA, margin expansion, DCF |
+| `wiki/pages/global-expansion.md` | Global Expansion & Go-to-Market — geographic growth, indirect sales, EAA/ADA catalysts |
+| `wiki/pages/customer-evidence.md` | Customer & Market Evidence — Seven Network, Google, UK Parliament, sports league wins |
+| `wiki/pages/competitive-landscape.md` | Competitive Landscape — Verbit, ENCO, Evertz, SyncWords, virtual encoding threats |
+| `wiki/zettels/INDEX.md` | Zettel catalog (109 entries) |
+| `wiki/zettels/20260423*.md` | 109 atomic knowledge notes |
+
+**Total files created:** 120 (109 zettels + 7 wiki pages + 4 infrastructure files).
+
+### Zettel Distribution by Source Category
+
+| Source Category | Files Read | Zettels | Namespace | Subagent |
+| :--- | :--- | :--- | :--- | :--- |
+| FY21–FY23 filings | 6 | 10 | `202604230200` | `015cdda3` |
+| 1H FY24 + FY24 filings | 4 | 10 | `202604230300` | `260fb7b2` |
+| 1H FY25 + FY25 + 1H FY26 filings | 6 | 10 | `202604230400` | `56f243aa` |
+| Transcripts | 7 | 32 | `202604230500` | `cde2dd3a` |
+| Product documentation | 10 | 14 | `202604230600` | `01fc48bb` |
+| Customer evidence | 7 | 14 | `202604230700` | `4db5bf8f` |
+| Competitor analyses | 6 (embedded) | 7 | `202604230800` | `955dca40` |
+| News + key metrics + valuation | 6 (embedded) | 12 | `202604230900` | `28a0721b` |
+| **Total** | **~52** | **109** | | |
+
+---
+
+## 5. Think Steps
+
+### Step 1: Task Strategy (05:26:30 UTC)
+> "Let me understand what Anton is asking:
+> 1. Use the zettel-wiki skill on the AI Media company folder
+> 2. Create the wiki in `00-ai-media/wiki/` (not the default wiki location)
+> 3. Only read files within the 00-ai-media folder
+>
+> So I need to:
+> - Set up a wiki structure at `00-ai-media/wiki/` with `pages/`, `zettels/`, `INDEX.md`, `LEDGER.md`
+> - Process raw evidence from the 01-data folder (structured sources) into zettels
+> - DO NOT use notes/memos from 00-notes (those are synthesis, not raw evidence per the skill)
+> - Create structure notes from the emergent zettel clusters
+>
+> The raw evidence sources are in `01-data/02-structured/`: 00-filings, 02-transcripts, 03-product-docs, 04-customer-evidence, 05-competitors, 06-news, 08-key-metrics, 10-valuation.
+>
+> This is a large body of evidence. I should use parallel subagents for extraction, then consolidate. I have up to 10 parallel subagents. Let me batch by source category."
+
+### Step 2: Architecture Planning (05:26:53 UTC)
+> "The raw evidence sources in `01-data/02-structured/`: filings (~20+ files), transcripts (~10), product docs (~10), customer evidence (~7), competitors (~6), news (~7), key metrics, valuation.
+>
+> I should NOT use 00-notes/ or 02-research/ — they are outputs of prior analysis.
+>
+> Plan: 8 subagents with non-overlapping timestamp namespaces:
+> 1. Filings early (FY21-FY23): namespace 0200
+> 2. Filings mid (FY24): namespace 0300
+> 3. Filings recent (FY25-FY26): namespace 0400
+> 4. Transcripts: namespace 0500
+> 5. Product docs: namespace 0600
+> 6. Customer evidence: namespace 0700
+> 7. Competitors: namespace 0800
+> 8. News + metrics + valuation: namespace 0900
+>
+> Each subagent gets: model gemini-flash, lightContext true, wiki root path, zettel template, source file list, timestamp namespace. After they all complete: consolidate, cross-link, structure notes, INDEX, LEDGER, audit."
+
+### Step 3: Subagent Batch Design (05:27:33 UTC)
+> "Finalized 8 batch assignments with file lists:
+> 1. Filings early: investorhub-3676802 through investorhub-4400818 (9 files) — namespace 0200
+> 2. Filings mid: investorhub-6216424 through investorhub-6502528, 2024-08-29 files (7 files) — namespace 0300
+> 3. Filings recent: investorhub-6815461 through 2026-02-25 (10 files) — namespace 0400
+> 4. Transcripts: .md versions where both exist (7 unique) — namespace 0500
+> 5. Product docs: 10 files — namespace 0600
+> 6. Customer evidence: 7 files — namespace 0700
+> 7. Competitors: 6 files — namespace 0800
+> 8. News + key metrics + valuation: ~10 text files — namespace 0900
+>
+> Model choice: gemini-flash for all subagents (extraction-heavy, cost-efficient)."
+
+### Step 4: Post-Extraction Consolidation (05:32:01 UTC)
+> "All 109 zettels landed. Now I need to:
+> 1. Build a full zettel catalog (read all titles/tags) for the INDEX
+> 2. Identify natural clusters for structure notes
+> 3. Wire cross-batch connections
+> 4. Write structure notes
+> 5. Update all INDEX.md files
+> 6. Write the LEDGER entry
+> 7. Run audit checks"
+
+### Step 5: Structure Note Clustering (05:32:41 UTC)
+> "I now have a full catalog of 109 zettels. Let me cluster them:
+>
+> 1. **Competitive Moat & Vertical Integration** (~15-20 zettels) — iCap network, vertical integration, hardware control, switching costs, data moat
+> 2. **LEXI Product Suite & AI Technology** (~20+ zettels) — LEXI 3.0, DR, Voice, Recorded, AI, Brew, Vision, CCMatch, Alta
+> 3. **Business Model Transformation** (~15 zettels) — SaaS pivot, HaaS, revenue mix, strategic cannibalization
+> 4. **Financial Performance** (~10 zettels) — ARR, EBITDA, margin expansion, valuation, R&D
+> 5. **Go-to-Market & Global Expansion** (~12 zettels) — geographic, indirect sales, EAA/regulatory
+> 6. **Customer & Market Evidence** (~10 zettels) — Seven Network, Google, UK Parliament, enterprise validation
+> 7. **Competitive Landscape** (~8 zettels) — competitors, virtual encoding threat, SRT
+>
+> 7 structure notes. Each subagent reads its assigned zettels, writes the page, and updates each zettel's `## Related` section with a backlink. Cross-batch connections are handled by the structure notes themselves — they serve as the connective tissue."
+
+---
+
+## 6. Cost & Token Summary
+
+### Main Session (Opus)
+
+| Metric | Value |
+| :--- | :--- |
+| Input tokens | 92 |
+| Output tokens | 25,215 |
+| Cache read | 3,395,459 |
+| Cache write | 827,504 |
+| **Total tokens** | **4,248,270** |
+
+### Subagent Token Usage
+
+#### Extraction Subagents
+
+| Session ID | Label | Duration | Tool Calls | Files Read | Zettels | Input | Output | Cache Read | Total |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `015cdda3` | filings-early | 81s | 17 | 6 | 10 | 189,276 | 9,630 | 1,170,240 | 1,369,146 |
+| `260fb7b2` | filings-mid | 76s | 15 | 4 | 10 | 93,227 | 9,260 | 511,620 | 614,107 |
+| `56f243aa` | filings-recent | 82s | 18 | 6 | 10 | 150,743 | 10,123 | 910,122 | 1,070,988 |
+| `cde2dd3a` | transcripts | 189s | 41 | 7 | 32 | 239,121 | 22,750 | 2,102,745 | 2,364,616 |
+| `01fc48bb` | product-docs | 117s | 26 | 10 | 14 | 160,221 | 13,271 | 1,254,149 | 1,427,641 |
+| `4db5bf8f` | customers | 93s | 21 | 7 | 14 | 127,587 | 11,347 | 486,879 | 625,813 |
+| `955dca40` | competitors | 52s | 9 | 0† | 7 | 57,468 | 6,818 | 205,950 | 270,236 |
+| `28a0721b` | news-metrics | 90s | 18 | 0† | 12 | 106,052 | 11,369 | 676,330 | 793,751 |
+| **Subtotal** | | | **165** | **40** | **109** | **1,123,695** | **94,568** | **7,318,035** | **8,536,298** |
+
+† Source text was embedded in the task prompt rather than read via `read` tool.
+
+#### Structure Note Subagents
+
+| Session ID | Label | Duration | Tool Calls | Zettels Edited | Input | Output | Cache Read | Total |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `a5136602` | competitive-moat | 63s | 9 | 3 | 64,570 | 10,686 | 297,747 | 373,003 |
+| `e34ed9c8` | lexi-product | 51s | 8 | 1 | 67,797 | 7,696 | 230,997 | 306,490 |
+| `46b236d8` | business-model | 95s | 26 | 19 | 111,080 | 10,574 | 904,459 | 1,026,113 |
+| `f3339ffe` | financials | 83s | 17 | 1 | 98,485 | 11,420 | 590,464 | 700,369 |
+| `536d670d` | global-expansion | 64s | 19 | 16 | 123,376 | 6,628 | 496,300 | 626,304 |
+| `62ab5839` | customers | 69s | 19 | 15 | 110,380 | 7,654 | 516,488 | 634,522 |
+| `75639b62` | competitive-landscape | 57s | 15 | 12 | 91,478 | 6,122 | 362,949 | 460,549 |
+| **Subtotal** | | | **113** | **67** | **667,166** | **60,780** | **3,399,404** | **4,127,350** |
+
+### Grand Totals
+
+| Metric | Main Session (Opus) | 8 Extraction (Flash) | 7 Structure (Flash) | Grand Total |
+| :--- | :--- | :--- | :--- | :--- |
+| Input tokens | 92 | 1,123,695 | 667,166 | 1,790,953 |
+| Output tokens | 25,215 | 94,568 | 60,780 | 180,563 |
+| Cache read | 3,395,459 | 7,318,035 | 3,399,404 | 14,112,898 |
+| Cache write | 827,504 | 0 | 0 | 827,504 |
+| **Total tokens** | **4,248,270** | **8,536,298** | **4,127,350** | **16,911,918** |
+
+---
+
+## 7. Subagent Usage
+
+### 7.1 Extraction Subagents
+
+| Session ID | Label | Duration | Tool Calls | Files Read | Zettels Written | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `015cdda3` | filings-early | 1m 21s | 17 | 6 | 10 | ✅ |
+| `260fb7b2` | filings-mid | 1m 16s | 15 | 4 | 10 | ✅ |
+| `56f243aa` | filings-recent | 1m 22s | 18 | 6 | 10 | ✅ |
+| `cde2dd3a` | transcripts | 3m 9s | 41 | 7 | 32 | ✅ |
+| `01fc48bb` | product-docs | 1m 57s | 26 | 10 | 14 | ✅ |
+| `4db5bf8f` | customers | 1m 33s | 21 | 7 | 14 | ✅ |
+| `955dca40` | competitors | 52s | 9 | 0† | 7 | ✅ |
+| `28a0721b` | news-metrics | 1m 30s | 18 | 0† | 12 | ✅ |
+| **Total** | | | **165** | **40** | **109** | **8/8 ✅** |
+
+† Source text embedded in task prompt.
+
+### 7.2 No Batch Failures
+
+All 8 extraction subagents completed successfully — a first for the zettel-wiki series (v1: 0 subagents used, v2: 1 batch failure out of 8). The transcript batch (`cde2dd3a`) was the longest at 3m 9s and produced the most zettels (32), processing all 7 transcript files including conference recordings and webinars.
+
+### 7.3 Structure Note Subagents
+
+| Session ID | Label | Duration | Tool Calls | Edits | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `a5136602` | competitive-moat | 1m 3s | 9 | 3 | ✅ |
+| `e34ed9c8` | lexi-product | 51s | 8 | 1 | ✅ |
+| `46b236d8` | business-model | 1m 35s | 26 | 19 | ✅ |
+| `f3339ffe` | financials | 1m 23s | 17 | 1 | ✅ |
+| `536d670d` | global-expansion | 1m 4s | 19 | 16 | ✅ |
+| `62ab5839` | customers | 1m 9s | 19 | 15 | ✅ |
+| `75639b62` | competitive-landscape | 57s | 15 | 12 | ✅ |
+| **Total** | | | **113** | **67** | **7/7 ✅** |
+
+**Backlink pattern:** Each structure note subagent wrote its page and then edited its assigned zettels to add `## Related` backlinks pointing to the new page. The `business-model` subagent made the most edits (19), reflecting the broad reach of business model transformation across filings, metrics, and product evidence.
+
+---
+
+## 8. Observations
+
+### 8.1 Three-Phase Architecture: Scout → Extract → Synthesize
+
+v3 introduced a clean three-phase architecture within a single session:
+
+1. **Scout** (05:26–05:27): Skill loading, source survey, batch planning. 3 think steps, 0 content reads.
+2. **Extract** (05:27–05:31): 8 parallel subagents read raw evidence and write zettels. Main session dormant.
+3. **Synthesize** (05:31–05:36): Main session builds zettel catalog, identifies clusters, spawns 7 page subagents, then performs audit and finalization.
+
+This is more disciplined than v2, where the main session read 2 content docs for orientation before spawning extractors. In v3, the orchestrator never reads a single source file — all content contact is delegated.
+
+### 8.2 Zero Failures: 8/8 Extraction + 7/7 Structure Notes
+
+For the first time in the series, no subagent batch failed. v2 lost batch 4 (FY21–23 filings, 9 files) to a context overflow — the same era of filings processed successfully in v3's batch 1 (filings-early). The likely reason: v3 split the filing history into 3 batches (early/mid/recent) instead of v2's 4 batches (which assigned 9 older filings to a single worker). Smaller batches per worker = fewer overflows.
+
+### 8.3 Transcript Batch Dominance
+
+The transcripts subagent (`cde2dd3a`) was an outlier: 32 zettels from 7 source files (4.6 zettels/file), taking 3m 9s and consuming 2.4M total tokens — the most of any batch. By comparison, filings averaged 1.5 zettels/file and product docs 1.4 zettels/file. Transcripts are information-dense because they capture unscripted management commentary, Q&A, and real-time market positioning that filings sanitize away.
+
+### 8.4 Task-Embedded Source Text
+
+Two batches (competitors and news-metrics) had their source files embedded directly in the task prompt rather than requiring the subagent to `read` them. This meant 0 `read` calls but higher input token counts relative to the actual extraction work. The tradeoff: fewer tool calls and round-trips at the cost of a larger initial context. For small files (competitor analyses and news articles tend to be short), this was likely more efficient.
+
+### 8.5 Structure Note Subagents as Backlink Workers
+
+The v3 page subagents did double duty: write the structure note _and_ edit every assigned zettel's `## Related` section to add a backlink. This eliminated the need for a separate cross-linking phase (which v2 required as a second 8-subagent pass). The most edit-heavy subagent was `business-model` (19 edits), while `lexi-product` made only 1 edit — suggesting it may have written the page but didn't update zettel backlinks comprehensively. This is a quality gap worth auditing.
+
+### 8.6 Wall Time: 47% Faster Than v2 for Similar Output
+
+| Metric | v1 | v2 (Ingest only) | v3 |
+| :--- | :--- | :--- | :--- |
+| Wall time | 13m 35s | 14m | 10m 50s |
+| Subagents | 0 | 8 | 15 |
+| Zettels | 30 | 117 | 109 |
+| Structure notes | 10 | 9 | 7 |
+| Source files processed | 4 (synthesized) | 47 (raw) | ~52 (raw) |
+| Failures | 0 | 1 | 0 |
+
+v3 produced nearly the same output as v2 (109 vs 117 zettels, 7 vs 9 pages) in 23% less wall time. The 8-zettel gap is partly explained by v3 skipping duplicate extraction (v2 had 6 identified duplicate clusters). The time savings come from:
+1. No separate maintenance phase for cross-linking (folded into structure note subagents)
+2. No batch failures requiring assessment
+3. Zero main-session content reads (pure orchestration)
+
+### 8.7 Token Economics
+
+| Metric | v2 | v3 | Change |
+| :--- | :--- | :--- | :--- |
+| Total tokens | 25.7M | 16.9M | –34% |
+| Main session | 11.0M | 4.2M | –62% |
+| Subagent sessions | 14.8M | 12.7M | –14% |
+| Subagent count | 16 | 15 | –6% |
+
+v3 was significantly more token-efficient, mostly because the main session context was leaner (no content reads = smaller accumulating context = fewer cache write/read tokens). The subagent totals were similar because the raw source corpus is roughly the same size.
+
+### 8.8 Think Step Discipline: 5 Decision Points
+
+The orchestrator used `think` at 5 points: task interpretation (1), architecture planning (1), batch design (1), post-extraction assessment (1), and structure note clustering (1). This is fewer than v2's 11 think steps despite similar complexity — suggesting the v3 orchestrator was more decisive, spending less time on mid-extraction triage (which v2 needed for failure handling).
+
+### 8.9 v1 → v2 → v3 Architecture Evolution
+
+| Aspect | v1 | v2 | v3 |
+| :--- | :--- | :--- | :--- |
+| Agent model | Single Opus | Opus + Flash | Opus + Flash |
+| Source material | 4 synthesized notes | 47 raw files | ~52 raw files |
+| Main session content reads | 4 (all sources) | 2 (orientation) | 0 (pure orchestration) |
+| Extraction subagents | 0 | 8 | 8 |
+| Structure note subagents | 0 | 0 (Opus wrote all) | 7 (Flash wrote all) |
+| Cross-linking | Manual (1 pass) | 8 subagents (separate phase) | Folded into page subagents |
+| Zettels | 30 | 117 | 109 |
+| Structure notes | 10 | 9 | 7 |
+| Failures | 0 | 1/8 | 0/15 |
+| Think steps | 4 | 11 | 5 |
+| Total tokens | ~1.3M | ~25.7M | ~16.9M |
+| Wall time | 13m 35s | ~20m | 10m 50s |
+
+The key architectural shift from v2 to v3 is the delegation of structure note writing from Opus to Flash. In v2, the orchestrator synthesized all 9 pages itself (~8K output tokens, ~4 minutes). In v3, 7 Flash subagents wrote the pages in parallel (~60K output tokens combined, ~60 seconds). This trades Opus editorial quality for parallelism and speed. Whether the structure notes are as narratively coherent as v2's Opus-written pages is an open quality question that a content-level audit would answer.
+
+### 8.10 Remaining Gaps
+
+1. **Orphan audit was light.** Only 1 orphan was found and fixed (board governance zettel). The audit checked for missing `## Related` sections but did not verify that every zettel has _inbound_ connections from other zettels — only that it links to a structure note. True cross-zettel connectivity was not audited.
+
+2. **Lexi-product backlinks.** The `page-lexi-product` subagent made only 1 edit despite being assigned ~20 zettels. This suggests many LEXI-related zettels may lack backlinks to their structure note — a gap the v2 maintenance phase would have caught.
+
+3. **No duplicate detection.** v2 identified 6 duplicate zettel clusters. v3 did not run any duplicate analysis. With 109 zettels extracted from overlapping chronological filings, duplicates are likely present.
+
+4. **Source exclusion rationale undocumented.** The skill says research outputs and notes are not zettel sources, and the orchestrator respected this. But the LEDGER entry does not record _which_ files from `01-data/02-structured/` were included vs. excluded, or why some filings (e.g., appendix 4E, annual report appendices) were skipped while others were processed.

--- a/docs/analysis/INDEX.md
+++ b/docs/analysis/INDEX.md
@@ -1,0 +1,9 @@
+# analysis
+
+| Name | Notes |
+| --- | --- |
+| [00-zettel-wiki-v1-trace-analysis.md](./00-zettel-wiki-v1-trace-analysis.md) | Full session trace of the Zettel-Wiki v1 test run (Steve): tool calls, line counts, think steps, token usage, and observations. |
+| [01-zettel-wiki-v2-trace-analysis.md](./01-zettel-wiki-v2-trace-analysis.md) | Full session trace of the Zettel-Wiki v2 test run (Charlie): Opus orchestrator + 16 Flash subagents, 117 zettels from 62 raw source files, per-turn token table, full think step transcripts, batch 4 failure analysis, v1/v2 comparison. |
+
+## Notes
+- Session trace analyses and post-mortems for agent workflow runs.


### PR DESCRIPTION
Adds design and operational docs from the Zettel-Wiki skill development:

- **v3 design document** — current skill spec (the one used for Oracle and AIM ingests)
- **v1→v2 upgrade plan** — post-mortem findings from v1 (over-indexed on synthesis, no subagents, no coverage accounting)
- **Collect-evidence upgrade plan** — lessons from Oracle research build (thin initial evidence base, needed multiple feedback rounds)
- **Trace analyses (v1, v2, v3)** — detailed post-mortems of each iteration
- **Updated docs INDEX**

No code changes. Claude skills files (.claude/) excluded per request.