### PR TITLE
feat: overhaul extract CLI — add extract-files, short flags, bare-invocation help

### DIFF
--- a/.claude/skills/subagent-driven-development.md
+++ b/.claude/skills/subagent-driven-development.md
@@ -1,0 +1,277 @@
+---
+name: subagent-driven-development
+description: Use when executing implementation plans with independent tasks in the current session
+---
+
+# Subagent-Driven Development
+
+Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review.
+
+**Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
+
+**Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Have implementation plan?" [shape=diamond];
+    "Tasks mostly independent?" [shape=diamond];
+    "Stay in this session?" [shape=diamond];
+    "subagent-driven-development" [shape=box];
+    "executing-plans" [shape=box];
+    "Manual execution or brainstorm first" [shape=box];
+
+    "Have implementation plan?" -> "Tasks mostly independent?" [label="yes"];
+    "Have implementation plan?" -> "Manual execution or brainstorm first" [label="no"];
+    "Tasks mostly independent?" -> "Stay in this session?" [label="yes"];
+    "Tasks mostly independent?" -> "Manual execution or brainstorm first" [label="no - tightly coupled"];
+    "Stay in this session?" -> "subagent-driven-development" [label="yes"];
+    "Stay in this session?" -> "executing-plans" [label="no - parallel session"];
+}
+```
+
+**vs. Executing Plans (parallel session):**
+- Same session (no context switch)
+- Fresh subagent per task (no context pollution)
+- Two-stage review after each task: spec compliance first, then code quality
+- Faster iteration (no human-in-loop between tasks)
+
+## The Process
+
+```dot
+digraph process {
+    rankdir=TB;
+
+    subgraph cluster_per_task {
+        label="Per Task";
+        "Dispatch implementer subagent (./implementer-prompt.md)" [shape=box];
+        "Implementer subagent asks questions?" [shape=diamond];
+        "Answer questions, provide context" [shape=box];
+        "Implementer subagent implements, tests, commits, self-reviews" [shape=box];
+        "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [shape=box];
+        "Spec reviewer subagent confirms code matches spec?" [shape=diamond];
+        "Implementer subagent fixes spec gaps" [shape=box];
+        "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
+        "Code quality reviewer subagent approves?" [shape=diamond];
+        "Implementer subagent fixes quality issues" [shape=box];
+        "Mark task complete in TodoWrite" [shape=box];
+    }
+
+    "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
+    "More tasks remain?" [shape=diamond];
+    "Dispatch final code reviewer subagent for entire implementation" [shape=box];
+    "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
+
+    "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
+    "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
+    "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Implementer subagent asks questions?" -> "Implementer subagent implements, tests, commits, self-reviews" [label="no"];
+    "Implementer subagent implements, tests, commits, self-reviews" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
+    "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" -> "Spec reviewer subagent confirms code matches spec?";
+    "Spec reviewer subagent confirms code matches spec?" -> "Implementer subagent fixes spec gaps" [label="no"];
+    "Implementer subagent fixes spec gaps" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
+    "Spec reviewer subagent confirms code matches spec?" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="yes"];
+    "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
+    "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
+    "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
+    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
+    "Mark task complete in TodoWrite" -> "More tasks remain?";
+    "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
+    "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
+    "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
+}
+```
+
+## Model Selection
+
+Use the least powerful model that can handle each role to conserve cost and increase speed.
+
+**Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
+
+**Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
+
+**Architecture, design, and review tasks**: use the most capable available model.
+
+**Task complexity signals:**
+- Touches 1-2 files with a complete spec → cheap model
+- Touches multiple files with integration concerns → standard model
+- Requires design judgment or broad codebase understanding → most capable model
+
+## Handling Implementer Status
+
+Implementer subagents report one of four statuses. Handle each appropriately:
+
+**DONE:** Proceed to spec compliance review.
+
+**DONE_WITH_CONCERNS:** The implementer completed the work but flagged doubts. Read the concerns before proceeding. If the concerns are about correctness or scope, address them before review. If they're observations (e.g., "this file is getting large"), note them and proceed to review.
+
+**NEEDS_CONTEXT:** The implementer needs information that wasn't provided. Provide the missing context and re-dispatch.
+
+**BLOCKED:** The implementer cannot complete the task. Assess the blocker:
+1. If it's a context problem, provide more context and re-dispatch with the same model
+2. If the task requires more reasoning, re-dispatch with a more capable model
+3. If the task is too large, break it into smaller pieces
+4. If the plan itself is wrong, escalate to the human
+
+**Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
+
+## Prompt Templates
+
+- `./implementer-prompt.md` - Dispatch implementer subagent
+- `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
+- `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
+
+## Example Workflow
+
+```
+You: I'm using Subagent-Driven Development to execute this plan.
+
+[Read plan file once: docs/superpowers/plans/feature-plan.md]
+[Extract all 5 tasks with full text and context]
+[Create TodoWrite with all tasks]
+
+Task 1: Hook installation script
+
+[Get Task 1 text and context (already extracted)]
+[Dispatch implementation subagent with full task text + context]
+
+Implementer: "Before I begin - should the hook be installed at user or system level?"
+
+You: "User level (~/.config/superpowers/hooks/)"
+
+Implementer: "Got it. Implementing now..."
+[Later] Implementer:
+  - Implemented install-hook command
+  - Added tests, 5/5 passing
+  - Self-review: Found I missed --force flag, added it
+  - Committed
+
+[Dispatch spec compliance reviewer]
+Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
+
+[Get git SHAs, dispatch code quality reviewer]
+Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
+
+[Mark Task 1 complete]
+
+Task 2: Recovery modes
+
+[Get Task 2 text and context (already extracted)]
+[Dispatch implementation subagent with full task text + context]
+
+Implementer: [No questions, proceeds]
+Implementer:
+  - Added verify/repair modes
+  - 8/8 tests passing
+  - Self-review: All good
+  - Committed
+
+[Dispatch spec compliance reviewer]
+Spec reviewer: ❌ Issues:
+  - Missing: Progress reporting (spec says "report every 100 items")
+  - Extra: Added --json flag (not requested)
+
+[Implementer fixes issues]
+Implementer: Removed --json flag, added progress reporting
+
+[Spec reviewer reviews again]
+Spec reviewer: ✅ Spec compliant now
+
+[Dispatch code quality reviewer]
+Code reviewer: Strengths: Solid. Issues (Important): Magic number (100)
+
+[Implementer fixes]
+Implementer: Extracted PROGRESS_INTERVAL constant
+
+[Code reviewer reviews again]
+Code reviewer: ✅ Approved
+
+[Mark Task 2 complete]
+
+...
+
+[After all tasks]
+[Dispatch final code-reviewer]
+Final reviewer: All requirements met, ready to merge
+
+Done!
+```
+
+## Advantages
+
+**vs. Manual execution:**
+- Subagents follow TDD naturally
+- Fresh context per task (no confusion)
+- Parallel-safe (subagents don't interfere)
+- Subagent can ask questions (before AND during work)
+
+**vs. Executing Plans:**
+- Same session (no handoff)
+- Continuous progress (no waiting)
+- Review checkpoints automatic
+
+**Efficiency gains:**
+- No file reading overhead (controller provides full text)
+- Controller curates exactly what context is needed
+- Subagent gets complete information upfront
+- Questions surfaced before work begins (not after)
+
+**Quality gates:**
+- Self-review catches issues before handoff
+- Two-stage review: spec compliance, then code quality
+- Review loops ensure fixes actually work
+- Spec compliance prevents over/under-building
+- Code quality ensures implementation is well-built
+
+**Cost:**
+- More subagent invocations (implementer + 2 reviewers per task)
+- Controller does more prep work (extracting all tasks upfront)
+- Review loops add iterations
+- But catches issues early (cheaper than debugging later)
+
+## Red Flags
+
+**Never:**
+- Start implementation on main/master branch without explicit user consent
+- Skip reviews (spec compliance OR code quality)
+- Proceed with unfixed issues
+- Dispatch multiple implementation subagents in parallel (conflicts)
+- Make subagent read plan file (provide full text instead)
+- Skip scene-setting context (subagent needs to understand where task fits)
+- Ignore subagent questions (answer before letting them proceed)
+- Accept "close enough" on spec compliance (spec reviewer found issues = not done)
+- Skip review loops (reviewer found issues = implementer fixes = review again)
+- Let implementer self-review replace actual review (both are needed)
+- **Start code quality review before spec compliance is ✅** (wrong order)
+- Move to next task while either review has open issues
+
+**If subagent asks questions:**
+- Answer clearly and completely
+- Provide additional context if needed
+- Don't rush them into implementation
+
+**If reviewer finds issues:**
+- Implementer (same subagent) fixes them
+- Reviewer reviews again
+- Repeat until approved
+- Don't skip the re-review
+
+**If subagent fails task:**
+- Dispatch fix subagent with specific instructions
+- Don't try to fix manually (context pollution)
+
+## Integration
+
+**Required workflow skills:**
+- **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
+- **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:requesting-code-review** - Code review template for reviewer subagents
+- **superpowers:finishing-a-development-branch** - Complete development after all tasks
+
+**Subagents should use:**
+- **superpowers:test-driven-development** - Subagents follow TDD for each task
+
+**Alternative workflow:**
+- **superpowers:executing-plans** - Use for parallel session instead of same-session execution

--- a/.claude/skills/using-git-worktrees.md
+++ b/.claude/skills/using-git-worktrees.md
@@ -1,0 +1,218 @@
+---
+name: using-git-worktrees
+description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+---
+
+# Using Git Worktrees
+
+## Overview
+
+Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching.
+
+**Core principle:** Systematic directory selection + safety verification = reliable isolation.
+
+**Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
+
+## Directory Selection Process
+
+Follow this priority order:
+
+### 1. Check Existing Directories
+
+```bash
+# Check in priority order
+ls -d .worktrees 2>/dev/null     # Preferred (hidden)
+ls -d worktrees 2>/dev/null      # Alternative
+```
+
+**If found:** Use that directory. If both exist, `.worktrees` wins.
+
+### 2. Check CLAUDE.md
+
+```bash
+grep -i "worktree.*director" CLAUDE.md 2>/dev/null
+```
+
+**If preference specified:** Use it without asking.
+
+### 3. Ask User
+
+If no directory exists and no CLAUDE.md preference:
+
+```
+No worktree directory found. Where should I create worktrees?
+
+1. .worktrees/ (project-local, hidden)
+2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
+
+Which would you prefer?
+```
+
+## Safety Verification
+
+### For Project-Local Directories (.worktrees or worktrees)
+
+**MUST verify directory is ignored before creating worktree:**
+
+```bash
+# Check if directory is ignored (respects local, global, and system gitignore)
+git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
+```
+
+**If NOT ignored:**
+
+Per Jesse's rule "Fix broken things immediately":
+1. Add appropriate line to .gitignore
+2. Commit the change
+3. Proceed with worktree creation
+
+**Why critical:** Prevents accidentally committing worktree contents to repository.
+
+### For Global Directory (~/.config/superpowers/worktrees)
+
+No .gitignore verification needed - outside project entirely.
+
+## Creation Steps
+
+### 1. Detect Project Name
+
+```bash
+project=$(basename "$(git rev-parse --show-toplevel)")
+```
+
+### 2. Create Worktree
+
+```bash
+# Determine full path
+case $LOCATION in
+  .worktrees|worktrees)
+    path="$LOCATION/$BRANCH_NAME"
+    ;;
+  ~/.config/superpowers/worktrees/*)
+    path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
+    ;;
+esac
+
+# Create worktree with new branch
+git worktree add "$path" -b "$BRANCH_NAME"
+cd "$path"
+```
+
+### 3. Run Project Setup
+
+Auto-detect and run appropriate setup:
+
+```bash
+# Node.js
+if [ -f package.json ]; then npm install; fi
+
+# Rust
+if [ -f Cargo.toml ]; then cargo build; fi
+
+# Python
+if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+if [ -f pyproject.toml ]; then poetry install; fi
+
+# Go
+if [ -f go.mod ]; then go mod download; fi
+```
+
+### 4. Verify Clean Baseline
+
+Run tests to ensure worktree starts clean:
+
+```bash
+# Examples - use project-appropriate command
+npm test
+cargo test
+pytest
+go test ./...
+```
+
+**If tests fail:** Report failures, ask whether to proceed or investigate.
+
+**If tests pass:** Report ready.
+
+### 5. Report Location
+
+```
+Worktree ready at <full-path>
+Tests passing (<N> tests, 0 failures)
+Ready to implement <feature-name>
+```
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| `.worktrees/` exists | Use it (verify ignored) |
+| `worktrees/` exists | Use it (verify ignored) |
+| Both exist | Use `.worktrees/` |
+| Neither exists | Check CLAUDE.md → Ask user |
+| Directory not ignored | Add to .gitignore + commit |
+| Tests fail during baseline | Report failures + ask |
+| No package.json/Cargo.toml | Skip dependency install |
+
+## Common Mistakes
+
+### Skipping ignore verification
+
+- **Problem:** Worktree contents get tracked, pollute git status
+- **Fix:** Always use `git check-ignore` before creating project-local worktree
+
+### Assuming directory location
+
+- **Problem:** Creates inconsistency, violates project conventions
+- **Fix:** Follow priority: existing > CLAUDE.md > ask
+
+### Proceeding with failing tests
+
+- **Problem:** Can't distinguish new bugs from pre-existing issues
+- **Fix:** Report failures, get explicit permission to proceed
+
+### Hardcoding setup commands
+
+- **Problem:** Breaks on projects using different tools
+- **Fix:** Auto-detect from project files (package.json, etc.)
+
+## Example Workflow
+
+```
+You: I'm using the using-git-worktrees skill to set up an isolated workspace.
+
+[Check .worktrees/ - exists]
+[Verify ignored - git check-ignore confirms .worktrees/ is ignored]
+[Create worktree: git worktree add .worktrees/auth -b feature/auth]
+[Run npm install]
+[Run npm test - 47 passing]
+
+Worktree ready at /Users/jesse/myproject/.worktrees/auth
+Tests passing (47 tests, 0 failures)
+Ready to implement auth feature
+```
+
+## Red Flags
+
+**Never:**
+- Create worktree without verifying it's ignored (project-local)
+- Skip baseline test verification
+- Proceed with failing tests without asking
+- Assume directory location when ambiguous
+- Skip CLAUDE.md check
+
+**Always:**
+- Follow directory priority: existing > CLAUDE.md > ask
+- Verify directory is ignored for project-local
+- Auto-detect and run project setup
+- Verify clean test baseline
+
+## Integration
+
+**Called by:**
+- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
+- **subagent-driven-development** - REQUIRED before executing any tasks
+- **executing-plans** - REQUIRED before executing any tasks
+- Any skill needing isolated workspace
+
+**Pairs with:**
+- **finishing-a-development-branch** - REQUIRED for cleanup after work complete

--- a/docs/05-morning-market-brief-cli-gap-analysis.md
+++ b/docs/05-morning-market-brief-cli-gap-analysis.md
@@ -499,7 +499,7 @@ Writes:
 
 Exact behavior:
 1. **Audit & Plan**: Charlie reads the collected headlines and the source status, decides whether the evidence is sufficient, and writes an `execution-plan.md` containing targeted questions or angles needed for the specific events that actually matter.
-2. **Targeted Extraction**: Charlie uses `minerva extract` / `extract-many` (e.g. `--model openai/gpt-5.4`) against massive raw SEC/IR files to answer his planned questions. This keeps his working context strictly focused on signal instead of noise.
+2. **Targeted Extraction**: Charlie uses `minerva extract` (or `extract-files` for many files) (e.g. `--model openai/gpt-5.4`) against massive raw SEC/IR files to answer his planned questions. This keeps his working context strictly focused on signal instead of noise.
 3. **Synthesis**: Charlie writes the final reports based on the extracted answers.
 
 Implementation details:
@@ -521,7 +521,7 @@ In practice, that means:
 - `brief prep` compresses and groups the collected evidence before Charlie sees it
 - Charlie wakes up and starts from `grouped-events.md` and `source-status.md`
 - Charlie determines his own audit verdict and reading plan
-- to read the full text of SEC filings or press releases, Charlie uses `minerva extract` or `minerva extract-many` (e.g. `--model openai/gpt-5.4`) to ask targeted questions, rather than pulling the entire document into context. This prevents context bloat and keeps his working session strictly focused on signal instead of noise.
+- to read the full text of SEC filings or press releases, Charlie uses `minerva extract` or `minerva extract-files` (e.g. `--model openai/gpt-5.4`) to ask targeted questions, rather than pulling the entire document into context. This prevents context bloat and keeps his working session strictly focused on signal instead of noise.
 
 ---
 
@@ -540,7 +540,7 @@ The daily run should work like this:
 9. Charlie wakes up, reads `grouped-events.md` and `source-status.md`, and takes over as the autonomous intelligence layer:
    - he decides whether to audit the evidence pack or request more data
    - he builds his own execution plan
-   - he uses `minerva extract` / `extract-many` to deep dive on the full sources without blowing up his context window
+   - he uses `minerva extract` / `extract-files` to deep dive on the full sources without blowing up his context window
    - he runs `minerva brief audit` to validate the evidence pack before writing; if the audit fails, he loops back to collect or extract more data until the evidence passes
    - once the audit passes, he writes `notes/morning-brief-report.md` and `notes/slack-brief.md`
 10. OpenClaw posts the Slack brief

--- a/docs/06-collect-evidence-analyze-business-cli-plan.md
+++ b/docs/06-collect-evidence-analyze-business-cli-plan.md
@@ -199,7 +199,7 @@ Model:
 
 Implementation notes:
 - one model call per matched file
-- use existing `extract-many` core logic
+- use existing `extract-files` core logic (literal markdown prompt pack via `--questions-file`)
 - skip outputs that already exist unless `--force`
 - write JSON + markdown per extracted source
 - source-backed outputs mirror the source-type folder layout; reference-backed outputs land under `structured/references/`

--- a/docs/14-evidence-v2-quickstart.md
+++ b/docs/14-evidence-v2-quickstart.md
@@ -143,14 +143,34 @@ minerva research "Robinhood payment for order flow regulatory risk 2024 2025" \
 
 Research output is not automatically evidence. If the output itself is useful, save it under `research/` and register it with `add-source`. If it points to better primary sources, download those sources into `data/sources/` or `data/references/` and register those instead.
 
-### `minerva extract` / `minerva extract-many`
+### `minerva extract` / `minerva extract-files`
 
-Runs targeted LLM extraction over a saved file. Use this after a source exists on disk and you need specific facts pulled out of it.
+Runs targeted LLM extraction over saved file(s). Use after a source exists on disk and you need specific facts pulled out of it.
 
 ```bash
-minerva extract "What revenue drivers and risks does management emphasize?" \
-  --file hard-disk/reports/00-companies/12-robinhood/data/sources/10-K/2025-02-18/07-mdna.md
+# One question or prompt pack against one file (flags before positional):
+minerva extract \
+  -f hard-disk/reports/00-companies/12-robinhood/data/sources/10-K/2025-02-18/07-mdna.md \
+  "What revenue drivers and risks does management emphasize?"
+
+# Many questions over one file (literal markdown prompt pack):
+minerva extract -q questions.md \
+  -f hard-disk/reports/00-companies/12-robinhood/data/sources/10-K/2025-02-18/07-mdna.md
+
+# Same prompt or pack across many files, written per-file under --out:
+minerva extract-files -q questions.md \
+  -f 'hard-disk/reports/00-companies/12-robinhood/data/sources/10-K/2025-02-18/*.md' \
+  -o hard-disk/reports/00-companies/12-robinhood/extractions/mdna-summary \
+  --concurrency 4
+
+# Curated files from different folders; one path or glob per line:
+minerva extract-files -q questions.md \
+  -F selected-source-files.txt \
+  -o hard-disk/reports/extractions/cross-company \
+  --concurrency 4
 ```
+
+`extract-files` is for UTF-8 text/markdown files. Convert PDFs, spreadsheets, images, and other binary sources to text first, or use the appropriate OpenClaw PDF/image tool.
 
 Extraction is a way to structure evidence; it is not a substitute for registering the underlying source in the ledger.
 

--- a/docs/16-analyze-business-wiki-integration-plan.md
+++ b/docs/16-analyze-business-wiki-integration-plan.md
@@ -597,7 +597,8 @@ Update `~/.openclaw/workspace/shared/TOOLS.md` and its Steve mirror. Verified ag
 | `minerva evidence init\|add-source\|audit` | Company evidence tree creation/reuse, source ledger registration, and evidence audit memo |
 | `minerva research "<query>"` | Deep web research via Parallel.ai |
 | `minerva extract "<question>" --file <path>` | LLM-powered extraction from a document |
-| `minerva extract-many --file <path> "<q1>" "<q2>"` | Multiple extractions in one pass |
+| `minerva extract --questions-file questions.md --file <path>` | Apply a literal markdown question pack against one document |
+| `minerva extract-files --files '<glob>' --out <dir>` | Apply one prompt or question pack across many files with bounded concurrency |
 | `minerva fileinfo <path>` | Inspect files and directories before deciding the handling path |
 | `minerva valuation dcf\|comps\|reverse-dcf\|sotp\|report` | Financial valuation models |
 | `minerva analyze ngrams\|topics` | Deterministic text analysis |

--- a/docs/18-minerva-extract-cli-tdd-plan.md
+++ b/docs/18-minerva-extract-cli-tdd-plan.md
@@ -1,0 +1,359 @@
+# Minerva extract CLI — TDD improvement plan
+
+**Date:** May 1, 2026
+**Status:** Audited and revised plan
+**Primary code:** [extract.py](project-minerva/src/harness/commands/extract.py)
+**Primary tests:** [test_extract.py](project-minerva/tests/test_harness/test_extract.py)
+
+---
+
+## Problem statement
+
+The current extraction CLI has the wrong shape for the workflows we actually use.
+
+`minerva extract` is the useful primitive: one extraction prompt/question pack against one input file or stdin. But it does not expose Gemini thinking controls even though the source default is `gemini-3-flash`, where we want minimal thinking for cheap, fast extraction.
+
+`minerva extract-many` is misleading. It asks multiple questions against the same document by making one Gemini call per question. That gives per-question isolation, but it duplicates the full document context for every question and is the wrong primitive for extraction at scale. If we want multiple questions against one file, a single `extract` call with a question pack is usually simpler and cheaper.
+
+The missing command is `extract-files`: one extraction prompt/question pack applied across many files with controlled concurrency and durable per-file outputs.
+
+---
+
+## Target command model
+
+### 1. `minerva extract`
+
+One input source, one model call, one output.
+
+Supported examples:
+
+```bash
+minerva extract "What does management say about churn?" --file source.md
+minerva extract --questions-file questions.md --file source.md
+cat source.md | minerva extract --questions-file questions.md
+```
+
+Rules:
+
+- Accept either a positional prompt/question, `--questions-file`, or both.
+- Treat `--questions-file` as a literal prompt/question pack, not one question per line.
+  - Preserve markdown headings, bullets, numbering, and internal blank lines.
+  - Trim only outer whitespace.
+- When both positional prompt and `--questions-file` are provided, compose one prompt with clear sections and make a single model call.
+- Add `--thinking <level>`.
+- Default to `--thinking minimal` when the model is `gemini-3-flash`.
+- Continue supporting `--model` and `--max-tokens`.
+- Do not make one model call per question.
+- Do not read stdin when `--file` is provided; the current unconditional stdin read can hang in an interactive terminal.
+
+### 2. Remove `minerva extract-many`
+
+Remove the command registration, run-chain dispatcher, tests, and docs/tool references for `extract-many`.
+
+Replacement guidance:
+
+- Many questions over one file: `minerva extract -q questions.md -f source.md`.
+- One or more questions over many files: `minerva extract-files -q questions.md -f ...`.
+
+Hidden references to remove or update:
+
+- [extract.py](project-minerva/src/harness/commands/extract.py) help text, callbacks, dispatch helpers, and alternatives.
+- [commands/__init__.py](project-minerva/src/harness/commands/__init__.py) registration.
+- [cli.py](project-minerva/src/harness/cli.py) run-chain dispatcher and `_available_root_commands()` manual command list.
+- [fileinfo.py](project-minerva/src/harness/commands/fileinfo.py) recommendations.
+- Historical docs matched by `rg "extract-many" docs src tests`.
+
+### 3. Add `minerva extract-files`
+
+Many input files, same extraction prompt/question pack, one model call per file.
+
+Proposed syntax:
+
+```bash
+minerva extract-files "What does management say about churn?" \
+  -f 'data/sources/**/*.md' \
+  -o data/extractions/churn \
+  --concurrency 4
+
+minerva extract-files -q questions.md \
+  -f oracle/income.md -f microsoft/q3-call.md -f amazon/q1-call.md \
+  -o data/extractions/cross-company
+
+minerva extract-files -q questions.md \
+  -F selected-files.txt \
+  -o data/extractions/curated-cross-company
+
+minerva extract-files --questions-file questions.md \
+  --files 'data/sources/**/*.md' \
+  --out data/extractions/source-summary \
+  --model gemini-3-flash \
+  --thinking minimal
+```
+
+Rules:
+
+- Accept either a positional prompt/question, `--questions-file`, or both.
+- Treat `--questions-file` exactly like `extract`: literal markdown prompt pack, formatting preserved.
+- Support repeated `--files` / `-f` values and glob patterns.
+- Support `--files-from LIST` / `-F LIST` for curated files scattered across unrelated folders; the list file is newline-delimited, supports comments with `#`, and resolves relative entries from the list file's directory.
+- Expand globs deterministically and sort by path.
+- Deduplicate paths after expansion.
+- Fail cleanly if a glob matches nothing, unless we later add an explicit `--allow-empty` flag.
+- Require `--out` for MVP. Skip `--stdout`; multiple file outputs to stdout are noisy and easy to misuse.
+- Do not combine all files into one giant prompt.
+- Treat `extract-files` as UTF-8 text/markdown extraction only. PDFs, spreadsheets, images, archives, and binary/non-UTF-8 files should produce clear per-file manifest failures telling the user to convert first or use a PDF/image-specific tool.
+- Use bounded concurrency; default `--concurrency 4`, lower bound `1`.
+- Fail the command if any file extraction fails, but keep successful outputs and write an error summary.
+
+Output layout:
+
+- Write one markdown file per input file under `--out`.
+- Preserve enough relative path context to avoid duplicate basenames.
+- Recommended helper: compute the common parent of all input files, then mirror relative paths under `--out`, replacing the extension with `.md`.
+  - Example: `data/sources/10-K/2025/item-1.md` -> `out/10-K/2025/item-1.md` if common parent is `data/sources`.
+  - If two inputs still collide after normalization, append a short stable hash suffix.
+- Write a manifest file under `--out`, e.g. `manifest.json`, containing source path, output path, status, error if any, model, thinking level, timestamp, and prompt/questions-file metadata.
+- Timestamp should use UTC ISO-8601 to avoid timezone ambiguity.
+- Default overwrite policy: fail if an output file already exists unless `--force` is passed. This avoids quietly clobbering extraction artifacts.
+
+---
+
+## Gemini thinking design
+
+Use the installed `google-genai` support for `GenerateContentConfig.thinking_config` / `ThinkingConfig`.
+
+The implementation must be model-aware. Gemini 3 and Gemini 2.5 do not use the same thinking controls.
+
+### Gemini 3 policy
+
+For `gemini-3*` models, use `thinking_level`:
+
+| CLI level | Gemini 3 config |
+| --- | --- |
+| `minimal` | `thinking_config.thinking_level = "MINIMAL"` |
+| `low` | `thinking_config.thinking_level = "LOW"` |
+| `medium` | `thinking_config.thinking_level = "MEDIUM"` |
+| `high` | `thinking_config.thinking_level = "HIGH"` |
+
+Policy:
+
+- Default `gemini-3-flash` to `minimal`.
+- Do not advertise true `off` for Gemini 3 Flash; Gemini 3 Flash's closest cheap setting is `minimal`.
+- If a user passes `--thinking off` with a Gemini 3 model, fail clearly or normalize to `minimal` with explicit messaging. Recommendation: fail clearly so users do not think thinking was fully disabled.
+- Do not set `thinking_budget` for Gemini 3.
+
+### Gemini 2.5 policy
+
+For `gemini-2.5*` models, use `thinking_budget`:
+
+| CLI level | Gemini 2.5 config |
+| --- | --- |
+| `off` | `thinking_config.thinking_budget = 0` |
+| `adaptive` | `thinking_config.thinking_budget = -1` |
+
+For fixed low/medium/high on Gemini 2.5, either map to documented budgets after verifying model limits or reject with a clear error. Recommendation for MVP: support only `off` and `adaptive` for Gemini 2.5 until budget values are deliberately chosen.
+
+### Non-Gemini-3/2.5 policy
+
+For other Gemini model strings:
+
+- If `--thinking` is omitted, omit `thinking_config`.
+- If `--thinking` is provided, either map only when known-safe or fail clearly.
+- Never silently send unsupported thinking config.
+
+### Implementation shape
+
+Create small helpers and test them without hitting Gemini:
+
+- `_resolve_default_thinking(model, explicit_thinking)`
+- `_build_thinking_config(model, thinking)`
+- `_build_generate_config(model, max_tokens, thinking)`
+
+Prefer constructing `google.genai.types.GenerateContentConfig` and `google.genai.types.ThinkingConfig`, or at least assert against the exact serialized shape. Never set both `thinking_level` and `thinking_budget` in the same request.
+
+If the selected model rejects a thinking config, surface the API error clearly. Do not silently retry without thinking unless Anton explicitly asks for fallback behavior later.
+
+---
+
+## Parser design
+
+The current `minerva run` dispatcher is too primitive for the target surface.
+
+Problems to fix:
+
+- `extract.dispatch()` assumes `args[0]` is the question, so `extract --questions-file q.md --file doc.md` cannot work.
+- `parse_flag_args()` overwrites repeated flags, so it cannot support repeated `--files` values.
+- Flag ordering is brittle; agents should be able to put flags before or after the positional prompt.
+
+Plan:
+
+- Introduce command-local argument parsing helpers for extraction commands instead of stretching `parse_flag_args()`.
+- Support flags before and after the positional prompt.
+- Support repeated `--files` for `extract-files`.
+- Return clean errors on unknown flags, missing flag values, missing question source, missing file source, and invalid thinking level before any Gemini call.
+
+---
+
+## TDD plan
+
+### Phase 0 — Capture current behavior before changing it
+
+Add or update tests that pin the existing surface area we intend to preserve:
+
+- `extract` reads `--file` and sends document text to `_generate_answer`.
+- `extract` reads stdin only when `--file` is omitted.
+- `extract` returns a helpful error when neither input nor question source exists.
+- `extract` honors `--model` and `--max-tokens`.
+
+These tests are the guardrail while removing `extract-many`.
+
+### Phase 1 — Add literal question-pack support to `extract`
+
+Write failing tests first:
+
+- `extract_command` accepts `questions_file` and preserves the file's internal markdown formatting.
+- Positional prompt + `--questions-file` are both included in a single model call under clear headings.
+- Empty/whitespace-only `--questions-file` fails cleanly.
+- Missing `--questions-file` path fails cleanly.
+- CLI callback accepts `--questions-file` without a positional question.
+- Run-chain dispatch supports `extract --questions-file questions.md --file source.md`.
+- Flags work before and after the positional prompt.
+- Quoted prompts with spaces survive dispatch parsing.
+
+Then implement:
+
+- Replace line-based `_merge_questions` semantics with `_build_question_pack` / `_read_question_pack` semantics.
+- Change `_generate_answer` to receive a prompt/question-pack string, not a single conceptual question.
+- Update `SYSTEM_PROMPT` wording so it supports one or many questions and asks for clearly labeled answer sections when the prompt contains multiple questions.
+
+### Phase 2 — Add thinking support to `extract`
+
+Write failing tests first:
+
+- Default `extract` with model `gemini-3-flash` resolves to `thinking="minimal"`.
+- Explicit `--thinking minimal|low|medium|high` on `gemini-3*` maps to `thinking_level` and never sets `thinking_budget`.
+- Explicit `--thinking off` on `gemini-3*` fails clearly before calling Gemini.
+- Explicit `--thinking off|adaptive` on `gemini-2.5*` maps to `thinking_budget` and never sets `thinking_level`.
+- Invalid `--thinking nonsense` returns a clean CLI error before calling Gemini.
+- Non-default model with omitted `--thinking` omits `thinking_config` unless a known policy says otherwise.
+
+Then implement:
+
+- Add `thinking` parameter through CLI callback, run-chain dispatch, `extract_command`, and `_generate_answer`.
+- Add `_resolve_default_thinking`, `_build_thinking_config`, and `_build_generate_config` helpers.
+- Update `client.models.generate_content(..., config=...)` to include both `max_output_tokens` and optional `thinking_config`.
+
+### Phase 3 — Remove `extract-many`
+
+Write failing/removal tests first:
+
+- Root command registry no longer includes `extract-many`.
+- Run-chain dispatcher no longer recognizes `extract-many`.
+- `_available_root_commands()` no longer advertises `extract-many`.
+- Help text and docs no longer recommend `extract-many`.
+- Old `test_extract_many_*` tests are deleted or replaced with `extract --questions-file` tests.
+
+Then implement:
+
+- Remove `extract_many_app` registration from [commands/__init__.py](project-minerva/src/harness/commands/__init__.py).
+- Remove `extract-many` dispatcher entry and manual availability entry from [cli.py](project-minerva/src/harness/cli.py).
+- Delete `dispatch_many`, `extract_many_command`, and `_gather_answers` if no longer used.
+- Update examples in code help strings, [fileinfo.py](project-minerva/src/harness/commands/fileinfo.py), and docs.
+
+### Phase 4 — Add `extract-files`
+
+Write failing tests first:
+
+- Command requires at least one question source and at least one file source.
+- Repeated `--files` values are accepted.
+- Glob expansion is sorted, deduped, and fails on no matches.
+- One Gemini call is made per file, not per question.
+- `--questions-file` works exactly like `extract`, preserving formatting.
+- `--out` creates one markdown output per input file.
+- Output path helper mirrors relative input paths and avoids duplicate-basename collisions.
+- Existing output files fail unless `--force` is passed.
+- `--concurrency 1` runs deterministically and is easy to test.
+- Partial failure writes successful outputs, records failures in the manifest, and exits non-zero.
+- `--model`, `--thinking`, and `--max-tokens` are passed through to each extraction.
+- Run-chain dispatch supports `extract-files`.
+- File read errors and likely-binary/unreadable text files produce per-file failures, not total crashes.
+
+Then implement:
+
+- Add a new Typer command app, probably in `src/harness/commands/extract.py` unless it grows large enough to split.
+- Register it as `extract-files` in `commands/__init__.py`.
+- Add run-chain dispatcher support; extraction commands should stay composable in `minerva run`.
+- Create helpers for file expansion, output path mapping, manifest writing, and bounded async execution.
+- Use `asyncio` + semaphore for bounded concurrency.
+
+### Phase 5 — Docs and migration cleanup
+
+Update:
+
+- [14-evidence-v2-quickstart.md](project-minerva/docs/14-evidence-v2-quickstart.md) to replace `extract-many` with `extract --questions-file` and `extract-files`.
+- [05-morning-market-brief-cli-gap-analysis.md](project-minerva/docs/05-morning-market-brief-cli-gap-analysis.md), [06-collect-evidence-analyze-business-cli-plan.md](project-minerva/docs/06-collect-evidence-analyze-business-cli-plan.md), and [16-analyze-business-wiki-integration-plan.md](project-minerva/docs/16-analyze-business-wiki-integration-plan.md) where they mention `extract-many`.
+- CLI help examples in `EXTRACT_HELP`.
+- Fileinfo recommendations.
+
+Migration note to keep in the plan and release notes, not necessarily in user-facing command help forever:
+
+```text
+`extract-many` was removed. Use `extract --questions-file` for many questions over one file, or `extract-files --questions-file` for the same question pack over many files.
+```
+
+---
+
+## Acceptance gates
+
+Before calling this done:
+
+```bash
+uv run pytest tests/test_harness/test_extract.py -q
+uv run pytest tests/test_harness/test_cli.py -q
+uv run pytest tests/test_harness -q
+uv run python -m compileall src/harness
+uv run minerva --help
+uv run minerva extract --help
+uv run minerva extract-files --help
+rg "extract-many" src tests docs --glob '!docs/18-minerva-extract-cli-tdd-plan.md'
+```
+
+Expected `rg "extract-many"` result after migration: no source/test hits, and only deliberate historical migration notes if we choose to keep them. The plan doc itself is excluded because it explains the removal.
+
+If Gemini credentials are available, run one live smoke test against a tiny fixture:
+
+```bash
+printf 'Revenue was $10M. Churn improved.' > /tmp/minerva-extract-smoke.md
+uv run minerva extract "What revenue is stated?" \
+  --file /tmp/minerva-extract-smoke.md \
+  --model gemini-3-flash \
+  --thinking minimal
+```
+
+Also verify the installed `minerva` entrypoint after packaging/update, because the global CLI currently can lag repo source.
+
+---
+
+## Decisions made after audit
+
+- `--questions-file` means literal markdown prompt pack, not one question per line.
+- `--stdout` for `extract-files` is not MVP.
+- Gemini thinking config must be model-aware: Gemini 3 uses `thinking_level`; Gemini 2.5 uses `thinking_budget`.
+- `--thinking off` should not be presented as supported for Gemini 3 Flash.
+- Parser work is part of the feature, not incidental cleanup.
+- `extract-files` writes a manifest and requires `--out`.
+- Existing outputs are protected unless `--force` is passed.
+
+---
+
+## Implementation order summary
+
+1. Tests for existing `extract` behavior and stdin-read fix.
+2. Tests for `extract --questions-file` literal prompt-pack behavior.
+3. Implement `extract --questions-file` as a single-call prompt pack.
+4. Tests for model-aware `--thinking` config.
+5. Implement Gemini thinking config.
+6. Remove `extract-many` tests/registration/dispatch/help references.
+7. Tests for `extract-files` parsing, file expansion, output paths, manifest, and partial failure behavior.
+8. Implement `extract-files` with bounded concurrency and durable outputs.
+9. Update docs and run acceptance gates.

--- a/docs/19-bare-invocation-help-plan.md
+++ b/docs/19-bare-invocation-help-plan.md
@@ -1,0 +1,161 @@
+# 19 — Bare Invocation Shows Help Without Error
+
+## Problem
+
+Five Minerva commands show a `What went wrong: ...` error block when invoked with zero arguments:
+
+| Command | Current behavior | Exit code |
+|---|---|---|
+| `minerva extract` | help + "no extraction prompt was provided" | 1 |
+| `minerva extract-files` | help + "no extraction prompt was provided" | 1 |
+| `minerva fileinfo` | help + "no path was provided" | 1 |
+| `minerva research` | help + "no research query was provided" | 1 |
+| `minerva run` | help + "no command chain was provided" | 1 |
+
+The other seven commands (`sec`, `evidence`, `portfolio`, `brief`, `valuation`, `analyze`, `plot`) are Typer subcommand groups and already show clean help with no error.
+
+## Desired behavior
+
+- *Bare invocation* (zero user-provided args/options): show help text, exit 0, no error message.
+- *Partial invocation* (some args but missing a required one): keep the existing `What went wrong` error + help, exit 1.
+
+Example:
+
+```
+$ minerva extract          # bare → clean help, exit 0
+$ minerva extract -f a.md  # partial (missing question) → error + help, exit 1
+```
+
+## Design
+
+### Shared helper
+
+Add a `show_help_if_bare` function to `common.py`:
+
+```python
+def show_help_if_bare(ctx: typer.Context, **kwargs: Any) -> None:
+    """If every kwarg is None or an empty collection, print help and exit 0."""
+    if all(_is_bare_default(v) for v in kwargs.values()):
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
+```
+
+With a narrow `_is_bare_default`:
+
+```python
+def _is_bare_default(v: Any) -> bool:
+    """True only for None or empty list/tuple — the values Typer uses for unprovided args."""
+    if v is None:
+        return True
+    if isinstance(v, (list, tuple)) and len(v) == 0:
+        return True
+    return False
+```
+
+**Why narrow, not falsy:** `extract-files` has `force: bool` (default `False`) and `concurrency: int` (default `4`) on the same callback. A broad falsy check would treat `False` and `0` as "not provided," silently misclassifying real user input. Typer passes `None` for unprovided `Optional` args and `None` for unprovided `list` options — never `""`, `False`, or `0`.
+
+### Per-command changes
+
+Each callback calls `show_help_if_bare(ctx, ...)` as its first line, before any validation. Only pass the *user-facing* parameters that indicate intent — not defaults like `model`, `max_tokens`, `concurrency` that always have values.
+
+| Command | Guard kwargs |
+|---|---|
+| `extract` | `question`, `file_path`, `questions_file` |
+| `extract-files` | `question`, `files`, `files_from`, `questions_file`, `out` |
+| `fileinfo` | `path` |
+| `research` | `query`, `output` |
+| `run` | `command` |
+
+### `run` special case
+
+`run` uses `typer.echo()` directly instead of `abort_with_help`. Refactor to use `show_help_if_bare` for bare invocation, then keep the existing error path for partial invocation (which is currently impossible since `run` only has one arg — but the refactor keeps the pattern consistent).
+
+### Exit code choice
+
+Click/Typer uses exit 0 for `--help`. Our bare-invocation guard also uses exit 0. This is consistent — bare invocation is semantically equivalent to asking for help, not an error.
+
+## TDD plan
+
+### Phase 1 — Tests (RED)
+
+Write tests in `tests/test_harness/test_bare_invocation.py`.
+
+**Unit tests for `_is_bare_default`:**
+
+```python
+@pytest.mark.parametrize("value,expected", [
+    (None, True),
+    ([], True),
+    ((), True),
+    ("hello", False),
+    (["a"], False),
+    ("", False),       # Typer never sends "" for unprovided args
+    (0, False),        # must not treat 0 as bare
+    (False, False),    # must not treat False as bare
+    (4, False),        # e.g. default concurrency
+])
+def test_is_bare_default(value, expected):
+    assert _is_bare_default(value) is expected
+```
+
+**Bare-invocation tests** via `typer.testing.CliRunner`:
+
+```python
+# test_bare_extract_shows_help_without_error
+# test_bare_extract_files_shows_help_without_error
+# test_bare_fileinfo_shows_help_without_error
+# test_bare_research_shows_help_without_error
+# test_bare_run_shows_help_without_error
+```
+
+Each asserts: exit code 0, output contains `Usage:`, output does NOT contain `What went wrong`.
+
+**Partial-invocation regression tests:**
+
+```python
+# test_partial_extract_still_errors
+#   minerva extract -f foo.md  → exit 1, "What went wrong"
+
+# test_partial_extract_files_still_errors
+#   minerva extract-files -f foo.md  → exit 1, "What went wrong"
+
+# test_partial_research_still_errors
+#   minerva research --output foo.md  → exit 1, "What went wrong"
+```
+
+**Dispatch path regression test:**
+
+```python
+# test_run_dispatch_extract_still_errors
+#   minerva run "extract"  → exit 1 (dispatch path unaffected)
+```
+
+All tests fail initially (RED).
+
+### Phase 2 — Implementation (GREEN)
+
+1. Add `_is_bare_default` and `show_help_if_bare` to `common.py`.
+2. Add `show_help_if_bare(ctx, ...)` as the first line of each of the five callbacks.
+3. Refactor `run_command` in `cli.py` to use the shared helper.
+
+Run tests — all pass (GREEN).
+
+### Phase 3 — Verify + install
+
+1. Run full test suite: `uv run pytest tests/test_harness -q`.
+2. Compile check: `uv run python -m compileall src/harness`.
+3. Global install: `uv tool install --force -e .`.
+4. Manual spot-check all 12 commands bare: each shows clean help, exit 0, no error.
+5. Manual spot-check partial invocations still error.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/harness/commands/common.py` | Add `_is_bare_default`, `show_help_if_bare` |
+| `src/harness/commands/extract.py` | Add bare-invocation guard to `extract_cli_command` and `extract_files_cli_command` |
+| `src/harness/commands/fileinfo.py` | Add bare-invocation guard to `fileinfo_cli_command` |
+| `src/harness/commands/research.py` | Add bare-invocation guard to `research_cli_command` |
+| `src/harness/cli.py` | Refactor `run_command` to use bare-invocation guard |
+| `tests/test_harness/test_bare_invocation.py` | New test file — ~14 tests |
+| `docs/INDEX.md` | Add this plan doc |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,23 +2,29 @@
 
 | Name | Type | Notes |
 | --- | --- | --- |
-| `00-jobwatch-architecture.md` | file | Architecture notes for JobWatch. |
-| `02-investment-harness.md` | file | Investment harness design notes. |
-| `03-log-analysis-company-analysis-2026-04-07.md` | file | Session-log review of company-analysis workflows and CLI opportunities. |
-| `04-browser-cli-v2-python-port.md` | file | Combined doc: implementation deep dive of the TS/JS browser-cli-v2 + full Python migration plan. |
-| `05-morning-market-brief-cli-gap-analysis.md` | file | V1 implementation plan for the morning market brief pipeline, including CLI commands, storage layout, and scheduler integration. |
-| `06-collect-evidence-analyze-business-cli-plan.md` | file | Design doc for a workflow-aware Minerva evidence/analysis layer supporting the `collect-evidence` and `analyze-business` skills. |
-| `07-collect-evidence-analyze-business-skill-update-notes.md` | file | Skill update notes for the evidence/analysis workflow. |
-| `08-robinhood-session-trace-audit.md` | file | Session trace audit for Robinhood analysis. |
-| `09-browser-fallback-improvement-plan.md` | file | Improvement plan: browser-based fallback for Cloudflare-blocked IR feeds and macro sources in the morning brief pipeline. |
-| `10-llm-wiki-zettelkasten-design.md` | file | Design synthesis: merging Karpathy's LLM Wiki pattern with the Zettelkasten method into a unified knowledge-base skill. |
-| `11-minerva-evidence-starter-live-tested-guide.md` | file | Live-tested starter walkthrough of the current `minerva evidence` workflow, including real command behavior, workflow design, and measurement gaps. |
-| `12-minerva-evidence-v2-zero-based-redesign.md` | file | Zero-based redesign for a smaller, more agentic evidence workflow built around `init`, `add-source`, `review`, and `analysis context`. |
-| `14-evidence-v2-quickstart.md` | file | Quickstart guide for the V2 evidence workflow: commands, workspace layout, migration, and SEC per-section file notes. |
-| `15-collect-evidence-research-upgrade-plan.md` | file | Upgrade plan: rename collect-evidence → research-and-collect, add shared deep-dive checklist, 10 research dimensions, competitive mapping, parallel execution, and structured data build. |
+| [00-jobwatch-architecture.md](./00-jobwatch-architecture.md) | file | Architecture notes for JobWatch. |
+| [02-zettel-wiki-v3-design.md](./02-zettel-wiki-v3-design.md) | file | V3 design notes for the zettel wiki workflow. |
+| [05-morning-market-brief-cli-gap-analysis.md](./05-morning-market-brief-cli-gap-analysis.md) | file | V1 implementation plan for the morning market brief pipeline, including CLI commands, storage layout, and scheduler integration. |
+| [06-collect-evidence-analyze-business-cli-plan.md](./06-collect-evidence-analyze-business-cli-plan.md) | file | Design doc for a workflow-aware Minerva evidence/analysis layer supporting the `collect-evidence` and `analyze-business` skills. |
+| [07-collect-evidence-analyze-business-skill-update-notes.md](./07-collect-evidence-analyze-business-skill-update-notes.md) | file | Skill update notes for the evidence/analysis workflow. |
+| [08-robinhood-session-trace-audit.md](./08-robinhood-session-trace-audit.md) | file | Session trace audit for Robinhood analysis. |
+| [09-browser-fallback-improvement-plan.md](./09-browser-fallback-improvement-plan.md) | file | Improvement plan for browser-based fallback on Cloudflare-blocked IR feeds and macro sources. |
+| [10-llm-wiki-zettelkasten-design.md](./10-llm-wiki-zettelkasten-design.md) | file | Design synthesis combining Karpathy's LLM Wiki pattern with Zettelkasten. |
+| [11-minerva-evidence-starter-live-tested-guide.md](./11-minerva-evidence-starter-live-tested-guide.md) | file | Live-tested starter walkthrough of the current `minerva evidence` workflow. |
+| [12-minerva-evidence-v2-zero-based-redesign.md](./12-minerva-evidence-v2-zero-based-redesign.md) | file | Zero-based redesign for a smaller, more agentic evidence workflow. |
+| [13-zettel-wiki-v2-upgrade-plan.md](./13-zettel-wiki-v2-upgrade-plan.md) | file | Upgrade plan for the zettel wiki workflow. |
+| [14-evidence-v2-quickstart.md](./14-evidence-v2-quickstart.md) | file | Quickstart guide for the V2 evidence workflow. |
+| [15-collect-evidence-research-upgrade-plan.md](./15-collect-evidence-research-upgrade-plan.md) | file | Upgrade plan for research-and-collect, research dimensions, and structured evidence buildout. |
+| [16-analyze-business-wiki-integration-plan.md](./16-analyze-business-wiki-integration-plan.md) | file | Plan for integrating analyze-business workflows with the local wiki. |
+| [17-analyze-business-v2-improvement-plan.md](./17-analyze-business-v2-improvement-plan.md) | file | Improvement plan for analyze-business v2 based on Oracle deep-dive trace analysis. |
+| [18-minerva-extract-cli-tdd-plan.md](./18-minerva-extract-cli-tdd-plan.md) | file | TDD plan for `minerva extract`, legacy multi-question command removal, and new `extract-files`. |
+| [19-bare-invocation-help-plan.md](./19-bare-invocation-help-plan.md) | file | TDD plan: bare `minerva <command>` shows clean help (no error), exit 0. |
+| [analysis/](./analysis/INDEX.md) | folder | Trace analyses and deeper implementation reviews. |
+| [plans/](./plans/) | folder | Additional planning documents. |
 
 ## Notes
 - Docs hold higher-level designs, reports, and durable reference writeups.
 - The morning-brief doc lives here because it defines the repo-level CLI additions, storage layout, and scheduler integration for the daily pipeline.
 - The evidence starter guide documents current behavior as-tested, including places where coverage and inventory count artifacts rather than logical sources.
 - The V2 redesign doc is the clean-sheet proposal for replacing deterministic bookkeeping with a smaller agentic interface.
+- `18-minerva-extract-cli-tdd-plan.md` is the current plan for fixing the extraction CLI shape before implementation.

--- a/docs/analysis/04-oracle-deep-dive-v2-session-trace.md
+++ b/docs/analysis/04-oracle-deep-dive-v2-session-trace.md
@@ -1,0 +1,567 @@
+# Oracle Deep Dive v2 — Session Trace
+
+**Session ID:** `f250c081-31c4-4c73-9a8d-4f0774a8c1de`
+**Date:** April 29, 2026, 08:34–08:49 EDT
+**Agent:** main (Charlie Buffet)
+**Model:** anthropic/claude-opus-4-6
+**Thinking level:** high (hidden — reasoning traces not recorded in JSONL)
+**Task:** Write a v1 deep dive for Oracle using the analyze-business skill + brainstorm pressure-test
+**Trigger:** Slack thread in #ai-infra from Anton: "oracle DD again"
+
+> **Note:** This is the second Oracle deep dive session. The first (`c53daaf0`, documented in `03-oracle-deep-dive-v1-session-trace.md`) ran at ~06:56 EDT the same day and produced a simpler deep dive without brainstorm. This session reused the same evidence base but followed the full analyze-business skill workflow: orient → plan → draft → brainstorm → revise. Tool call inputs are stored in the JSONL but tool result contents are null. Thinking blocks are not recorded when reasoning is set to "hidden." Think step content is reconstructed from stored `think` tool arguments.
+
+---
+
+## Session Metadata
+
+| Metric | Value |
+|---|---|
+| JSONL entries | 112 |
+| Session runs | 4 (main session was woken up 3 times by subagent completions) |
+| Assistant turns | 40 |
+| Tool calls | 56 |
+| Subagent sessions | 3 (brainstorm: charlie-buffet, mauboussin, taleb) |
+| User messages | 4 (1 initial + 3 subagent completion events) |
+| Model | anthropic/claude-opus-4-6 |
+| Thinking level | high (hidden) |
+| System prompt size | 49,290 chars |
+| Tools available | 27 |
+| Transport | SSE |
+
+### Tool Usage Summary
+
+| Tool | Count | Purpose |
+|---|---|---|
+| `read` | 22 | Skill files, wiki pages, structured data files, brainstorm outputs, INDEX files |
+| `edit` | 8 | Deep dive revisions (6 targeted edits to incorporate brainstorm feedback) + INDEX updates |
+| `exec` | 7 | File system exploration, directory listings |
+| `think` | 5 | Evidence assessment, comprehensive planning, judgment formation, brainstorm synthesis, plan finalization |
+| `write` | 4 | Plan, deep dive draft, brainstorm synthesis, plans INDEX |
+| `sessions_spawn` | 3 | Brainstorm subagents (charlie-buffet, mauboussin, taleb) |
+| `sessions_yield` | 3 | Waiting for subagent completions |
+| `message` | 2 | Slack progress update + completion report |
+| `subagents` | 1 | Listing active subagents to check status |
+| `memory_search` | 1 | Checking for prior Oracle work in memory |
+
+---
+
+## Execution Flow
+
+```mermaid
+flowchart TD
+    A["User Request<br/>(analyze-business skill, Oracle DD)"] --> B["Read SKILL.md +<br/>Memory Search +<br/>Checklist"]
+    B --> C["Explore Evidence Tree<br/>(exec × 5)"]
+    C --> D["Think: Evidence assessment"]
+    D --> E["Post Slack progress update"]
+    E --> F["Read 7 Wiki Sub-Pages<br/>(cloud-infra, AI, database,<br/>financials, governance, health, apps)"]
+    F --> G["Think: Comprehensive assessment<br/>vs checklist"]
+    G --> H["Read 8 Structured Data Files<br/>(key financials, ROIC, scenarios,<br/>depreciation, cap alloc, comps,<br/>competitive pos, capex/risk)"]
+    H --> I["Think: Form judgment +<br/>plan report structure"]
+    I --> J["Write Plan File"]
+    J --> K["Write Deep Dive Draft<br/>(~35,838 chars)"]
+    K --> L["Read Brainstorm SKILL.md"]
+    L --> M["Spawn 3 Brainstorm Subagents<br/>(Charlie, Mauboussin, Taleb)"]
+    M --> N["Yield + Wait<br/>(~3.5 min idle)"]
+    N --> O["Read 3 Brainstorm Outputs"]
+    O --> P["Think: Synthesize feedback +<br/>decide revisions"]
+    P --> Q["Write Brainstorm Synthesis"]
+    Q --> R["Edit Deep Dive<br/>(6 targeted revisions)"]
+    R --> S["Update INDEX files +<br/>Post Report to Slack"]
+```
+
+---
+
+## Detailed Trace (All Steps)
+
+### Session Start
+- **Timestamp:** 2026-04-29T12:34:19.474Z (08:34:19 EDT)
+- **CWD:** `/Users/charlie-buffet/.openclaw/workspace`
+
+---
+
+### Run 1: Orientation → Draft → Spawn (08:34–08:41 EDT)
+
+| Step | Timestamp (UTC) | Tool | Key Parameters | Outcome |
+|---|---|---|---|---|
+| 1 | 12:34:22 | `read` | `skills/analyze-business/SKILL.md` | Loaded skill instructions (6,397 chars) |
+| 2 | 12:34:26 | `read` | `skills/analyze-business/references/deep-dive-checklist.md` | Loaded checklist (3,103 chars) |
+| 2 | 12:34:26 | `memory_search` | query: "Oracle ORCL evidence research wiki analysis" | 0 hits — no prior Oracle work in memory |
+| 3 | 12:34:30 | `think` | "No prior Oracle work in memory. Let me check the hard-disk…" | Decided to survey evidence tree and wiki |
+| 4 | 12:34:30 | `exec` | `ls … \| grep -i oracle; find … -iname "*oracle*"` | Found `12-oracle` company folder |
+| 5 | 12:34:35 | `exec` | `find … wiki -iname "*oracle*"; ls … wiki/` | Discovered wiki pages for Oracle |
+| 5 | 12:34:35 | `exec` | `find … 12-oracle -type f \| head -50` | Surveyed evidence tree (~40 files) |
+| 6 | 12:34:39 | `exec` | `cat … wiki/pages/oracle/oracle.md` | Read main wiki structure note via exec (5,746 chars) |
+| 6 | 12:34:39 | `exec` | `find … wiki/zettels -iname "*oracle*"` | Found Oracle-related zettels |
+| 6 | 12:34:39 | `exec` | `find … wiki/zettels -name "*.md" \| wc -l; find … wiki/pages/oracle` | 1,504 total zettels; 7 Oracle sub-pages |
+| 7 | 12:34:44 | `think` | "We have a rich evidence base for Oracle…" (full text below) | Assessed evidence breadth; planned the workflow: read → plan → draft → brainstorm → revise |
+| 8 | 12:34:59 | `message` | Slack progress update to thread | "On it. We have a solid evidence base already…" |
+| 9 | 12:34:59 | `read` | `wiki/pages/oracle/cloud-infrastructure.md` | OCI architecture, demand, capex (8,585 chars) |
+| 9 | 12:34:59 | `read` | `wiki/pages/oracle/ai-strategy.md` | AI strategy, OpenAI contract (8,068 chars) |
+| 9 | 12:34:59 | `read` | `wiki/pages/oracle/database-multicloud.md` | Database moat, multi-cloud (6,338 chars) |
+| 9 | 12:34:59 | `read` | `wiki/pages/oracle/financial-trajectory.md` | Revenue, margins, balance sheet (14,851 chars) |
+| 10 | 12:35:14 | `read` | `wiki/pages/oracle/governance-risk.md` | Governance, reference classes, risks (12,291 chars) |
+| 10 | 12:35:14 | `read` | `wiki/pages/oracle/health.md` | Oracle Health / Cerner (4,915 chars) |
+| 10 | 12:35:14 | `read` | `wiki/pages/oracle/applications-platform.md` | Fusion, NetSuite, AI agents (6,256 chars) |
+| 11 | 12:35:20 | `read` | `oracle/data/structured/oracle-key-financials.md` | Key financial metrics (5,198 chars) |
+| 11 | 12:35:20 | `read` | `oracle/data/structured/oracle-roic-analysis.md` | ROIC deep analysis (28,038 chars) |
+| 11 | 12:35:20 | `read` | `oracle/data/structured/oracle-scenario-analysis.md` | Scenario analysis (27,798 chars) |
+| 12 | 12:35:47 | `think` | "This is an extraordinarily rich evidence base…" (full text below) | Assessed all checklist dimensions; identified thin areas; decided to draft immediately |
+| 13 | 12:35:52 | `read` | `oracle/data/structured/oracle-depreciation-wave-model.md` | Depreciation projections (35,967 chars) |
+| 13 | 12:35:52 | `read` | `oracle/data/structured/oracle-capital-allocation-history.md` | Capital allocation shift (20,528 chars) |
+| 13 | 12:35:52 | `read` | `oracle/data/structured/oracle-competitive-positioning.md` | Competitive analysis (4,591 chars) |
+| 14 | 12:35:57 | `read` | `oracle/data/structured/oracle-capex-and-balance-sheet-risk.md` | Balance sheet risk (4,096 chars) |
+| 14 | 12:35:57 | `read` | `oracle/data/structured/oracle-peer-valuation-comps.md` | Peer valuation comparisons (14,150 chars) |
+| 15 | 12:36:07 | `think` | "I now have a comprehensive picture…" (full text below) | Finalized plan structure; formed key judgments before drafting |
+| 16 | 12:36:11 | `exec` | `ls oracle/plans/` | Checked plan numbering convention |
+| 17 | 12:36:43 | `write` | `oracle/plans/01-plan-oracle-deep-dive.md` | Plan file (4,069 chars) |
+| 18 | 12:40:39 | `write` | `oracle/analysis/oracle-deep-dive-v1.md` | **Full deep dive draft** (~35,838 chars, ~4 min generation) |
+| 19 | 12:40:43 | `read` | `skills/brainstorm/SKILL.md` | Loaded brainstorm skill instructions (2,385 chars) |
+| 20 | 12:41:07 | `sessions_spawn` ×3 | 3 brainstorm subagents (see Subagent section below) | All 3 spawned simultaneously |
+| 21 | 12:41:38 | `sessions_yield` | "Three brainstorm subagents spawned…" | Paused main session. **Run 1 ends.** |
+
+---
+
+### Run 2: Charlie's Brainstorm Arrives (08:45 EDT)
+
+| Step | Timestamp (UTC) | Tool | Key Parameters | Outcome |
+|---|---|---|---|---|
+| 22 | 12:45:21 | `subagents` | `action: list` | Charlie complete. Mauboussin and Taleb still running. |
+| 23 | 12:45:24 | `sessions_yield` | "Mauboussin and Taleb still running — waiting." | Paused. **Run 2 ends.** |
+
+---
+
+### Run 3: Mauboussin's Brainstorm Arrives (08:45 EDT)
+
+| Step | Timestamp (UTC) | Tool | Key Parameters | Outcome |
+|---|---|---|---|---|
+| 24 | 12:45:58 | `sessions_yield` | "Charlie and Mauboussin done. Waiting on Taleb." | Paused. **Run 3 ends.** |
+
+---
+
+### Run 4: All Three In → Synthesis → Revise → Post (08:46–08:49 EDT)
+
+| Step | Timestamp (UTC) | Tool | Key Parameters | Outcome |
+|---|---|---|---|---|
+| 25 | 12:46:14 | `read` | `oracle/analysis/brainstorm-dd-charlie.md` | Charlie's brainstorm (21,824 chars) |
+| 25 | 12:46:14 | `read` | `oracle/analysis/brainstorm-dd-mauboussin.md` | Mauboussin's brainstorm (26,522 chars) |
+| 25 | 12:46:14 | `read` | `oracle/analysis/brainstorm-dd-taleb.md` | Taleb's brainstorm (26,488 chars) |
+| 26 | 12:46:42 | `think` | "Excellent brainstorm output from all three…" (full text below) | Synthesized feedback; identified 9 revisions to incorporate |
+| 27 | 12:47:18 | `write` | `oracle/analysis/brainstorm-dd-synthesis.md` | Brainstorm synthesis (5,241 chars) |
+| 28 | 12:47:45 | `edit` | Deep dive: expanded variable #5 (database moat + multi-cloud) and added variable #6 (inference transition) | Strengthened bull case coverage |
+| 29 | 12:47:55 | `edit` | Deep dive: changed base rate from "approximately 10%" to "approximately 10–20%" with Oracle-specific adjustments | More honest range presentation |
+| 30 | 12:48:07 | `edit` | Deep dive: added two-business ROIC decomposition paragraph (core 22–25% vs infrastructure 1–2%) | Mauboussin's key suggestion |
+| 31 | 12:48:25 | `edit` | Deep dive: added "Reflexive Doom Loop" section + true obligation set ($424B vs $23B OCF = 18:1) | Taleb's key suggestions |
+| 32 | 12:48:42 | `edit` | Deep dive: rewrote floor analysis with honest obligation netting ($25–45 range, business vs equity floor distinction) | Taleb's floor critique |
+| 33 | 12:48:57 | `edit` | Deep dive: rewrote recommendation with $110–140 entry range, acknowledged bearish tilt, added caveat about ROIC during spending phases | Balanced all three agents' feedback |
+| 34 | 12:49:02 | `read` | `oracle/analysis/INDEX.md` | Read existing INDEX for update |
+| 35 | 12:49:10 | `edit` | `oracle/analysis/INDEX.md` | Updated with deep dive + brainstorm entries |
+| 36 | 12:49:14 | `write` | `oracle/plans/INDEX.md` | Created plans INDEX |
+| 37 | 12:49:18 | `edit` | Attempted edit to plans/INDEX.md (already written in step 36) | Redundant — file already correct |
+| 38 | 12:49:37 | `message` | Final completion report to Slack thread | Full summary with thesis, recommendation, and brainstorm highlights |
+| 39 | 12:49:38 | — | Text only: "Oracle deep dive v1 is done…" | Summary text (redundant with message tool — `message` already sent) |
+| 40 | 12:49:41 | — | "NO_REPLY" | Session ends. |
+
+---
+
+## Content Ingestion Map
+
+### Files Read by Main Session
+
+**Skill & Infrastructure Files (5 reads, 17,717 chars):**
+
+| # | File | Chars | Purpose |
+|---|---|---|---|
+| 1 | `skills/analyze-business/SKILL.md` | 6,397 | Main skill instructions |
+| 2 | `skills/analyze-business/references/deep-dive-checklist.md` | 3,103 | Report quality checklist |
+| 3 | `skills/research-evidence/SKILL.md` | 5,046 | Evidence management skill (read during v1, reused from context) |
+| 4 | `skills/brainstorm/SKILL.md` | 2,385 | Brainstorm skill instructions |
+| 5 | `oracle/analysis/INDEX.md` | 776 | INDEX update reference |
+
+**Wiki Sub-Pages (7 reads, 67,050 chars):**
+
+| # | File | Chars | Key Content |
+|---|---|---|---|
+| 6 | `wiki/pages/oracle/cloud-infrastructure.md` | 8,585 | OCI architecture, RPO ($553B), capex ($50B/year), demand signals, sovereign cloud |
+| 7 | `wiki/pages/oracle/ai-strategy.md` | 8,068 | OpenAI contract (~$300B), Stargate, RDMA networking, Meta/xAI |
+| 8 | `wiki/pages/oracle/database-multicloud.md` | 6,338 | Multi-cloud 1529% growth, Oracle 23ai, moat durability, PostgreSQL threat |
+| 9 | `wiki/pages/oracle/financial-trajectory.md` | 14,851 | Revenue acceleration, margin dynamics, balance sheet transformation |
+| 10 | `wiki/pages/oracle/governance-risk.md` | 12,291 | Ellison control, reference classes, telecom parallel, restructuring |
+| 11 | `wiki/pages/oracle/health.md` | 4,915 | Oracle Health / VA-Cerner, clinical AI |
+| 12 | `wiki/pages/oracle/applications-platform.md` | 6,256 | Fusion, NetSuite, 150x cross-sell, AI agents |
+
+Note: The main `oracle.md` structure note (5,746 chars) was read via `exec` (cat) rather than the `read` tool — functionally identical but not counted in `read` tool totals.
+
+**Structured Data Files (8 reads, 140,366 chars):**
+
+| # | File | Chars | Key Content |
+|---|---|---|---|
+| 13 | `oracle-key-financials.md` | 5,198 | FY2021–FY2025 + Q3 FY2026 financial summary |
+| 14 | `oracle-roic-analysis.md` | 28,038 | Total ROIC (10–12%), incremental ROIC (~2%), break-even math |
+| 15 | `oracle-scenario-analysis.md` | 27,798 | Bull $300 / Base $180 / Bear $85 / Catastrophic $50 |
+| 16 | `oracle-depreciation-wave-model.md` | 35,967 | D&A $3.9B → $12–20B by FY2029, EPS suppression |
+| 17 | `oracle-capital-allocation-history.md` | 20,528 | Buyback era ($57B) → capex era ($50B/year pivot) |
+| 18 | `oracle-competitive-positioning.md` | 4,591 | Market share, pricing, Flexera survey, Gartner DBMS |
+| 19 | `oracle-capex-and-balance-sheet-risk.md` | 4,096 | Debt, leases, credit rating, interest coverage |
+| 20 | `oracle-peer-valuation-comps.md` | 14,150 | ORCL vs CRM, SAP, NOW, WDAY, MSFT, AMZN, GOOGL |
+
+**Brainstorm Outputs (3 reads, 74,834 chars):**
+
+| # | File | Chars | Key Content |
+|---|---|---|---|
+| 21 | `brainstorm-dd-charlie.md` | 21,824 | Moat analysis, inference transition angle, scenario recalibration |
+| 22 | `brainstorm-dd-mauboussin.md` | 26,522 | Expectations decomposition, reverse-DCF, two-business ROIC, base rate calibration |
+| 23 | `brainstorm-dd-taleb.md` | 26,488 | Doom loop, true obligation set ($424B), false floor, fat tails |
+
+**Totals:**
+
+| Category | Reads | Chars |
+|---|---|---|
+| Skill & infrastructure | 5 | 17,717 |
+| Wiki sub-pages | 7 | 67,050 |
+| Structured data | 8 | 140,366 |
+| Brainstorm outputs | 3 | 74,834 |
+| **Total** | **23** | **299,967** |
+
+> All reads were full-file (100%). The agent never used `offset`/`limit` for partial reads.
+
+---
+
+## Think Steps (Full Transcripts)
+
+### Think 1: Initial Evidence Assessment (12:34:30 UTC)
+
+> No prior Oracle work in memory. Let me check the hard-disk for any existing Oracle evidence or company folder, and also check the wiki for any Oracle-related content.
+
+*Brief — just a routing decision to survey the evidence tree.*
+
+### Think 2: Evidence Landscape (12:34:44 UTC)
+
+> We have a rich evidence base for Oracle:
+>
+> Wiki:
+> - Main oracle.md structure note (comprehensive — I just read it)
+> - 7 sub-pages: cloud-infrastructure, ai-strategy, database-multicloud, financial-trajectory, health, applications-platform, governance-risk
+> - 1504 zettels total in wiki (many linked from the oracle pages)
+>
+> Evidence tree (12-oracle):
+> - Research: oci-vs-hyperscalers, oci-technical-performance, neocloud-economics, oracle-bear-cases
+> - Structured data: segment revenue time series, ROIC analysis, scenario analysis, depreciation wave model, competitive positioning, capex/balance sheet risk, capital allocation history, key financials, peer valuation comps
+> - References: bear cases, hyperscaler cloud segments, credit analysis, capex-rpo analysis, neocloud disclosures, non-flattering reference classes, OCI market position, CoreWeave S-1 highlights
+> - Sources: earnings transcripts (Q2-Q4 2024, Q2 2025, Q4 2025)
+> - Existing brainstorm output: charlie, mauboussin, taleb perspectives + summary
+> - Plans folder exists
+>
+> This is a very well-developed evidence base. The skill says to:
+> 1. Orient and plan — assess evidence vs checklist, write plan
+> 2. Draft — write the deep dive
+> 3. Strengthen — brainstorm against the analysis
+>
+> For v1 deep dive, I need to:
+> 1. Read the wiki pages and evidence files to assess readiness
+> 2. Write a plan
+> 3. Draft the report
+> 4. Run brainstorm to challenge it
+> 5. Revise
+>
+> This is going to be a big piece of work. Let me structure this carefully.
+>
+> First, let me read the sub-pages of the wiki to understand the evidence depth. Then I can assess gaps and write a plan. Then draft. Then brainstorm.
+>
+> Given the volume of material, I should read the key wiki sub-pages and structured data files. Let me batch the reads.
+>
+> Actually, this is a massive amount of work. Let me post a quick acknowledgment to Anton in the thread, then get to work.
+
+### Think 3: Comprehensive Assessment vs Checklist (12:35:47 UTC)
+
+> This is an extraordinarily rich evidence base. Let me take stock of what I have and what the skill requires:
+>
+> **Evidence assessment against the deep-dive checklist:**
+>
+> 1. **Evidence readiness** — Excellent. Seven wiki structure pages, extensive zettels, structured financial data (key financials, ROIC analysis, scenario analysis, peer comps, segment data, capital allocation, depreciation wave model, competitive positioning), five earnings transcripts, prior brainstorm output.
+>
+> 2. **Business and revenue model** — Well-covered across wiki pages (database-multicloud, applications-platform, cloud-infrastructure).
+>
+> 3. **Key value drivers** — Well-covered. The wiki identifies: OCI infrastructure growth, OpenAI contract execution, database multi-cloud consumption, margin trajectory, capital allocation.
+>
+> 4. **Industry, competition, ecosystem** — Covered in governance-risk (competitive landscape, reference classes), cloud-infrastructure (hyperscaler comps), structured data (peer valuation comps, competitive positioning).
+>
+> 5. **Outside view and base rates** — Excellent. Reference class analysis with telecom bubble, non-hyperscaler IaaS failure rate, leveraged pivot base rate, data center economics ceiling. ~10% base rate for earning above-WACC returns.
+>
+> 6. **Management, incentives, capital allocation** — Covered in governance-risk (Ellison control, new CEOs, CFO hire, compensation), financial-trajectory (buybacks to capex pivot), capital allocation history.
+>
+> 7. **Financial quality** — Excellent. ROIC analysis, key financials, scenario analysis, depreciation wave model, margin dynamics.
+>
+> 8. **Risk and fragility** — Excellent. Telecom bubble parallel, OpenAI concentration, $135B debt + $261B off-balance-sheet leases, Ellison pledged shares, credit downgrade risk.
+>
+> 9. **Change and optionality** — Covered in applications (AI agents, embedded finance, 150x cross-sell), health (clinical AI), database (multi-cloud consumption growth).
+>
+> 10. **Valuation and expectations** — Excellent. Scenario analysis with bull/base/bear/catastrophic, probability-weighted expected value, peer comps.
+>
+> 11. **Recommendation and monitorable judgment** — This is what the deep dive needs to provide.
+>
+> 12. **Adversarial checks** — Prior brainstorm exists but was for evidence collection. The skill says I need to run brainstorm against the ANALYSIS itself (the thesis, reasoning, weight given to evidence), not just the evidence base.
+>
+> **Gaps:**
+> - Evidence is strong across all checklist dimensions. The main gaps flagged in the wiki pages are:
+>   - Independent OCI performance benchmarks (sparse)
+>   - RPO cancellation clause details (undisclosed)
+>   - OpenAI actual consumption rate (undisclosed)
+>   - OCI utilization rates (undisclosed)
+>   - Oracle Health specific financials (undisclosed)
+>   - $261B off-balance-sheet lease composition (opaque)
+>
+> These are genuine information limitations, not research gaps we can fill. They should be disclosed in the report.
+>
+> **Plan:**
+> 1. Write the plan file
+> 2. Draft the deep dive, using the checklist as spine but writing it as a readable investment memo
+> 3. Run brainstorm against the analysis
+> 4. Revise based on brainstorm feedback
+>
+> Given the volume of material, this is going to be a substantial piece of work. Let me also read a few more key files: the depreciation wave model, capital allocation history, and competitive positioning, then write the plan and start drafting.
+>
+> Let me also check the current stock price and any very recent developments.
+
+### Think 4: Plan Finalization and Key Judgments (12:36:07 UTC)
+
+> I now have a comprehensive picture of the evidence base. Let me write the plan, then draft the deep dive. This is a massive amount of material, so the deep dive needs to be well-structured and judgment-heavy.
+>
+> Plan:
+> 1. Write plan file to evidence tree
+> 2. Draft the deep dive as a readable investment memo
+> 3. Run brainstorm against the analysis
+> 4. Revise
+>
+> Let me first check the plans folder to see numbering convention, then write the plan.
+>
+> Key judgments I need to form:
+> - What is Oracle really worth? The scenario analysis puts expected value at ~$161 vs ~$166 current price.
+> - Is the capex pivot value-creating or value-destroying? ROIC analysis says incremental ROIC has collapsed to ~2%.
+> - What's the right framework? Oracle is transitioning from software to infrastructure — which comp set matters?
+> - The telecom parallel is the sharpest risk analog.
+> - The database moat is the strongest bull argument that isn't about AI.
+>
+> Let me proceed to write the plan and then the full deep dive. I'll work in parallel chunks.
+
+### Think 5: Brainstorm Synthesis (12:46:42 UTC)
+
+> Excellent brainstorm output from all three. Let me synthesize the key feedback and decide what to incorporate into the revision:
+>
+> **Consensus across all three agents:**
+> 1. The ROIC framework is the right centerpiece and is well-executed
+> 2. The reference class analysis is valuable and honest
+> 3. The depreciation wave model is strong and underappreciated
+> 4. The recommendation is directionally correct (don't buy at $166)
+>
+> **Key disagreements and areas for revision:**
+>
+> **Charlie (more bullish):**
+> - Scenario probabilities may be too bearish — suggests 25/40/25/10 instead of 20/40/25/15
+> - Telecom reference class has a structural flaw (no software layer underneath)
+> - Multi-cloud database strategy is underweighted as a potential thesis-changer
+> - Inference transition is the biggest missing variable
+> - Short-term incremental ROIC overweighted (every infra build looks terrible during spending)
+> - OpenAI concentration overstated (it's a growing counterparty, not a cyclical one)
+> - Ellison margin call risk overstated (symptom, not cause)
+> - Suggests "small position with watchful eyes" rather than "pass entirely"
+> - Entry range should be $115-140, not a point target of $130
+>
+> **Mauboussin (more analytical/neutral):**
+> - Needs a reverse-DCF to discipline expectations analysis
+> - Should decompose ROIC into two businesses more explicitly
+> - WACC may be too generous at 9.5-10% — should be 11-12%
+> - The 10% base rate should be a range (10-25%) with explicit Oracle-specific adjustments
+> - Scenario weights need more explicit derivation
+> - The $130 entry point needs quantitative backing
+> - Time dimension is missing (near-term distribution favors base case)
+> - Multi-cloud database is underweighted as potential thesis-changer
+> - Slight bearish narrative bias detected
+>
+> **Taleb (more bearish):**
+> - The reflexive doom loop isn't modeled as a system
+> - True obligations are ~$424B (debt + leases + committed leases) vs $23B OCF = 18:1
+> - Catastrophic scenario is sanitized — true worst case is $15-30, not $50
+> - The database "floor" is a false floor for equity (negative equity after all obligations)
+> - Probability assignments are false precision on fat tails
+> - Bull should be 10% (matching base rate), not 20%
+> - Suggests "interesting" at $100-110, not $130
+> - Expected value framework fails for fat-tailed, one-shot bets
+> - Position sizing matters more than entry price
+>
+> **What I should revise in the deep dive:**
+>
+> 1. **Add the inference transition as a key variable** — Charlie's strongest point. Oracle's database position is MORE relevant for inference than training. This is underexplored.
+>
+> 2. **Strengthen the multi-cloud database coverage** — All three flagged this as underweighted. It's the highest-ROIC growth vector and potentially thesis-changing.
+>
+> 3. **Make the floor calculation more honest** — Taleb is right that the floor needs to account for the full obligation set ($424B). The current $41-51 is misleadingly precise. Add the honest math.
+>
+> 4. **Acknowledge the base rate should be a range, not a point** — Mauboussin is right. 10-20% with Oracle-specific adjustments is more honest than a single 10%.
+>
+> 5. **Add the two-business ROIC decomposition** — Mauboussin's suggestion is excellent. Separate the core franchise (~22-25% ROIC) from the infrastructure capital (~1-2% ROIC).
+>
+> 6. **Acknowledge the reflexive doom loop as a system** — Taleb is right that the risks are interconnected, not independent.
+>
+> 7. **Soften the precision of the $130 target** — Charlie and Mauboussin both flag this. Make it a range ($110-140).
+>
+> 8. **Keep the recommendation as "do not initiate"** — Charlie pushes toward "small position" but Taleb pushes harder the other way. The evidence supports the current recommendation being directionally right. I'll acknowledge the bull pushback but maintain the core call.
+>
+> 9. **Add acknowledgment of bearish tilt** — Mauboussin correctly detects this. Name it explicitly.
+>
+> Let me now revise the deep dive and write the brainstorm synthesis, then post to Anton.
+
+---
+
+## Subagent Details
+
+### Brainstorm Subagents (3 spawned simultaneously at 12:41:07 UTC)
+
+| Agent | Model Requested | Model Actual | Thinking | Start | End | Duration | Output |
+|---|---|---|---|---|---|---|---|
+| think-like-charlie-buffet | opus | claude-opus-4-6 | medium | 12:41:46 | 12:45:03 | 3m 17s | brainstorm-dd-charlie.md (21,824 chars) |
+| think-like-mauboussin | gemini-pro | claude-opus-4-6 | medium | 12:41:46 | 12:45:45 | 3m 59s | brainstorm-dd-mauboussin.md (26,522 chars) |
+| think-like-taleb | openai/gpt-5.5 | claude-opus-4-6 | medium | 12:41:46 | 12:45:58 | 4m 12s | brainstorm-dd-taleb.md (26,488 chars) |
+
+> **Note on model resolution:** All three subagents requested different models (opus, gemini-pro, openai/gpt-5.5) but all resolved to `claude-opus-4-6` according to the trajectory metadata. This could indicate model fallback behavior, a configuration override, or trajectory metadata recording the parent's model rather than the subagent's actual model. The output quality differences across the three agents (Charlie is more bullish, Mauboussin more analytical, Taleb more risk-focused) are driven by the prompt-pack persona, not the underlying model.
+
+### Brainstorm Consensus Map
+
+| Topic | Charlie | Mauboussin | Taleb |
+|---|---|---|---|
+| ROIC framework | ✅ Right centerpiece | ✅ Well-applied | ✅ Correct |
+| Reference classes | Structural flaw (no software layer) | Should be a range (10–25%) | May be generous |
+| Scenario weights | Too bearish (25/40/25/10) | Roughly defensible | Too generous to bull (10/40/30/20) |
+| Database moat | Underweighted as thesis-changer | Underweighted | Floor exists for business, not equity |
+| Recommendation | Small position at $115-140 | Correct, but $130 needs quantitative backing | Pass. Interesting at $100-110 |
+| Missing angle | Inference transition | Reverse-DCF, time dimension | Reflexive doom loop as a system |
+
+---
+
+## Output Artifacts
+
+| Artifact | Path | Chars | Written By |
+|---|---|---|---|
+| Deep dive report (revised) | `analysis/oracle-deep-dive-v1.md` | 41,016 | Main agent (draft) + 6 targeted edits (post-brainstorm) |
+| Deep dive plan | `plans/01-plan-oracle-deep-dive.md` | 4,069 | Main agent |
+| Brainstorm: Charlie | `analysis/brainstorm-dd-charlie.md` | 21,824 | Subagent (think-like-charlie-buffet) |
+| Brainstorm: Mauboussin | `analysis/brainstorm-dd-mauboussin.md` | 26,522 | Subagent (think-like-mauboussin) |
+| Brainstorm: Taleb | `analysis/brainstorm-dd-taleb.md` | 26,488 | Subagent (think-like-taleb) |
+| Brainstorm synthesis | `analysis/brainstorm-dd-synthesis.md` | 5,241 | Main agent |
+| Analysis INDEX | `analysis/INDEX.md` | 776 | Main agent (edited) |
+| Plans INDEX | `plans/INDEX.md` | 132 | Main agent |
+| Slack progress update | Thread 1777465648.712119 | ~200 chars | Main agent |
+| Slack final report | Thread 1777465648.712119 | ~2,500 chars | Main agent |
+| **Total output** | | **~126,068 chars** | |
+
+> Path prefix key: `analysis/` and `plans/` = `~/Documents/project-minerva/hard-disk/reports/00-companies/12-oracle/`
+
+---
+
+## Workflow Comparison: v1 vs v2
+
+| Aspect | v1 (Session `c53daaf0`) | v2 (Session `f250c081`) |
+|---|---|---|
+| Evidence surface | Evidence tree only (no wiki) | Wiki + evidence tree |
+| Wiki pages read | 0 | 7 sub-pages (67,050 chars) |
+| Structured data read | 7 files | 8 files |
+| Brainstorm skill | None | ✅ 3-agent brainstorm |
+| Brainstorm subagents | 0 | 3 (all Opus) |
+| Deep dive revisions | 0 | 6 targeted edits |
+| Post-brainstorm synthesis | No | Yes (brainstorm-dd-synthesis.md) |
+| Plan file | No | Yes (01-plan-oracle-deep-dive.md) |
+| Think steps | 3 | 5 |
+| Tool calls (main) | 27 | 56 |
+| Tool calls (total) | 27 | ~56 + subagent calls |
+| Wall time | ~8 min | ~15 min 22s |
+| Active work time | ~8 min | ~11 min (plus ~4 min idle waiting) |
+| Total chars read | 147,705 | 299,967 |
+| Deep dive output | 35,838 chars | 41,016 chars (revised) |
+| Total output | ~36,500 chars | ~126,068 chars |
+| Report quality | Good — linear synthesis | Stronger — brainstorm-tested, acknowledges biases, more nuanced |
+
+### Key Differences
+
+1. **Wiki as primary evidence surface.** v2 read all 7 Oracle wiki sub-pages (67K chars of synthesized knowledge) before touching the structured data files. v1 went directly to raw evidence files. The wiki provided a higher-level entry point that shaped the analysis structure.
+
+2. **Full skill workflow.** v2 followed the analyze-business skill completely: orient → plan → draft → brainstorm → revise. v1 skipped the plan and brainstorm steps.
+
+3. **Brainstorm as quality control.** The three-agent brainstorm surfaced concrete improvements:
+   - Inference transition as a missing key variable (Charlie)
+   - Two-business ROIC decomposition (Mauboussin)
+   - Reflexive doom loop as a system (Taleb)
+   - False precision in floor and entry targets (all three)
+   - Bearish narrative bias (Mauboussin)
+
+   All of these were incorporated as targeted edits to the deep dive, improving the final output without requiring a full rewrite.
+
+4. **Self-aware biases.** The revised deep dive explicitly acknowledges its own bearish tilt — a meta-quality that the v1 report lacked.
+
+5. **Output volume.** v2 produced ~3.4x more output than v1 (126K vs 37K chars) in ~2x the time, driven primarily by the brainstorm outputs (75K chars from subagents).
+
+---
+
+## Session Rhythm
+
+```
+08:34:19 ─── Run 1 starts ────────────────────────────────────────────────
+  08:34 | Skill + memory + checklist reads (orientation)
+  08:35 | Evidence tree exploration (6 exec commands)
+  08:35 | Think: evidence assessment + workflow plan
+  08:35 | Slack progress update
+  08:35 | Wiki sub-pages (7 reads in 2 batches, 67K chars)
+  08:35 | Think: comprehensive checklist assessment
+  08:36 | Structured data files (8 reads in 3 batches, 140K chars)
+  08:36 | Think: form key judgments + plan structure
+  08:37 | Write plan file (4K chars)
+  08:37–08:40 | Write deep dive draft (~36K chars, ~4 min generation)
+  08:41 | Read brainstorm skill → spawn 3 subagents → yield
+08:41:38 ─── Run 1 ends (7m 19s) ────────────────────────────────────────
+
+  ~~~ 3.5 minutes idle: brainstorm subagents running ~~~
+
+08:45:11 ─── Run 2 starts (Charlie's brainstorm arrives) ─────────────────
+  08:45 | Check subagent status → yield (Mauboussin + Taleb still running)
+08:45:24 ─── Run 2 ends (13s) ───────────────────────────────────────────
+
+08:45:54 ─── Run 3 starts (Mauboussin arrives) ──────────────────────────
+  08:46 | Yield (Taleb still running)
+08:45:58 ─── Run 3 ends (4s) ────────────────────────────────────────────
+
+08:46:07 ─── Run 4 starts (Taleb arrives) ───────────────────────────────
+  08:46 | Read 3 brainstorm outputs (75K chars)
+  08:47 | Think: synthesize all feedback, identify 9 revisions
+  08:47 | Write brainstorm synthesis (5K chars)
+  08:48 | 6 targeted edits to deep dive (revisions from brainstorm)
+  08:49 | Update INDEX files
+  08:49 | Post final report to Slack
+08:49:41 ─── Run 4 ends (3m 34s) ────────────────────────────────────────
+
+Total wall time: 15m 22s
+Active work: ~11m 10s across 4 runs
+Idle (waiting): ~4m 12s
+```
+
+---
+
+## Observations
+
+### 1. Wiki-First vs Evidence-First
+v2 read the wiki before the evidence files. This matters: the wiki pages are pre-synthesized summaries with inline zettel links, providing a structured entry point. v1 went directly to raw structured data. The wiki-first approach produced a better-organized analysis because the agent absorbed the narrative structure before diving into numbers.
+
+### 2. Deep Dive Generation: 4 Minutes for 36K Characters
+The single `write` call that produced the deep dive draft (step 18) took approximately 4 minutes — from 12:36:43 to 12:40:39. This is the session's longest individual operation. The ~36K character output was generated in a single model call with all previously-read evidence (300K+ chars) in context. The quality is remarkably high for a single pass, which is why the brainstorm revisions were targeted edits rather than a full rewrite.
+
+### 3. Brainstorm Efficiency
+The brainstorm phase added 4 minutes of idle wait time but produced 75K chars of pressure-testing across 3 distinct analytical lenses. The main agent's post-brainstorm synthesis (think step 5) is the session's longest and most substantive reasoning — it evaluated disagreements, prioritized 9 revisions, and decided which feedback to incorporate and which to acknowledge but not act on. The 6 targeted edits took under 2 minutes. The total brainstorm-to-revision cycle added ~7 minutes to the session (4 min idle + 3 min active) for a measurably better report.
+
+### 4. Model Resolution Anomaly
+All three brainstorm subagents were requested with different models (opus, gemini-pro, gpt-5.5) but all ran on claude-opus-4-6 per trajectory metadata. This suggests either: (a) model aliases resolved to the same underlying model, (b) fallback behavior due to availability, or (c) trajectory metadata records the session's base model rather than the per-call model. The output quality differences are driven entirely by the prompt-pack persona (SOUL.md, AGENTS.md) rather than the model.
+
+### 5. Edit-Based Revision > Rewrite
+The agent chose 6 targeted `edit` calls to revise the deep dive rather than regenerating the full report. This preserved the 36K characters of original prose while surgically incorporating the brainstorm feedback. The edits added ~5K characters of new content (inference transition section, two-business ROIC paragraph, doom loop section, revised floor analysis, revised recommendation). This is a much more efficient pattern than the alternative (rewrite the entire 41K document).
+
+### 6. No Partial Reads
+Consistent with all prior trace analyses: every `read` call was 100% of the file. The largest file read was `oracle-depreciation-wave-model.md` at 35,967 chars. No `offset`/`limit` parameters were used anywhere.
+
+### 7. Slack Discipline
+Exactly 2 Slack messages: one progress update at the start, one comprehensive final report. All intermediate reasoning stayed in `think` calls. The final report included thesis, recommendation, key reasoning bullet points, brainstorm highlights, and file paths — a complete summary that didn't require Anton to read the full 41K report to understand the conclusion.

--- a/docs/analysis/INDEX.md
+++ b/docs/analysis/INDEX.md
@@ -6,6 +6,7 @@
 | [01-zettel-wiki-v2-trace-analysis.md](./01-zettel-wiki-v2-trace-analysis.md) | Full session trace of the Zettel-Wiki v2 test run (Charlie): Opus orchestrator + 16 Flash subagents, 117 zettels from 62 raw source files, per-turn token table, full think step transcripts, batch 4 failure analysis, v1/v2 comparison. |
 | [02-zettel-wiki-v3-trace-analysis.md](./02-zettel-wiki-v3-trace-analysis.md) | Zettel-Wiki v3 trace analysis. |
 | [03-oracle-deep-dive-v1-session-trace.md](./03-oracle-deep-dive-v1-session-trace.md) | Full session trace of Oracle deep dive v1 (Charlie, Opus): 27 tool calls, 17 evidence files read, 84-source evidence base → 35,838-char investment memo. Includes execution flow diagram, tool usage breakdown, token efficiency analysis, and key decisions. |
+| [04-oracle-deep-dive-v2-session-trace.md](./04-oracle-deep-dive-v2-session-trace.md) | Full session trace of Oracle deep dive v2 (Charlie, Opus + 3 brainstorm subagents): 56 tool calls, 23 files read (300K chars), wiki-first evidence approach, full analyze-business skill workflow with brainstorm → revise cycle. 15m 22s wall time, 126K chars total output. |
 
 ## Notes
 - Session trace analyses and post-mortems for agent workflow runs.

--- a/src/harness/cli.py
+++ b/src/harness/cli.py
@@ -9,6 +9,7 @@ from typing import Callable
 import typer
 
 from harness.commands import register_commands
+from harness.commands.common import show_help_if_bare
 from harness.commands import analyze as analyze_commands
 from harness.commands import brief as brief_commands
 from harness.commands import evidence as evidence_commands
@@ -37,7 +38,8 @@ app = typer.Typer(
         "Minerva investment harness CLI.\n\n"
         "Examples:\n"
         "  minerva sec 10k AAPL --items 7\n"
-        "  minerva extract \"What are the key risks?\" --file apple-10k.md\n"
+        "  minerva extract -f apple-10k.md \"What are the key risks?\"\n"
+        "  minerva extract-files -q questions.md -F selected-files.txt -o data/extractions/summary\n"
         "  minerva run \"sec 10k AAPL --items 1A | extract 'What are the top 3 risk factors?'\"\n"
     ),
     add_completion=False,
@@ -62,6 +64,7 @@ def run_command(
     ),
 ) -> None:
     """Execute a shell-style command chain with pipes and short-circuit operators."""
+    show_help_if_bare(ctx, command=command)
     if not command:
         typer.echo(
             "What went wrong: no command chain was provided.\n"
@@ -220,7 +223,7 @@ def dispatch_command(argv: list[str], stdin: bytes = b"", settings: HarnessSetti
         "extract": lambda full_argv, current_settings, current_stdin: extract_commands.dispatch(
             full_argv[1:], settings=current_settings, stdin=current_stdin
         ),
-        "extract-many": lambda full_argv, current_settings, current_stdin: extract_commands.dispatch_many(
+        "extract-files": lambda full_argv, current_settings, current_stdin: extract_commands.dispatch_files(
             full_argv[1:], settings=current_settings, stdin=current_stdin
         ),
         "fileinfo": lambda full_argv, current_settings, current_stdin: fileinfo_commands.dispatch(
@@ -301,5 +304,4 @@ def _available_root_commands() -> list[str]:
         names.add(command_info.name or command_info.callback.__name__.replace("_", "-"))
     for group_info in app.registered_groups:
         names.add(group_info.name or "group")
-    names.add("extract-many")
     return sorted(names)

--- a/src/harness/commands/__init__.py
+++ b/src/harness/commands/__init__.py
@@ -17,6 +17,6 @@ def register_commands(app: typer.Typer) -> None:
     app.add_typer(analyze.app, name="analyze")
     app.add_typer(plot.app, name="plot")
     app.add_typer(extract.app, name="extract")
-    app.add_typer(extract.extract_many_app, name="extract-many")
+    app.add_typer(extract.extract_files_app, name="extract-files")
     app.add_typer(fileinfo.app, name="fileinfo")
     app.add_typer(research.app, name="research")

--- a/src/harness/commands/common.py
+++ b/src/harness/commands/common.py
@@ -56,6 +56,31 @@ def error_result(
     )
 
 
+def _is_bare_default(v: object) -> bool:
+    """True only for None or empty list/tuple — the values Typer uses for unprovided args.
+
+    Deliberately narrow: does NOT treat False, 0, or "" as bare.
+    Typer passes None for unprovided Optional args and None for unprovided list options.
+    """
+    if v is None:
+        return True
+    if isinstance(v, (list, tuple)) and len(v) == 0:
+        return True
+    return False
+
+
+def show_help_if_bare(ctx: typer.Context, **kwargs: object) -> None:
+    """If every kwarg is an unprovided default (None or empty collection), print help and exit 0.
+
+    Call as the first line of a Typer callback to give bare invocations clean help
+    instead of an error message.  Pass only user-facing parameters that indicate intent —
+    not defaults like model/max_tokens/concurrency that always have values.
+    """
+    if all(_is_bare_default(v) for v in kwargs.values()):
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
+
+
 def abort_with_help(
     ctx: typer.Context,
     *,

--- a/src/harness/commands/extract.py
+++ b/src/harness/commands/extract.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import glob as _glob
+import hashlib
+import json
 import time
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -12,8 +17,8 @@ from harness.commands.common import (
     abort_with_help,
     elapsed_ms,
     error_result,
-    parse_flag_args,
-    read_text_input,
+    show_help_if_bare,
+    resolve_path,
 )
 from harness.config import HarnessSettings, get_settings
 from harness.output import CommandResult, OutputEnvelope
@@ -21,88 +26,85 @@ from harness.output import CommandResult, OutputEnvelope
 EXTRACT_HELP = (
     "LLM-powered information extraction from large text documents.\n\n"
     "Examples:\n"
-    "  minerva extract \"What is the revenue by segment?\" --file apple-10k.md\n"
-    "  minerva extract-many --file apple-10k.md \"Revenue by segment\" \"Key risk factors\"\n"
+    "  minerva extract -f apple-10k.md \"What is the revenue by segment?\"\n"
+    "  minerva extract -q questions.md -f apple-10k.md\n"
     "  minerva run \"sec 10k AAPL --items 1A | extract 'What are the top 3 risk factors?'\"\n"
 )
 
-DEFAULT_MODEL = "gemini-3-flash"
-SYSTEM_PROMPT = (
-    "Extract information relevant to the following question. "
-    "Be concise and specific. Cite section/page numbers when possible."
+EXTRACT_FILES_HELP = (
+    "Apply one extraction prompt or question pack across many UTF-8 text/markdown files.\n\n"
+    "Examples:\n"
+    "  minerva extract-files \\\n"
+    "    -f 'data/sources/**/*.md' -o data/extractions/churn \\\n"
+    "    \"What does management say about churn?\"\n"
+    "  minerva extract-files -q questions.md \\\n"
+    "    -f oracle/income.md -f microsoft/q3-call.md \\\n"
+    "    -f amazon/q1-call.md -o data/extractions/cross-company\n"
+    "  minerva extract-files -q questions.md -F selected-files.txt \\\n"
+    "    -o data/extractions/summary\n"
+    "  minerva extract-files --questions-file questions.md \\\n"
+    "    --files 'data/sources/**/*.md' --out data/extractions/summary \\\n"
+    "    --model gemini-3-flash --thinking minimal --concurrency 4\n"
 )
 
+DEFAULT_MODEL = "gemini-3-flash"
+DEFAULT_MAX_TOKENS = 4096
+DEFAULT_CONCURRENCY = 4
+MODEL_ALIASES: dict[str, str] = {
+    # OpenClaw/user-facing shorthand; Google GenAI expects the preview model id today.
+    "gemini-3-flash": "gemini-3-flash-preview",
+}
+UNSUPPORTED_TEXT_EXTRACTION_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".pdf",
+        ".doc",
+        ".docx",
+        ".xls",
+        ".xlsx",
+        ".ppt",
+        ".pptx",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".zip",
+        ".gz",
+        ".tar",
+    }
+)
+
+SYSTEM_PROMPT = (
+    "Extract information relevant to the prompt below. Be concise and specific. "
+    "Cite section/page numbers when possible. If the prompt contains multiple "
+    "questions, answer each under a clearly labeled markdown heading."
+)
+
+VALID_THINKING_LEVELS: frozenset[str] = frozenset({"off", "minimal", "low", "medium", "high", "adaptive"})
+
 app = typer.Typer(help=EXTRACT_HELP, no_args_is_help=False, invoke_without_command=True)
-extract_many_app = typer.Typer(help=EXTRACT_HELP, no_args_is_help=False, invoke_without_command=True)
+extract_files_app = typer.Typer(help=EXTRACT_FILES_HELP, no_args_is_help=False, invoke_without_command=True)
+
+
+# ---------------------------------------------------------------------------
+# `extract`
+# ---------------------------------------------------------------------------
 
 
 def dispatch(args: list[str], settings: HarnessSettings | None = None, stdin: bytes = b"") -> CommandResult:
-    """Dispatch the single-question extract command for `minerva run`."""
+    """Dispatch the `extract` command for `minerva run`."""
     active_settings = settings or get_settings()
-    if not args:
-        return CommandResult.from_text(
-            "",
-            stderr=_usage_error(
-                "no extraction question was provided",
-                "pass a question and either `--file PATH` or piped stdin",
-                ["`extract \"What is the revenue by segment?\" --file apple-10k.md`", "`extract-many --file apple-10k.md \"Revenue by segment\" \"Key risks\"`"],
-                EXTRACT_HELP,
-            ),
-            exit_code=1,
-        )
-
-    question = args[0]
     try:
-        parsed = parse_flag_args(args[1:])
+        parsed = _parse_extract_args(args)
     except ValueError as exc:
         return CommandResult.from_text("", stderr=str(exc), exit_code=1)
     return extract_command(
-        question=question,
-        file_path=str(parsed["file"]) if "file" in parsed else None,
-        model=str(parsed.get("model", DEFAULT_MODEL)),
-        max_tokens=int(parsed.get("max-tokens", 4096)),
-        stdin=stdin,
-        settings=active_settings,
-    )
-
-
-def dispatch_many(args: list[str], settings: HarnessSettings | None = None, stdin: bytes = b"") -> CommandResult:
-    """Dispatch the multi-question extract command for `minerva run`."""
-    active_settings = settings or get_settings()
-    file_path: str | None = None
-    questions_file: str | None = None
-    model: str = DEFAULT_MODEL
-    max_tokens: int = 4096
-    questions: list[str] = []
-
-    index = 0
-    while index < len(args):
-        token = args[index]
-        if token == "--file" and index + 1 < len(args):
-            file_path = args[index + 1]
-            index += 2
-            continue
-        if token == "--questions-file" and index + 1 < len(args):
-            questions_file = args[index + 1]
-            index += 2
-            continue
-        if token == "--model" and index + 1 < len(args):
-            model = args[index + 1]
-            index += 2
-            continue
-        if token == "--max-tokens" and index + 1 < len(args):
-            max_tokens = int(args[index + 1])
-            index += 2
-            continue
-        questions.append(token)
-        index += 1
-
-    return extract_many_command(
-        questions=questions,
-        file_path=file_path,
-        questions_file=questions_file,
-        model=model,
-        max_tokens=max_tokens,
+        question=parsed.question,
+        questions_file=parsed.questions_file,
+        file_path=parsed.file_path,
+        model=parsed.model,
+        max_tokens=parsed.max_tokens,
+        thinking=parsed.thinking,
         stdin=stdin,
         settings=active_settings,
     )
@@ -110,10 +112,12 @@ def dispatch_many(args: list[str], settings: HarnessSettings | None = None, stdi
 
 def extract_command(
     *,
-    question: str,
+    question: str | None = None,
+    questions_file: str | None = None,
     file_path: str | None = None,
     model: str = DEFAULT_MODEL,
-    max_tokens: int = 4096,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    thinking: str | None = None,
     stdin: bytes = b"",
     settings: HarnessSettings | None = None,
 ) -> CommandResult:
@@ -123,36 +127,151 @@ def extract_command(
         return error_result(
             "GEMINI_API_KEY is not set",
             "set GEMINI_API_KEY and retry",
-            ["`export GEMINI_API_KEY=...`", "`minerva analyze ngrams sample.txt`"],
+            ["`export GEMINI_API_KEY=...`"],
             start,
         )
     try:
-        document_text = read_text_input(file_path=file_path, stdin=stdin)
+        prompt_pack = _build_prompt_pack(question=question, questions_file=questions_file)
+        document_text = _read_document_text(file_path=file_path, stdin=stdin)
+        resolved_thinking = _resolve_default_thinking(model, thinking)
+        # Validate thinking config before any network call.
+        _build_thinking_config(model, resolved_thinking)
+        prompt = _compose_prompt(prompt_pack=prompt_pack, document_text=document_text)
         answer = _generate_answer(
-            question=question,
+            prompt=prompt,
             document_text=document_text,
             model=model,
             max_tokens=max_tokens,
+            thinking=resolved_thinking,
             api_key=active_settings.gemini_api_key,
         )
-    except Exception as exc:
+    except _UsageError as exc:
+        return error_result(
+            exc.what,
+            exc.what_to_do,
+            exc.alternatives,
+            start,
+        )
+    except ValueError as exc:
+        return error_result(
+            f"invalid extraction configuration: {exc}",
+            "use a supported model/thinking combination, or omit `--thinking`",
+            ["`--thinking minimal` for gemini-3-*", "`--thinking adaptive` for gemini-2.5-*"],
+            start,
+        )
+    except Exception as exc:  # noqa: BLE001
         return error_result(
             f"extraction failed: {exc}",
             "verify the input source, Gemini API key, and model name, then retry",
-            ["`extract \"What is the revenue by segment?\" --file apple-10k.md`", "`extract-many --file apple-10k.md \"Revenue by segment\" \"Key risks\"`"],
+            [
+                "`extract \"What is the revenue by segment?\" --file apple-10k.md`",
+                "`extract --questions-file questions.md --file apple-10k.md`",
+            ],
             start,
         )
     return CommandResult.from_text(answer.strip(), duration_ms=elapsed_ms(start))
 
 
-def extract_many_command(
+@app.callback()
+def extract_cli_command(
+    ctx: typer.Context,
+    question: str | None = typer.Argument(None, help="Question or prompt to apply to the input document."),
+    file_path: str | None = typer.Option(None, "--file", "-f", help="Path to a text file. Omit to read from stdin."),
+    questions_file: str | None = typer.Option(
+        None,
+        "--questions-file",
+        "-q",
+        help="Markdown file containing the question/prompt pack to apply to the input document.",
+    ),
+    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Gemini model to use."),
+    max_tokens: int = typer.Option(DEFAULT_MAX_TOKENS, "--max-tokens", help="Maximum response tokens."),
+    thinking: str | None = typer.Option(
+        None,
+        "--thinking",
+        help="Thinking level: off|minimal|low|medium|high|adaptive (model-aware).",
+    ),
+) -> None:
+    """Run a single extraction call against an input document.
+
+    Example:
+      minerva extract "What is the revenue by segment?" --file apple-10k.md
+      minerva extract --questions-file questions.md --file apple-10k.md
+    """
+    show_help_if_bare(ctx, question=question, file_path=file_path, questions_file=questions_file)
+    if not question and not questions_file:
+        abort_with_help(
+            ctx,
+            what_went_wrong="no extraction prompt was provided",
+            what_to_do="pass a positional question, `--questions-file PATH`, or both",
+            alternatives=[
+                "`minerva extract \"What is the revenue by segment?\" --file apple-10k.md`",
+                "`minerva extract --questions-file questions.md --file apple-10k.md`",
+            ],
+        )
+    stdin = b"" if file_path else typer.get_binary_stream("stdin").read()
+    if not file_path and not stdin:
+        abort_with_help(
+            ctx,
+            what_went_wrong="no input document was provided for `extract`",
+            what_to_do="pass `--file PATH` or pipe text into the command",
+            alternatives=[
+                "`minerva extract \"What is the revenue by segment?\" --file apple-10k.md`",
+                "`minerva run \"sec 10k AAPL --items 7 | extract 'Revenue by segment'\"`",
+            ],
+        )
+    _print(
+        extract_command(
+            question=question,
+            questions_file=questions_file,
+            file_path=file_path,
+            model=model,
+            max_tokens=max_tokens,
+            thinking=thinking,
+            stdin=stdin,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# `extract-files`
+# ---------------------------------------------------------------------------
+
+
+def dispatch_files(args: list[str], settings: HarnessSettings | None = None, stdin: bytes = b"") -> CommandResult:
+    """Dispatch the `extract-files` command for `minerva run`."""
+    _ = stdin  # extract-files does not consume stdin
+    active_settings = settings or get_settings()
+    try:
+        parsed = _parse_extract_files_args(args)
+    except ValueError as exc:
+        return CommandResult.from_text("", stderr=str(exc), exit_code=1)
+    return extract_files_command(
+        question=parsed.question,
+        questions_file=parsed.questions_file,
+        files=parsed.files,
+        files_from=parsed.files_from,
+        out=parsed.out,
+        model=parsed.model,
+        max_tokens=parsed.max_tokens,
+        thinking=parsed.thinking,
+        concurrency=parsed.concurrency,
+        force=parsed.force,
+        settings=active_settings,
+    )
+
+
+def extract_files_command(
     *,
-    questions: list[str],
-    file_path: str | None = None,
+    question: str | None = None,
     questions_file: str | None = None,
+    files: list[str] | None = None,
+    files_from: str | None = None,
+    out: str | None = None,
     model: str = DEFAULT_MODEL,
-    max_tokens: int = 4096,
-    stdin: bytes = b"",
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    thinking: str | None = None,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    force: bool = False,
     settings: HarnessSettings | None = None,
 ) -> CommandResult:
     start = time.perf_counter()
@@ -161,165 +280,673 @@ def extract_many_command(
         return error_result(
             "GEMINI_API_KEY is not set",
             "set GEMINI_API_KEY and retry",
-            ["`export GEMINI_API_KEY=...`", "`minerva analyze topics sample.txt`"],
+            ["`export GEMINI_API_KEY=...`"],
+            start,
+        )
+    if not out:
+        return error_result(
+            "no output directory was provided",
+            "pass `--out DIR` so per-file extractions are written somewhere durable",
+            ["`extract-files \"Q\" --files 'data/**/*.md' --out data/extractions/q`"],
             start,
         )
     try:
-        merged_questions = _merge_questions(questions, questions_file)
-        if not merged_questions:
-            raise ValueError("at least one question is required")
-        document_text = read_text_input(file_path=file_path, stdin=stdin)
-        answers = asyncio.run(
-            _gather_answers(
-                questions=merged_questions,
-                document_text=document_text,
-                model=model,
-                max_tokens=max_tokens,
-                api_key=active_settings.gemini_api_key,
-            )
-        )
-    except Exception as exc:
+        prompt_pack = _build_prompt_pack(question=question, questions_file=questions_file)
+    except _UsageError as exc:
+        return error_result(exc.what, exc.what_to_do, exc.alternatives, start)
+
+    if not files and not files_from:
         return error_result(
-            f"parallel extraction failed: {exc}",
-            "verify the input source, question list, Gemini API key, and model name, then retry",
-            ["`extract-many --file apple-10k.md \"Revenue by segment\" \"Key risks\"`", "`extract \"What is the revenue by segment?\" --file apple-10k.md`"],
+            "no input files were provided",
+            "pass one or more `--files PATH_OR_GLOB` values or `--files-from LIST`",
+            [
+                "`extract-files \"Q\" --files data/sources/a.md --out out/`",
+                "`extract-files \"Q\" --files-from files.txt --out out/`",
+            ],
             start,
         )
-    output = "\n\n".join(f"## {question}\n{answer.strip()}" for question, answer in zip(merged_questions, answers, strict=False))
-    return CommandResult.from_text(output, duration_ms=elapsed_ms(start))
 
+    try:
+        resolved_files = _expand_file_inputs(files or [], files_from=files_from)
+    except _UsageError as exc:
+        return error_result(exc.what, exc.what_to_do, exc.alternatives, start)
 
-@app.callback()
-def extract_cli_command(
-    ctx: typer.Context,
-    question: str | None = typer.Argument(None, help="Question to answer about the input document."),
-    file_path: str | None = typer.Option(None, "--file", help="Path to a text file. Omit to read from stdin."),
-    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Gemini model to use."),
-    max_tokens: int = typer.Option(4096, "--max-tokens", help="Maximum response tokens."),
-) -> None:
-    """Ask one focused question about input text.
-
-    Example:
-      minerva extract "What is the revenue by segment?" --file apple-10k.md
-    """
-    stdin = typer.get_binary_stream("stdin").read()
-    if not question:
-        abort_with_help(
-            ctx,
-            what_went_wrong="no extraction question was provided",
-            what_to_do="pass a question and either `--file PATH` or piped stdin",
-            alternatives=["`minerva extract \"What is the revenue by segment?\" --file apple-10k.md`", "`minerva extract-many --file apple-10k.md \"Revenue by segment\" \"Key risks\"`"],
+    resolved_thinking = _resolve_default_thinking(model, thinking)
+    try:
+        _build_thinking_config(model, resolved_thinking)
+    except ValueError as exc:
+        return error_result(
+            f"invalid thinking config: {exc}",
+            "use a thinking level supported by the selected model, or omit `--thinking`",
+            ["`--thinking minimal` for gemini-3-*", "`--thinking adaptive` for gemini-2.5-*"],
+            start,
         )
-    if not file_path and not stdin:
-        abort_with_help(
-            ctx,
-            what_went_wrong="no input document was provided for `extract`",
-            what_to_do="pass `--file PATH` or pipe text into the command",
-            alternatives=["`minerva extract \"What is the revenue by segment?\" --file apple-10k.md`", "`minerva run \"sec 10k AAPL --items 7 | extract 'Revenue by segment'\"`"],
-        )
-    _print(extract_command(question=question, file_path=file_path, model=model, max_tokens=max_tokens, stdin=stdin))
 
-
-@extract_many_app.callback()
-def extract_many_cli_command(
-    ctx: typer.Context,
-    questions: list[str] = typer.Argument(None, help="One or more questions."),
-    file_path: str | None = typer.Option(None, "--file", help="Path to a text file. Omit to read from stdin."),
-    questions_file: str | None = typer.Option(None, "--questions-file", help="Path to a file with one question per line."),
-    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Gemini model to use."),
-    max_tokens: int = typer.Option(4096, "--max-tokens", help="Maximum response tokens per answer."),
-) -> None:
-    """Ask multiple questions about the same document concurrently.
-
-    Example:
-      minerva extract-many --file apple-10k.md "Revenue by segment" "Key risk factors"
-    """
-    stdin = typer.get_binary_stream("stdin").read()
-    if not questions and not questions_file:
-        abort_with_help(
-            ctx,
-            what_went_wrong="no extraction questions were provided",
-            what_to_do="pass question arguments, `--questions-file`, or both",
-            alternatives=["`minerva extract extract-many --file apple-10k.md \"Revenue by segment\" \"Key risks\"`", "`minerva extract \"What is the revenue by segment?\" --file apple-10k.md`"],
+    if concurrency < 1:
+        return error_result(
+            f"--concurrency must be >= 1 (got {concurrency})",
+            "pass `--concurrency` >= 1",
+            ["`--concurrency 4`"],
+            start,
         )
-    if not file_path and not stdin:
-        abort_with_help(
-            ctx,
-            what_went_wrong="no input document was provided for `extract-many`",
-            what_to_do="pass `--file PATH` or pipe text into the command",
-            alternatives=["`minerva extract extract-many --file apple-10k.md \"Revenue by segment\" \"Key risks\"`", "`minerva run \"sec 10k AAPL --items 7 | extract-many 'Revenue by segment' 'Key risks'\"`"],
-        )
-    _print(
-        extract_many_command(
-            questions=questions,
-            file_path=file_path,
-            questions_file=questions_file,
+
+    out_root = resolve_path(out)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    # Plan output paths (mirroring relative paths under common parent).
+    plan = _plan_output_paths(resolved_files, out_root)
+
+    # Pre-check overwrite when not --force.
+    if not force:
+        collisions = [str(target) for _, target in plan if target.exists()]
+        if collisions:
+            preview = ", ".join(collisions[:3])
+            return error_result(
+                f"{len(collisions)} output file(s) already exist (e.g. {preview})",
+                "pass `--force` to overwrite existing outputs, or choose a different `--out`",
+                ["`--force`", "`--out <fresh-dir>`"],
+                start,
+            )
+
+    entries: list[dict[str, Any]] = asyncio.run(
+        _run_extractions(
+            plan=plan,
+            prompt_pack=prompt_pack,
             model=model,
             max_tokens=max_tokens,
-            stdin=stdin,
+            thinking=resolved_thinking,
+            api_key=active_settings.gemini_api_key,
+            concurrency=concurrency,
+        )
+    )
+
+    manifest = {
+        "model": model,
+        "api_model": _api_model_name(model),
+        "thinking": resolved_thinking,
+        "max_tokens": max_tokens,
+        "questions_file": str(resolve_path(questions_file)) if questions_file else None,
+        "question": question,
+        "out": str(out_root),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "entries": entries,
+    }
+    (out_root / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    failures = [entry for entry in entries if entry["status"] != "ok"]
+    summary_lines = [
+        f"wrote {len(entries) - len(failures)} extraction(s) under {out_root}",
+        f"manifest: {out_root / 'manifest.json'}",
+    ]
+    if failures:
+        summary_lines.append(f"{len(failures)} extraction(s) failed; see manifest for details.")
+        return CommandResult.from_text(
+            "\n".join(summary_lines),
+            stderr=f"{len(failures)} extraction(s) failed",
+            exit_code=1,
+            duration_ms=elapsed_ms(start),
+        )
+    return CommandResult.from_text("\n".join(summary_lines), duration_ms=elapsed_ms(start))
+
+
+@extract_files_app.callback()
+def extract_files_cli_command(
+    ctx: typer.Context,
+    question: str | None = typer.Argument(None, help="Question or prompt to apply to each input file."),
+    files: list[str] = typer.Option(
+        None,
+        "--files",
+        "-f",
+        help="One or more UTF-8 text/markdown source file paths or glob patterns (repeatable).",
+    ),
+    files_from: str | None = typer.Option(
+        None,
+        "--files-from",
+        "-F",
+        help="Newline-delimited file containing source paths or globs; relative entries resolve from the list file's directory.",
+    ),
+    out: str | None = typer.Option(None, "--out", "-o", help="Output directory for per-file markdown results."),
+    questions_file: str | None = typer.Option(
+        None,
+        "--questions-file",
+        "-q",
+        help="Markdown file containing the question/prompt pack to apply to each source file.",
+    ),
+    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Gemini model to use."),
+    max_tokens: int = typer.Option(DEFAULT_MAX_TOKENS, "--max-tokens", help="Maximum response tokens per file."),
+    thinking: str | None = typer.Option(
+        None,
+        "--thinking",
+        help="Thinking level: off|minimal|low|medium|high|adaptive (model-aware).",
+    ),
+    concurrency: int = typer.Option(DEFAULT_CONCURRENCY, "--concurrency", help="Bounded concurrency (>=1)."),
+    force: bool = typer.Option(False, "--force", help="Overwrite existing output files."),
+) -> None:
+    """Apply one extraction prompt across many files, writing one markdown output per file."""
+    show_help_if_bare(ctx, question=question, files=files, files_from=files_from, questions_file=questions_file, out=out)
+    if not question and not questions_file:
+        abort_with_help(
+            ctx,
+            what_went_wrong="no extraction prompt was provided",
+            what_to_do="pass a positional question, `--questions-file PATH`, or both",
+            alternatives=[
+                "`minerva extract-files \"Q\" --files 'data/**/*.md' --out out/`",
+                "`minerva extract-files --questions-file questions.md --files data/a.md --out out/`",
+            ],
+        )
+    if not files and not files_from:
+        abort_with_help(
+            ctx,
+            what_went_wrong="no input files were provided",
+            what_to_do="pass one or more `--files PATH_OR_GLOB` values or `--files-from LIST`",
+            alternatives=["`--files data/a.md --files data/b.md`", "`--files 'data/**/*.md'`", "`--files-from files.txt`"],
+        )
+    if not out:
+        abort_with_help(
+            ctx,
+            what_went_wrong="no `--out` directory was provided",
+            what_to_do="pass `--out DIR` so per-file extractions are written somewhere durable",
+            alternatives=["`--out data/extractions/q`"],
+        )
+    _print(
+        extract_files_command(
+            question=question,
+            questions_file=questions_file,
+            files=list(files or []),
+            files_from=files_from,
+            out=out,
+            model=model,
+            max_tokens=max_tokens,
+            thinking=thinking,
+            concurrency=concurrency,
+            force=force,
         )
     )
 
 
-def _generate_answer(*, question: str, document_text: str, model: str, max_tokens: int, api_key: str) -> str:
+# ---------------------------------------------------------------------------
+# Argument parsing helpers (run-chain)
+# ---------------------------------------------------------------------------
+
+
+class _UsageError(Exception):
+    def __init__(self, what: str, what_to_do: str, alternatives: list[str]) -> None:
+        super().__init__(what)
+        self.what = what
+        self.what_to_do = what_to_do
+        self.alternatives = alternatives
+
+
+class _ExtractArgs:
+    __slots__ = ("question", "questions_file", "file_path", "model", "max_tokens", "thinking")
+
+    def __init__(self) -> None:
+        self.question: str | None = None
+        self.questions_file: str | None = None
+        self.file_path: str | None = None
+        self.model: str = DEFAULT_MODEL
+        self.max_tokens: int = DEFAULT_MAX_TOKENS
+        self.thinking: str | None = None
+
+
+class _ExtractFilesArgs:
+    __slots__ = (
+        "question",
+        "questions_file",
+        "files",
+        "files_from",
+        "out",
+        "model",
+        "max_tokens",
+        "thinking",
+        "concurrency",
+        "force",
+    )
+
+    def __init__(self) -> None:
+        self.question: str | None = None
+        self.questions_file: str | None = None
+        self.files: list[str] = []
+        self.files_from: str | None = None
+        self.out: str | None = None
+        self.model: str = DEFAULT_MODEL
+        self.max_tokens: int = DEFAULT_MAX_TOKENS
+        self.thinking: str | None = None
+        self.concurrency: int = DEFAULT_CONCURRENCY
+        self.force: bool = False
+
+
+def _parse_extract_args(args: list[str]) -> _ExtractArgs:
+    parsed = _ExtractArgs()
+    positionals: list[str] = []
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in {"--file", "-f"}:
+            parsed.file_path = _require_value(args, i, token)
+            i += 2
+        elif token in {"--questions-file", "-q"}:
+            parsed.questions_file = _require_value(args, i, token)
+            i += 2
+        elif token == "--model":
+            parsed.model = _require_value(args, i, token)
+            i += 2
+        elif token == "--max-tokens":
+            parsed.max_tokens = int(_require_value(args, i, token))
+            i += 2
+        elif token == "--thinking":
+            parsed.thinking = _require_value(args, i, token)
+            i += 2
+        elif token.startswith("--"):
+            raise ValueError(f"unknown flag for `extract`: `{token}`")
+        else:
+            positionals.append(token)
+            i += 1
+    if len(positionals) > 1:
+        raise ValueError(f"too many positional arguments for `extract`: {positionals}")
+    if positionals:
+        parsed.question = positionals[0]
+    return parsed
+
+
+def _parse_extract_files_args(args: list[str]) -> _ExtractFilesArgs:
+    parsed = _ExtractFilesArgs()
+    positionals: list[str] = []
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in {"--files", "-f"}:
+            parsed.files.append(_require_value(args, i, token))
+            i += 2
+        elif token in {"--files-from", "-F"}:
+            parsed.files_from = _require_value(args, i, token)
+            i += 2
+        elif token in {"--questions-file", "-q"}:
+            parsed.questions_file = _require_value(args, i, token)
+            i += 2
+        elif token in {"--out", "-o"}:
+            parsed.out = _require_value(args, i, token)
+            i += 2
+        elif token == "--model":
+            parsed.model = _require_value(args, i, token)
+            i += 2
+        elif token == "--max-tokens":
+            parsed.max_tokens = int(_require_value(args, i, token))
+            i += 2
+        elif token == "--thinking":
+            parsed.thinking = _require_value(args, i, token)
+            i += 2
+        elif token == "--concurrency":
+            parsed.concurrency = int(_require_value(args, i, token))
+            i += 2
+        elif token == "--force":
+            parsed.force = True
+            i += 1
+        elif token.startswith("--"):
+            raise ValueError(f"unknown flag for `extract-files`: `{token}`")
+        else:
+            positionals.append(token)
+            i += 1
+    if len(positionals) > 1:
+        raise ValueError(f"too many positional arguments for `extract-files`: {positionals}")
+    if positionals:
+        parsed.question = positionals[0]
+    return parsed
+
+
+def _require_value(args: list[str], index: int, flag: str) -> str:
+    if index + 1 >= len(args):
+        raise ValueError(f"missing value for flag `{flag}`")
+    return args[index + 1]
+
+
+# ---------------------------------------------------------------------------
+# Prompt / input helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt_pack(*, question: str | None, questions_file: str | None) -> str:
+    sections: list[str] = []
+    if question and question.strip():
+        sections.append(question.strip())
+    if questions_file:
+        path = resolve_path(questions_file)
+        if not path.exists():
+            raise _UsageError(
+                f"questions file not found: {questions_file}",
+                "pass an existing path to `--questions-file`",
+                ["`--questions-file path/to/questions.md`"],
+            )
+        raw = path.read_text(encoding="utf-8")
+        body = raw.strip("\n")
+        body = body.strip()
+        if not body:
+            raise _UsageError(
+                f"questions file is empty: {questions_file}",
+                "populate the file with a markdown prompt or question pack",
+                ["`--questions-file path/to/questions.md`"],
+            )
+        sections.append(body)
+    if not sections:
+        raise _UsageError(
+            "no extraction prompt was provided",
+            "pass a positional question, `--questions-file PATH`, or both",
+            [
+                "`extract \"Q\" --file doc.md`",
+                "`extract --questions-file questions.md --file doc.md`",
+            ],
+        )
+    if len(sections) == 1:
+        return sections[0]
+    return "\n\n".join(
+        [
+            "# Inline question",
+            sections[0],
+            "",
+            "# Question pack",
+            sections[1],
+        ]
+    )
+
+
+def _read_document_text(*, file_path: str | None, stdin: bytes) -> str:
+    if file_path:
+        return resolve_path(file_path).read_text(encoding="utf-8")
+    if stdin:
+        return stdin.decode("utf-8", errors="replace")
+    raise _UsageError(
+        "no input document was provided",
+        "pass `--file PATH` or pipe text into the command",
+        ["`--file path/to/doc.md`"],
+    )
+
+
+def _compose_prompt(*, prompt_pack: str, document_text: str) -> str:
+    return f"{SYSTEM_PROMPT}\n\nPrompt:\n{prompt_pack}\n\nDocument:\n{document_text}"
+
+
+# ---------------------------------------------------------------------------
+# Thinking config helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_default_thinking(model: str, explicit: str | None) -> str | None:
+    if explicit is not None:
+        return explicit
+    if _is_gemini_3_flash(model):
+        return "minimal"
+    return None
+
+
+def _build_thinking_config(model: str, thinking: str | None):
+    """Return a ThinkingConfig (or None) for the given model.
+
+    Raises ValueError on unsupported (model, level) combinations.
+    """
+    if thinking is None:
+        return None
+    if thinking not in VALID_THINKING_LEVELS:
+        raise ValueError(
+            f"unknown thinking level `{thinking}` (expected one of {sorted(VALID_THINKING_LEVELS)})"
+        )
+
+    try:
+        from google.genai import types as genai_types
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise RuntimeError("google-genai is not installed") from exc
+
+    if _is_gemini_3(model):
+        if thinking in {"off", "adaptive"}:
+            raise ValueError(
+                f"`--thinking {thinking}` is not supported for Gemini 3 models; "
+                "use minimal|low|medium|high"
+            )
+        return genai_types.ThinkingConfig(thinking_level=thinking.upper())
+
+    if _is_gemini_25(model):
+        if thinking == "off":
+            return genai_types.ThinkingConfig(thinking_budget=0)
+        if thinking == "adaptive":
+            return genai_types.ThinkingConfig(thinking_budget=-1)
+        raise ValueError(
+            f"`--thinking {thinking}` is not supported for Gemini 2.5 models; use off|adaptive"
+        )
+
+    raise ValueError(
+        f"`--thinking` is not configured for model `{model}`; omit `--thinking` to skip thinking config"
+    )
+
+
+def _build_generate_config(model: str, max_tokens: int, thinking: str | None):
+    try:
+        from google.genai import types as genai_types
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise RuntimeError("google-genai is not installed") from exc
+    thinking_cfg = _build_thinking_config(model, thinking)
+    kwargs: dict[str, Any] = {"max_output_tokens": max_tokens}
+    if thinking_cfg is not None:
+        kwargs["thinking_config"] = thinking_cfg
+    return genai_types.GenerateContentConfig(**kwargs)
+
+
+def _is_gemini_3(model: str) -> bool:
+    return model.startswith("gemini-3")
+
+
+def _is_gemini_3_flash(model: str) -> bool:
+    return model.startswith("gemini-3-flash")
+
+
+def _is_gemini_25(model: str) -> bool:
+    return model.startswith("gemini-2.5")
+
+
+def _api_model_name(model: str) -> str:
+    return MODEL_ALIASES.get(model, model)
+
+
+# ---------------------------------------------------------------------------
+# Gemini call
+# ---------------------------------------------------------------------------
+
+
+def _generate_answer(
+    *,
+    prompt: str,
+    document_text: str,  # kept for tests/observability
+    model: str,
+    max_tokens: int,
+    thinking: str | None,
+    api_key: str,
+) -> str:
+    _ = document_text  # the prompt already includes it; this preserves a tap point for tests
     try:
         from google import genai
     except ModuleNotFoundError as exc:
         raise RuntimeError("google-genai is not installed") from exc
     client = genai.Client(api_key=api_key)
-    prompt_text = f"{SYSTEM_PROMPT}\n\nQuestion: {question}\n\nDocument:\n{document_text}"
-    response = client.models.generate_content(model=model, contents=prompt_text, config={"max_output_tokens": max_tokens})
+    config = _build_generate_config(model, max_tokens, thinking)
+    response = client.models.generate_content(model=_api_model_name(model), contents=prompt, config=config)
     text = getattr(response, "text", None)
     if not text:
         raise ValueError("Gemini returned an empty response")
     return str(text)
 
 
-async def _gather_answers(
+# ---------------------------------------------------------------------------
+# extract-files internals
+# ---------------------------------------------------------------------------
+
+
+def _expand_file_inputs(patterns: list[str], *, files_from: str | None = None) -> list[Path]:
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+
+    inputs: list[tuple[str, Path | None]] = [(raw, None) for raw in patterns]
+    if files_from:
+        inputs.extend(_read_files_from(files_from))
+
+    for raw, base_dir in inputs:
+        candidate = Path(raw).expanduser()
+        if base_dir is not None and not candidate.is_absolute():
+            candidate = base_dir / candidate
+        expanded_raw = str(candidate)
+        matches: list[str]
+        if any(ch in raw for ch in ["*", "?", "["]):
+            matches = sorted(_glob.glob(expanded_raw, recursive=True))
+            if not matches:
+                raise _UsageError(
+                    f"no files matched pattern `{raw}`",
+                    "verify the path or glob pattern; quote the value to prevent shell expansion",
+                    ["`--files 'data/**/*.md'`"],
+                )
+        else:
+            matches = [expanded_raw]
+        for match in matches:
+            path = Path(match).resolve()
+            if path.is_dir():
+                continue
+            if not path.exists():
+                raise _UsageError(
+                    f"file does not exist: {match}",
+                    "pass paths or globs that match real files",
+                    ["`--files 'data/**/*.md'`"],
+                )
+            if path in seen:
+                continue
+            seen.add(path)
+            ordered.append(path)
+    if not ordered:
+        raise _UsageError(
+            "no files matched the provided `--files` values",
+            "pass one or more `--files PATH_OR_GLOB` values that match real files",
+            ["`--files data/a.md`", "`--files 'data/**/*.md'`"],
+        )
+    return sorted(ordered)
+
+
+def _read_files_from(files_from: str) -> list[tuple[str, Path | None]]:
+    path = resolve_path(files_from)
+    if not path.exists():
+        raise _UsageError(
+            f"files list not found: {files_from}",
+            "pass an existing newline-delimited file to `--files-from`",
+            ["`--files-from path/to/files.txt`"],
+        )
+    base_dir = path.parent
+    entries: list[tuple[str, Path | None]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        raw = line.strip()
+        if not raw or raw.startswith("#"):
+            continue
+        entries.append((raw, base_dir))
+    if not entries:
+        raise _UsageError(
+            f"files list is empty: {files_from}",
+            "add one path or glob per line",
+            ["`--files-from path/to/files.txt`"],
+        )
+    return entries
+
+
+def _read_extraction_text(path: Path) -> str:
+    if path.suffix.lower() in UNSUPPORTED_TEXT_EXTRACTION_EXTENSIONS:
+        raise ValueError(
+            f"unsupported non-text file type `{path.suffix}`; convert to text first or use the OpenClaw pdf/image tools"
+        )
+    raw = path.read_bytes()
+    if b"\x00" in raw[:8192]:
+        raise ValueError("file appears to be binary; convert to UTF-8 text before using extract-files")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("file is not valid UTF-8 text; convert it before using extract-files") from exc
+
+
+def _plan_output_paths(files: list[Path], out_root: Path) -> list[tuple[Path, Path]]:
+    common = _common_parent(files)
+    used: set[Path] = set()
+    plan: list[tuple[Path, Path]] = []
+    for src in files:
+        try:
+            rel = src.relative_to(common)
+        except ValueError:
+            rel = Path(src.name)
+        target = (out_root / rel).with_suffix(".md")
+        if target in used:
+            digest = hashlib.sha1(str(src).encode("utf-8")).hexdigest()[:8]
+            target = target.with_name(f"{target.stem}-{digest}{target.suffix}")
+        used.add(target)
+        plan.append((src, target))
+    return plan
+
+
+def _common_parent(files: list[Path]) -> Path:
+    if not files:
+        return Path(".")
+    if len(files) == 1:
+        return files[0].parent
+    parts_lists = [p.parts for p in files]
+    common: list[str] = []
+    for tuples in zip(*parts_lists):
+        if all(part == tuples[0] for part in tuples):
+            common.append(tuples[0])
+        else:
+            break
+    if not common:
+        return Path(files[0].anchor or ".")
+    return Path(*common)
+
+
+async def _run_extractions(
     *,
-    questions: list[str],
-    document_text: str,
+    plan: list[tuple[Path, Path]],
+    prompt_pack: str,
     model: str,
     max_tokens: int,
+    thinking: str | None,
     api_key: str,
-) -> list[str]:
-    semaphore = asyncio.Semaphore(max(len(questions), 1))
+    concurrency: int,
+) -> list[dict[str, Any]]:
+    semaphore = asyncio.Semaphore(max(concurrency, 1))
 
-    async def _run(question: str) -> str:
+    async def _run_one(src: Path, target: Path) -> dict[str, Any]:
         async with semaphore:
-            return await asyncio.to_thread(
-                _generate_answer,
-                question=question,
-                document_text=document_text,
-                model=model,
-                max_tokens=max_tokens,
-                api_key=api_key,
-            )
+            entry: dict[str, Any] = {
+                "source": str(src),
+                "output": str(target),
+                "status": "ok",
+                "error": None,
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            }
+            try:
+                document_text = _read_extraction_text(src)
+                prompt = _compose_prompt(prompt_pack=prompt_pack, document_text=document_text)
+                answer = await asyncio.to_thread(
+                    _generate_answer,
+                    prompt=prompt,
+                    document_text=document_text,
+                    model=model,
+                    max_tokens=max_tokens,
+                    thinking=thinking,
+                    api_key=api_key,
+                )
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(answer.strip() + "\n", encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                entry["status"] = "error"
+                entry["error"] = f"{type(exc).__name__}: {exc}"
+            entry["finished_at"] = datetime.now(timezone.utc).isoformat()
+            return entry
 
-    return list(await asyncio.gather(*[_run(question) for question in questions]))
-
-
-def _merge_questions(questions: list[str], questions_file: str | None) -> list[str]:
-    merged = [question.strip() for question in questions if question.strip()]
-    if questions_file:
-        merged.extend(
-            question.strip()
-            for question in Path(questions_file).expanduser().read_text(encoding="utf-8").splitlines()
-            if question.strip()
-        )
-    return merged
-
-
-def _usage_error(what: str, what_to_do: str, alternatives: list[str], help_text: str) -> str:
-    return "\n".join(
-        [
-            f"What went wrong: {what}",
-            f"What to do instead: {what_to_do}",
-            f"Available alternatives: {', '.join(alternatives)}",
-            "",
-            help_text.rstrip(),
-        ]
+    return list(
+        await asyncio.gather(*[_run_one(src, target) for src, target in plan])
     )
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
 
 
 def _print(result: CommandResult) -> None:

--- a/src/harness/commands/fileinfo.py
+++ b/src/harness/commands/fileinfo.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import typer
 
-from harness.commands.common import abort_with_help, elapsed_ms, error_result, relative_display_path, resolve_path
+from harness.commands.common import abort_with_help, elapsed_ms, error_result, relative_display_path, resolve_path, show_help_if_bare
 from harness.context import detect_file_format, estimate_tokens, is_binary
 from harness.config import HarnessSettings, get_settings
 from harness.output import CommandResult, OutputEnvelope
@@ -71,6 +71,7 @@ def fileinfo_cli_command(
     Example:
       minerva fileinfo ./aapl-filings/AAPL/10-K/2025-11-01.md
     """
+    show_help_if_bare(ctx, path=path)
     if not path:
         abort_with_help(
             ctx,
@@ -128,7 +129,7 @@ def _directory_inventory(path: Path) -> str:
     lines.extend(
         [
             f"total: {total_files} files, {_human_size(total_bytes)}, ~{total_tokens} tokens",
-            "recommendation: Use `minerva extract` or `extract-many` on individual files for targeted extraction.",
+            "recommendation: Use `minerva extract` for one file or `minerva extract-files` for many files.",
         ]
     )
     return "\n".join(lines)
@@ -159,7 +160,7 @@ def _recommendation(*, binary: bool, format_name: str, estimated_tokens: int) ->
         return "Binary file. Convert to text before processing."
     if estimated_tokens < 5_000:
         return "Small enough to read directly with OpenClaw's `read` tool."
-    return "Use `minerva extract` or `extract-many` for targeted extraction."
+    return "Use `minerva extract` for one file or `minerva extract-files` for many files."
 
 
 def _human_size(size_bytes: int) -> str:

--- a/src/harness/commands/research.py
+++ b/src/harness/commands/research.py
@@ -9,6 +9,7 @@ import typer
 
 from harness.commands.common import (
     abort_with_help,
+    show_help_if_bare,
     elapsed_ms,
     error_result,
     maybe_export_text,
@@ -94,6 +95,7 @@ def research_cli_command(
     Example:
       minerva research "market map of vertical SaaS companies in hospitality"
     """
+    show_help_if_bare(ctx, query=query, output=output)
     if not query:
         abort_with_help(
             ctx,

--- a/tests/test_harness/test_bare_invocation.py
+++ b/tests/test_harness/test_bare_invocation.py
@@ -1,0 +1,126 @@
+"""Tests for bare-invocation help behavior (doc 19).
+
+Bare invocation (zero user args) → clean help, exit 0, no error.
+Partial invocation (some args, missing required) → error + help, exit 1.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from harness.cli import app
+from harness.commands.common import _is_bare_default
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _is_bare_default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, True),
+        ([], True),
+        ((), True),
+        ("hello", False),
+        (["a"], False),
+        ("", False),  # Typer never sends "" for unprovided args
+        (0, False),  # must not treat 0 as bare
+        (False, False),  # must not treat False as bare
+        (4, False),  # e.g. default concurrency value
+        (True, False),
+        ([None], False),  # list with one None element is NOT empty
+    ],
+)
+def test_is_bare_default(value: object, expected: bool) -> None:
+    assert _is_bare_default(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# Bare invocation — clean help, exit 0, no error
+# ---------------------------------------------------------------------------
+
+
+def test_bare_extract_shows_help_without_error() -> None:
+    result = runner.invoke(app, ["extract"])
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\n{result.output}"
+    assert "Usage:" in result.output
+    assert "What went wrong" not in result.output
+
+
+def test_bare_extract_files_shows_help_without_error() -> None:
+    result = runner.invoke(app, ["extract-files"])
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\n{result.output}"
+    assert "Usage:" in result.output
+    assert "What went wrong" not in result.output
+
+
+def test_bare_fileinfo_shows_help_without_error() -> None:
+    result = runner.invoke(app, ["fileinfo"])
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\n{result.output}"
+    assert "Usage:" in result.output
+    assert "What went wrong" not in result.output
+
+
+def test_bare_research_shows_help_without_error() -> None:
+    result = runner.invoke(app, ["research"])
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\n{result.output}"
+    assert "Usage:" in result.output
+    assert "What went wrong" not in result.output
+
+
+def test_bare_run_shows_help_without_error() -> None:
+    result = runner.invoke(app, ["run"])
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\n{result.output}"
+    assert "Usage:" in result.output
+    assert "What went wrong" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Partial invocation — error + help, exit 1 (regression guards)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_extract_still_errors(tmp_path) -> None:
+    """extract with --file but no question should still error."""
+    src = tmp_path / "src.md"
+    src.write_text("body", encoding="utf-8")
+    result = runner.invoke(app, ["extract", "-f", str(src)])
+    assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}.\n{result.output}"
+    assert "What went wrong" in result.output
+
+
+def test_partial_extract_files_still_errors(tmp_path) -> None:
+    """extract-files with --files but no question/out should still error."""
+    src = tmp_path / "src.md"
+    src.write_text("body", encoding="utf-8")
+    result = runner.invoke(app, ["extract-files", "-f", str(src)])
+    assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}.\n{result.output}"
+    assert "What went wrong" in result.output
+
+
+def test_partial_research_still_errors() -> None:
+    """research with --output but no query should still error."""
+    result = runner.invoke(app, ["research", "--output", "foo.md"])
+    assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}.\n{result.output}"
+    assert "What went wrong" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Dispatch path regression — run "extract" still errors
+# ---------------------------------------------------------------------------
+
+
+def test_run_dispatch_extract_still_errors() -> None:
+    """'minerva run extract' goes through dispatch, should still show an error (not clean help).
+
+    Note: `run` wraps dispatch results in an OutputEnvelope and always exits 0 at the
+    process level.  The important assertion is that the dispatch path still produces an
+    error message — i.e. it did NOT get the bare-invocation clean-help treatment.
+    """
+    result = runner.invoke(app, ["run", "extract"])
+    assert "no extraction prompt" in result.output or "What went wrong" in result.output

--- a/tests/test_harness/test_cli.py
+++ b/tests/test_harness/test_cli.py
@@ -67,9 +67,10 @@ def test_direct_cli_missing_args_show_full_help_for_valuation_dcf() -> None:
 
 
 def test_direct_cli_missing_args_show_full_help_for_research() -> None:
+    """Bare 'minerva research' now shows clean help (exit 0, no error)."""
     result = runner.invoke(app, ["research"])
 
-    assert result.exit_code == 1
-    assert "What went wrong:" in result.stdout
+    assert result.exit_code == 0
+    assert "What went wrong" not in result.stdout
     assert "Usage:" in result.stdout
     assert "Deep web research powered by Parallel.ai." in result.stdout

--- a/tests/test_harness/test_extract.py
+++ b/tests/test_harness/test_extract.py
@@ -1,40 +1,848 @@
-"""Tests for extract commands."""
+"""Tests for extract and extract-files commands."""
 
+from __future__ import annotations
+
+import json
 from pathlib import Path
+
+import pytest
 
 from harness.commands import extract
 from harness.config import HarnessSettings
+
+
+# ---------------------------------------------------------------------------
+# Phase 0 / 1 — `extract` core behavior
+# ---------------------------------------------------------------------------
 
 
 def test_extract_command_reads_file_and_calls_model(tmp_path: Path, monkeypatch) -> None:
     settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
     file_path = tmp_path / "doc.txt"
     file_path.write_text("Revenue is $10M.", encoding="utf-8")
-    monkeypatch.setattr("harness.commands.extract._generate_answer", lambda **kwargs: "Revenue: $10M")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "Revenue: $10M"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
 
     result = extract.extract_command(question="What is revenue?", file_path=str(file_path), settings=settings)
 
     assert result.exit_code == 0
     assert result.stdout.decode("utf-8") == "Revenue: $10M"
+    # The prompt sent to the model must contain the question.
+    assert "What is revenue?" in captured["prompt"]
+    assert "Revenue is $10M." in captured["prompt"]
 
 
-def test_extract_many_merges_inline_and_file_questions(tmp_path: Path, monkeypatch) -> None:
+def test_extract_command_reports_missing_input(tmp_path: Path) -> None:
     settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
-    questions_file = tmp_path / "questions.txt"
-    questions_file.write_text("Q2\n", encoding="utf-8")
-    monkeypatch.setattr(
-        "harness.commands.extract._gather_answers",
-        lambda **kwargs: __import__("asyncio").sleep(0, result=["A1", "A2"]),
-    )
 
-    result = extract.extract_many_command(
-        questions=["Q1"],
-        questions_file=str(questions_file),
-        stdin=b"Document text",
+    result = extract.extract_command(question="What is revenue?", settings=settings)
+
+    assert result.exit_code == 1
+    assert b"no input" in result.stderr.lower() or b"input" in result.stderr.lower()
+
+
+def test_extract_command_reports_missing_question(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    result = extract.extract_command(file_path=str(file_path), settings=settings)
+
+    assert result.exit_code == 1
+    assert b"question" in result.stderr.lower() or b"prompt" in result.stderr.lower()
+
+
+def test_extract_command_does_not_read_stdin_when_file_provided(tmp_path: Path, monkeypatch) -> None:
+    """When --file is provided, stdin must not contribute (or hang)."""
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("file content", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_command(
+        question="Q",
+        file_path=str(file_path),
+        stdin=b"piped stdin",
         settings=settings,
     )
 
     assert result.exit_code == 0
-    output = result.stdout.decode("utf-8")
-    assert "## Q1" in output
-    assert "## Q2" in output
+    assert "file content" in captured["prompt"]
+    assert "piped stdin" not in captured["prompt"]
+
+
+def test_extract_command_passes_through_model_and_max_tokens(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    extract.extract_command(
+        question="Q",
+        file_path=str(file_path),
+        model="gemini-2.5-pro",
+        max_tokens=2048,
+        settings=settings,
+    )
+
+    assert captured["model"] == "gemini-2.5-pro"
+    assert captured["max_tokens"] == 2048
+
+
+def test_extract_questions_file_preserves_markdown_formatting(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    questions_file = tmp_path / "questions.md"
+    questions_file.write_text(
+        "# Topics\n\n- Revenue by segment\n- Key risks\n\n## Notes\n\n1. Cite sections.\n2. Be concise.\n",
+        encoding="utf-8",
+    )
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("Document body.", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_command(
+        questions_file=str(questions_file),
+        file_path=str(file_path),
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    prompt = captured["prompt"]
+    assert "# Topics" in prompt
+    assert "- Revenue by segment" in prompt
+    assert "- Key risks" in prompt
+    assert "## Notes" in prompt
+    assert "1. Cite sections." in prompt
+
+
+def test_extract_combines_positional_and_questions_file_in_one_call(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    questions_file = tmp_path / "questions.md"
+    questions_file.write_text("- Question A\n- Question B\n", encoding="utf-8")
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("body", encoding="utf-8")
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_command(
+        question="Inline question",
+        questions_file=str(questions_file),
+        file_path=str(file_path),
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    prompt = calls[0]["prompt"]
+    assert "Inline question" in prompt
+    assert "Question A" in prompt
+    assert "Question B" in prompt
+
+
+def test_extract_questions_file_empty_fails_cleanly(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    questions_file = tmp_path / "empty.md"
+    questions_file.write_text("   \n\n", encoding="utf-8")
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("body", encoding="utf-8")
+
+    result = extract.extract_command(
+        questions_file=str(questions_file),
+        file_path=str(file_path),
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+    assert b"empty" in result.stderr.lower() or b"questions" in result.stderr.lower()
+
+
+def test_extract_questions_file_missing_path_fails_cleanly(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("body", encoding="utf-8")
+
+    result = extract.extract_command(
+        questions_file=str(tmp_path / "does-not-exist.md"),
+        file_path=str(file_path),
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Thinking config helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_thinking_for_gemini_3_flash() -> None:
+    assert extract._resolve_default_thinking("gemini-3-flash", None) == "minimal"
+    assert extract._resolve_default_thinking("gemini-3-flash", "low") == "low"
+    assert extract._resolve_default_thinking("gemini-3-pro", None) is None
+    assert extract._resolve_default_thinking("gemini-2.5-pro", None) is None
+
+
+def test_build_thinking_config_gemini_3_uses_thinking_level() -> None:
+    cfg = extract._build_thinking_config("gemini-3-flash", "minimal")
+    assert cfg is not None
+    assert cfg.thinking_level == "MINIMAL"
+    assert cfg.thinking_budget is None
+
+    cfg_high = extract._build_thinking_config("gemini-3-pro", "high")
+    assert cfg_high.thinking_level == "HIGH"
+    assert cfg_high.thinking_budget is None
+
+
+def test_build_thinking_config_gemini_3_rejects_off() -> None:
+    with pytest.raises(ValueError):
+        extract._build_thinking_config("gemini-3-flash", "off")
+
+
+def test_build_thinking_config_gemini_25_uses_thinking_budget() -> None:
+    cfg_off = extract._build_thinking_config("gemini-2.5-pro", "off")
+    assert cfg_off.thinking_budget == 0
+    assert cfg_off.thinking_level is None
+
+    cfg_adaptive = extract._build_thinking_config("gemini-2.5-flash", "adaptive")
+    assert cfg_adaptive.thinking_budget == -1
+    assert cfg_adaptive.thinking_level is None
+
+
+def test_build_thinking_config_gemini_25_rejects_levels() -> None:
+    with pytest.raises(ValueError):
+        extract._build_thinking_config("gemini-2.5-pro", "minimal")
+
+
+def test_build_thinking_config_invalid_level_raises() -> None:
+    with pytest.raises(ValueError):
+        extract._build_thinking_config("gemini-3-flash", "nonsense")
+
+
+def test_build_thinking_config_unknown_model_with_no_thinking_returns_none() -> None:
+    assert extract._build_thinking_config("some-other-model", None) is None
+
+
+def test_build_thinking_config_unknown_model_with_thinking_raises() -> None:
+    with pytest.raises(ValueError):
+        extract._build_thinking_config("some-other-model", "minimal")
+
+
+def test_api_model_name_maps_user_facing_gemini_3_flash_alias() -> None:
+    assert extract._api_model_name("gemini-3-flash") == "gemini-3-flash-preview"
+    assert extract._api_model_name("gemini-3-flash-preview") == "gemini-3-flash-preview"
+
+
+def test_extract_command_default_thinking_for_gemini_3_flash(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    extract.extract_command(question="Q", file_path=str(file_path), settings=settings)
+
+    assert captured["thinking"] == "minimal"
+
+
+def test_extract_command_explicit_thinking_passes_through(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    extract.extract_command(
+        question="Q",
+        file_path=str(file_path),
+        model="gemini-3-pro",
+        thinking="high",
+        settings=settings,
+    )
+
+    assert captured["thinking"] == "high"
+
+
+def test_extract_command_invalid_thinking_returns_clean_error(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    file_path = tmp_path / "doc.md"
+    file_path.write_text("body", encoding="utf-8")
+    called = {"value": False}
+
+    def fake_generate(**kwargs):
+        called["value"] = True
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_command(
+        question="Q",
+        file_path=str(file_path),
+        thinking="nonsense",
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+    assert called["value"] is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 1/2 — `extract` run-chain dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_supports_questions_file_with_file(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    questions_file = tmp_path / "q.md"
+    questions_file.write_text("- A\n- B\n", encoding="utf-8")
+    source = tmp_path / "src.md"
+    source.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch(
+        ["--questions-file", str(questions_file), "--file", str(source)],
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert "- A" in captured["prompt"]
+
+
+def test_dispatch_supports_short_file_and_questions_flags(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    questions_file = tmp_path / "q.md"
+    questions_file.write_text("Short question", encoding="utf-8")
+    source = tmp_path / "src.md"
+    source.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch(["-q", str(questions_file), "-f", str(source)], settings=settings)
+
+    assert result.exit_code == 0
+    assert "Short question" in captured["prompt"]
+
+
+def test_dispatch_supports_flags_before_positional_question(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    source = tmp_path / "src.md"
+    source.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch(
+        ["--file", str(source), "--model", "gemini-3-flash", "What is X?"],
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert "What is X?" in captured["prompt"]
+    assert captured["model"] == "gemini-3-flash"
+
+
+def test_dispatch_supports_thinking_flag(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    source = tmp_path / "src.md"
+    source.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch(
+        ["Q", "--file", str(source), "--model", "gemini-3-pro", "--thinking", "low"],
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert captured["thinking"] == "low"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — `extract-files`
+# ---------------------------------------------------------------------------
+
+
+def test_extract_files_requires_question_source(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    src = tmp_path / "src.md"
+    src.write_text("body", encoding="utf-8")
+    out = tmp_path / "out"
+
+    result = extract.extract_files_command(
+        files=[str(src)],
+        out=str(out),
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+    assert b"question" in result.stderr.lower() or b"prompt" in result.stderr.lower()
+
+
+def test_extract_files_requires_at_least_one_file(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    out = tmp_path / "out"
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[],
+        out=str(out),
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+    assert b"file" in result.stderr.lower()
+
+
+def test_extract_files_glob_no_matches_fails(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    out = tmp_path / "out"
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(tmp_path / "does-not-exist-*.md")],
+        out=str(out),
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+
+
+def test_extract_files_one_call_per_file_writes_outputs(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    (sources / "a.md").write_text("Alpha body.", encoding="utf-8")
+    (sources / "b.md").write_text("Bravo body.", encoding="utf-8")
+    out = tmp_path / "out"
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return f"answer for {kwargs['document_text'][:5]}"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        question="What is it?",
+        files=[str(sources / "*.md")],
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 0, result.stderr.decode("utf-8")
+    assert len(calls) == 2
+    a_out = out / "a.md"
+    b_out = out / "b.md"
+    assert a_out.exists()
+    assert b_out.exists()
+    assert "answer for Alpha" in a_out.read_text(encoding="utf-8")
+    assert "answer for Bravo" in b_out.read_text(encoding="utf-8")
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert len(manifest["entries"]) == 2
+    assert all(entry["status"] == "ok" for entry in manifest["entries"])
+    assert manifest["model"]
+    assert manifest["api_model"]
+
+
+def test_extract_files_questions_file_passes_pack(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    src = sources / "doc.md"
+    src.write_text("body", encoding="utf-8")
+    qfile = tmp_path / "q.md"
+    qfile.write_text("# Topics\n\n- Q1\n- Q2\n", encoding="utf-8")
+    out = tmp_path / "out"
+    captured: list[dict] = []
+
+    def fake_generate(**kwargs):
+        captured.append(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        questions_file=str(qfile),
+        files=[str(src)],
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert "# Topics" in captured[0]["prompt"]
+    assert "- Q1" in captured[0]["prompt"]
+
+
+def test_extract_files_force_required_to_overwrite(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    src = sources / "a.md"
+    src.write_text("body", encoding="utf-8")
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "a.md").write_text("preexisting", encoding="utf-8")
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", lambda **kw: "answer")
+
+    # Without --force: failure, output preserved
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(src)],
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+    assert result.exit_code == 1
+    assert (out / "a.md").read_text(encoding="utf-8") == "preexisting"
+
+    # With --force: overwrite
+    result_force = extract.extract_files_command(
+        question="Q",
+        files=[str(src)],
+        out=str(out),
+        concurrency=1,
+        force=True,
+        settings=settings,
+    )
+    assert result_force.exit_code == 0
+    assert "answer" in (out / "a.md").read_text(encoding="utf-8")
+
+
+def test_extract_files_partial_failure_writes_manifest_and_exits_nonzero(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    (sources / "good.md").write_text("ok body", encoding="utf-8")
+    (sources / "bad.md").write_text("bad body", encoding="utf-8")
+    out = tmp_path / "out"
+
+    def fake_generate(**kwargs):
+        if "bad" in kwargs["document_text"]:
+            raise RuntimeError("boom")
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(sources / "*.md")],
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code != 0
+    assert (out / "good.md").exists()
+    assert not (out / "bad.md").exists()
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    statuses = {entry["source"]: entry["status"] for entry in manifest["entries"]}
+    assert any(status == "ok" for status in statuses.values())
+    assert any(status == "error" for status in statuses.values())
+
+
+def test_extract_files_passes_model_thinking_max_tokens(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    (sources / "a.md").write_text("body", encoding="utf-8")
+    out = tmp_path / "out"
+    captured: list[dict] = []
+
+    def fake_generate(**kwargs):
+        captured.append(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    extract.extract_files_command(
+        question="Q",
+        files=[str(sources / "*.md")],
+        out=str(out),
+        model="gemini-3-pro",
+        thinking="medium",
+        max_tokens=1024,
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert captured[0]["model"] == "gemini-3-pro"
+    assert captured[0]["thinking"] == "medium"
+    assert captured[0]["max_tokens"] == 1024
+
+
+def test_extract_files_mirrors_relative_paths(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    sources = tmp_path / "sources"
+    (sources / "10-K").mkdir(parents=True)
+    (sources / "10-K" / "item-1.md").write_text("a", encoding="utf-8")
+    (sources / "10-Q").mkdir(parents=True)
+    (sources / "10-Q" / "item-1.md").write_text("b", encoding="utf-8")
+    out = tmp_path / "out"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", lambda **kw: "ans")
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(sources / "**" / "*.md")],
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    # Common parent is `sources/`; the two distinct subdirs are preserved so basenames don't collide.
+    assert (out / "10-K" / "item-1.md").exists()
+    assert (out / "10-Q" / "item-1.md").exists()
+
+
+def test_extract_files_dispatch_supports_repeated_files(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    a = tmp_path / "a.md"
+    a.write_text("alpha", encoding="utf-8")
+    b = tmp_path / "b.md"
+    b.write_text("bravo", encoding="utf-8")
+    out = tmp_path / "out"
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch_files(
+        [
+            "Q",
+            "--files", str(a),
+            "--files", str(b),
+            "--out", str(out),
+            "--concurrency", "1",
+        ],
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 2
+
+
+def test_extract_files_dispatch_supports_short_flags(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    a = tmp_path / "a.md"
+    a.write_text("alpha", encoding="utf-8")
+    qfile = tmp_path / "questions.md"
+    qfile.write_text("Q", encoding="utf-8")
+    out = tmp_path / "out"
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch_files(
+        ["-q", str(qfile), "-f", str(a), "-o", str(out), "--concurrency", "1"],
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+
+
+def test_extract_files_dispatch_supports_short_files_from(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    a = tmp_path / "a.md"
+    a.write_text("alpha", encoding="utf-8")
+    list_file = tmp_path / "files.txt"
+    list_file.write_text("a.md\n", encoding="utf-8")
+    out = tmp_path / "out"
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.dispatch_files(["Q", "-F", str(list_file), "-o", str(out), "--concurrency", "1"], settings=settings)
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+
+
+def test_extract_files_supports_files_from_for_curated_scattered_files(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="***")
+    root = tmp_path / "reports"
+    oracle = root / "oracle" / "data"
+    microsoft = root / "microsoft" / "filings"
+    amazon = root / "amazon" / "sources"
+    oracle.mkdir(parents=True)
+    microsoft.mkdir(parents=True)
+    amazon.mkdir(parents=True)
+    (oracle / "file-a.md").write_text("oracle", encoding="utf-8")
+    (microsoft / "file-b.md").write_text("microsoft", encoding="utf-8")
+    (amazon / "file-c.md").write_text("amazon", encoding="utf-8")
+    list_file = tmp_path / "files.txt"
+    list_file.write_text(
+        "# curated cross-company extraction\n"
+        "reports/oracle/data/file-a.md\n"
+        "reports/microsoft/filings/file-b.md\n"
+        "reports/amazon/sources/file-c.md\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out"
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return f"answer: {kwargs['document_text']}"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        question="Q",
+        files_from=str(list_file),
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 0, result.stderr.decode("utf-8")
+    assert len(calls) == 3
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    sources = {Path(entry["source"]).name for entry in manifest["entries"]}
+    assert sources == {"file-a.md", "file-b.md", "file-c.md"}
+
+
+def test_extract_files_cli_accepts_files_from_without_files(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="***")
+    src = tmp_path / "source.md"
+    src.write_text("body", encoding="utf-8")
+    qfile = tmp_path / "questions.md"
+    qfile.write_text("Q", encoding="utf-8")
+    list_file = tmp_path / "files.txt"
+    list_file.write_text("source.md\n", encoding="utf-8")
+    out = tmp_path / "out"
+    captured: dict = {}
+
+    def fake_command(**kwargs):
+        captured.update(kwargs)
+        return extract.CommandResult.from_text("ok")
+
+    monkeypatch.setattr("harness.commands.extract.extract_files_command", fake_command)
+    monkeypatch.setattr("harness.commands.extract.get_settings", lambda: settings)
+
+    extract.extract_files_cli_command(
+        ctx=None,  # only used for validation failures
+        question=None,
+        files=None,
+        files_from=str(list_file),
+        out=str(out),
+        questions_file=str(qfile),
+    )
+
+    assert captured["files"] == []
+    assert captured["files_from"] == str(list_file)
+
+
+def test_extract_files_records_non_text_files_as_failures(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="***")
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    (sources / "good.md").write_text("ok body", encoding="utf-8")
+    (sources / "report.pdf").write_bytes(b"%PDF-1.7 fake pdf")
+    out = tmp_path / "out"
+    calls: list[dict] = []
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(sources / "good.md"), str(sources / "report.pdf")],
+        out=str(out),
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+    assert len(calls) == 1
+    assert (out / "good.md").exists()
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    pdf_entry = next(entry for entry in manifest["entries"] if entry["source"].endswith("report.pdf"))
+    assert pdf_entry["status"] == "error"
+    assert "unsupported non-text" in pdf_entry["error"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — legacy multi-question command removal
+# ---------------------------------------------------------------------------
+
+
+def test_extract_module_no_longer_exposes_extract_many() -> None:
+    assert not hasattr(extract, "extract_many_command")
+    assert not hasattr(extract, "extract_many_app")
+    assert not hasattr(extract, "dispatch_many")


### PR DESCRIPTION
## Summary

- **New `extract-files` command**: Apply one extraction prompt across many scattered files with bounded concurrency, per-file markdown outputs, and a JSON manifest.
  - Supports `-f` (repeated files/globs), `-F` (curated file list), `-q` (questions-file), `-o` (output dir)
  - PDF/binary files cleanly rejected with manifest errors
  - `--force` for overwriting, `--concurrency` for parallelism

- **Short flags**: `-f`, `-q` on `extract`; `-f`, `-F`, `-q`, `-o` on `extract-files`

- **Removed `extract-many`**: Replaced by `extract --questions-file` (many questions, one file) and `extract-files` (one question pack, many files)

- **Model-aware thinking**: `--thinking` flag with sensible defaults (`minimal` for gemini-3-flash), model alias mapping

- **Bare-invocation help**: `minerva extract`, `extract-files`, `fileinfo`, `research`, `run` now show clean help (exit 0) when invoked with no args. Partial invocations still error.

- **Fixed help examples**: Flags-first ordering to work around Typer `invoke_without_command` limitation

## Tests
- 167 tests passing (38 extract tests, 20 bare-invocation tests)
- Functional testing against real Oracle, Amazon, Microsoft, Robinhood, Salesforce data