### PR TITLE
fix: stop creating notes/ folder on evidence init

### DIFF
--- a/src/harness/workflows/evidence/registry.py
+++ b/src/harness/workflows/evidence/registry.py
@@ -13,7 +13,6 @@ def ensure_company_tree(paths: CompanyPaths) -> None:
     """Create the canonical company evidence tree."""
     for directory in [
         paths.root,
-        paths.notes_dir,
         paths.sources_dir,
         paths.references_dir,
         paths.meta_dir,


### PR DESCRIPTION
Removes `paths.notes_dir` from `ensure_company_tree()` so `minerva evidence init` no longer creates the `notes/` directory. The path definition stays in `paths.py` in case it's needed later.