### PR TITLE
fix(sec): remove ticker nesting from bulk-download, single-ticker only

### DIFF
--- a/scripts/fix_ticker_nesting.py
+++ b/scripts/fix_ticker_nesting.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Flatten ticker-nested source directories in company evidence trees.
+
+Scans hard-disk/reports/00-companies/*/data/sources/ for ticker folders
+(e.g. RDDT/, TEAM/) and merges their children into the parent sources/ dir.
+
+Usage:
+    python3 scripts/fix_ticker_nesting.py              # dry-run (default)
+    python3 scripts/fix_ticker_nesting.py --execute     # actually move files
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+
+REAL_SOURCE_TYPES = {
+    "10-K", "10-Q", "8-K", "earnings", "financials", "proxy", "news",
+    "competitors", "transcripts", "presentations", "references",
+    "investor-materials", "partnership", "legacy", "sec", "web", "assets",
+    "webcasts",
+}
+
+BASE = Path(__file__).resolve().parent.parent / "hard-disk" / "reports" / "00-companies"
+
+
+def find_ticker_dirs() -> list[dict]:
+    """Find all ticker-nested directories that need flattening."""
+    results = []
+    for company_dir in sorted(BASE.iterdir()):
+        sources = company_dir / "data" / "sources"
+        if not sources.exists():
+            continue
+        for d in sorted(sources.iterdir()):
+            if not d.is_dir() or d.name in REAL_SOURCE_TYPES or d.name.startswith(".") or d.name == "INDEX.md":
+                continue
+            children = [c for c in d.iterdir() if c.is_dir() and c.name in REAL_SOURCE_TYPES]
+            if not children:
+                continue
+            results.append({
+                "company": company_dir.name,
+                "sources_dir": sources,
+                "ticker_dir": d,
+                "ticker": d.name,
+                "children": sorted(c.name for c in children),
+            })
+    return results
+
+
+def check_conflicts(ticker_dir: Path, sources_dir: Path) -> list[dict]:
+    """Check for file-level conflicts between nested and flat directories."""
+    conflicts = []
+    for nested_file in ticker_dir.rglob("*"):
+        if not nested_file.is_file():
+            continue
+        rel = nested_file.relative_to(ticker_dir)
+        flat_target = sources_dir / rel
+        if flat_target.exists():
+            h1 = hashlib.md5(nested_file.read_bytes()).hexdigest()
+            h2 = hashlib.md5(flat_target.read_bytes()).hexdigest()
+            conflicts.append({
+                "nested": nested_file,
+                "flat": flat_target,
+                "rel": rel,
+                "same_hash": h1 == h2,
+            })
+    return conflicts
+
+
+def flatten_one(ticker_dir: Path, sources_dir: Path, *, execute: bool) -> list[str]:
+    """Flatten one ticker directory into its parent sources dir."""
+    log = []
+    for child in sorted(ticker_dir.iterdir()):
+        if not child.is_dir():
+            # Stray files at ticker level — move them too
+            target = sources_dir / child.name
+            if target.exists():
+                log.append(f"  SKIP (exists): {child.name}")
+                continue
+            log.append(f"  MOVE file: {child.name}")
+            if execute:
+                shutil.move(str(child), str(target))
+            continue
+
+        target = sources_dir / child.name
+        if target.exists():
+            # Merge: move files from nested into existing flat dir
+            for nested_file in sorted(child.rglob("*")):
+                if not nested_file.is_file():
+                    continue
+                rel = nested_file.relative_to(child)
+                flat_target = target / rel
+                if flat_target.exists():
+                    h1 = hashlib.md5(nested_file.read_bytes()).hexdigest()
+                    h2 = hashlib.md5(flat_target.read_bytes()).hexdigest()
+                    if h1 == h2:
+                        log.append(f"  SKIP (identical): {child.name}/{rel}")
+                        if execute:
+                            nested_file.unlink()
+                    else:
+                        log.append(f"  ❌ CONFLICT (different): {child.name}/{rel}")
+                        # Don't move — manual resolution needed
+                else:
+                    log.append(f"  MERGE: {child.name}/{rel}")
+                    if execute:
+                        flat_target.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.move(str(nested_file), str(flat_target))
+        else:
+            # No conflict — just move the whole dir
+            log.append(f"  MOVE dir: {child.name}/ ({len(list(child.rglob('*')))} items)")
+            if execute:
+                shutil.move(str(child), str(target))
+
+    # Remove the now-empty ticker dir
+    if execute:
+        # Remove any remaining empty subdirs
+        for d in sorted(ticker_dir.rglob("*"), reverse=True):
+            if d.is_dir():
+                try:
+                    d.rmdir()
+                except OSError:
+                    pass
+        try:
+            ticker_dir.rmdir()
+            log.append(f"  REMOVED: {ticker_dir.name}/")
+        except OSError as e:
+            log.append(f"  ⚠️  Could not remove {ticker_dir.name}/: {e}")
+    else:
+        log.append(f"  WOULD REMOVE: {ticker_dir.name}/")
+
+    return log
+
+
+def refresh_sources_index(sources_dir: Path, *, execute: bool) -> str | None:
+    """Regenerate INDEX.md for a sources directory."""
+    idx = sources_dir / "INDEX.md"
+    dirs = sorted(d.name for d in sources_dir.iterdir() if d.is_dir() and not d.name.startswith("."))
+    files = sorted(f.name for f in sources_dir.iterdir() if f.is_file() and f.name != "INDEX.md" and not f.name.startswith("."))
+
+    lines = ["# Index: sources", "", "## Directories", ""]
+    if dirs:
+        for d in dirs:
+            lines.append(f"- [{d}/](./{d}/)")
+    else:
+        lines.append("- (none)")
+    lines.extend(["", "## Files", ""])
+    if files:
+        for f in files:
+            lines.append(f"- [{f}](./{f})")
+    else:
+        lines.append("- (none)")
+    lines.append("")
+
+    content = "\n".join(lines)
+    if execute:
+        idx.write_text(content, encoding="utf-8")
+    return content
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Flatten ticker-nested source directories")
+    parser.add_argument("--execute", action="store_true", help="Actually perform the moves (default: dry-run)")
+    args = parser.parse_args()
+
+    mode = "EXECUTE" if args.execute else "DRY-RUN"
+    print(f"=== Ticker Nesting Cleanup ({mode}) ===\n")
+
+    targets = find_ticker_dirs()
+    if not targets:
+        print("No ticker-nested directories found. Nothing to do.")
+        return
+
+    # Pre-flight conflict check
+    has_blocking_conflict = False
+    for t in targets:
+        conflicts = check_conflicts(t["ticker_dir"], t["sources_dir"])
+        diff_conflicts = [c for c in conflicts if not c["same_hash"]]
+        if diff_conflicts:
+            has_blocking_conflict = True
+            print(f"❌ BLOCKING CONFLICT in {t['company']}:")
+            for c in diff_conflicts:
+                print(f"   {c['rel']}: nested ≠ flat (different content)")
+
+    if has_blocking_conflict:
+        print("\nAborting: resolve conflicts above before running with --execute")
+        sys.exit(1)
+
+    # Process each
+    total_moved = 0
+    for t in targets:
+        print(f"{t['company']} — {t['ticker']}/ → flatten")
+        log = flatten_one(t["ticker_dir"], t["sources_dir"], execute=args.execute)
+        for line in log:
+            print(line)
+        total_moved += 1
+
+        # Refresh INDEX.md
+        refresh_sources_index(t["sources_dir"], execute=args.execute)
+        if args.execute:
+            print("  REFRESHED: INDEX.md")
+        else:
+            print("  WOULD REFRESH: INDEX.md")
+        print()
+
+    print(f"{'Processed' if args.execute else 'Would process'}: {total_moved} folders")
+    if not args.execute:
+        print("\nRe-run with --execute to apply changes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/harness/commands/sec.py
+++ b/src/harness/commands/sec.py
@@ -35,7 +35,7 @@ SEC_HELP = (
     "  minerva sec 10k AAPL --items 1,1A,7\n"
     "  minerva sec financials MSFT --type income --periods 5\n"
     "  minerva sec download AAPL --form 10-K --format markdown\n"
-    "  minerva sec bulk-download AAPL MSFT --output ./comp-analysis\n"
+    "  minerva sec bulk-download AAPL --output ./filings\n"
 )
 
 app = typer.Typer(help=SEC_HELP, no_args_is_help=True)
@@ -124,7 +124,7 @@ def dispatch(
 
         if subcommand == "bulk-download":
             parsed_args: list[str] = []
-            tickers: list[str] = []
+            ticker: str | None = None
             index = 1
             while index < len(args):
                 token = args[index]
@@ -132,13 +132,13 @@ def dispatch(
                     parsed_args.extend(args[index : index + 2])
                     index += 2
                     continue
-                tickers.append(token)
+                ticker = token
                 index += 1
             parsed = parse_flag_args(parsed_args)
-            if not tickers:
-                return _dispatch_help("bulk-download", ["`sec bulk-download AAPL MSFT --output ./comp-analysis`"])
+            if not ticker:
+                return _dispatch_help("bulk-download", ["`sec bulk-download AAPL --output ./filings`"])
             return bulk_download_command(
-                tickers=tickers,
+                ticker=ticker,
                 output_dir=str(parsed["output"]) if "output" in parsed else None,
                 annual=int(parsed.get("annual", 5)),
                 quarters=int(parsed.get("quarters", 4)),
@@ -298,7 +298,7 @@ def download_filing_command(
 
 def bulk_download_command(
     *,
-    tickers: list[str],
+    ticker: str,
     output_dir: str | None = None,
     annual: int = 5,
     quarters: int = 4,
@@ -306,7 +306,7 @@ def bulk_download_command(
     include_financials: bool = True,
     settings: HarnessSettings | None = None,
 ) -> CommandResult:
-    """Download a filing library for one or more tickers."""
+    """Download a filing library for a single ticker."""
     start: float = time.perf_counter()
     active_settings = settings or get_settings()
     identity_error = _configure_edgar(active_settings)
@@ -314,23 +314,19 @@ def bulk_download_command(
         return error_result(identity_error, "set EDGAR_IDENTITY and retry", ["`export EDGAR_IDENTITY='Minerva Research name@email.com'`"], start)
 
     base_output = resolve_path(output_dir or ".")
-    lines: list[str] = []
     try:
-        for ticker in tickers:
-            summary = _bulk_download_one(
-                ticker=ticker,
-                base_output=base_output,
-                annual=annual,
-                quarters=quarters,
-                earnings=earnings,
-                include_financials=include_financials,
-            )
-            lines.extend(summary)
-            lines.append("")
+        lines = _bulk_download_one(
+            ticker=ticker,
+            base_output=base_output,
+            annual=annual,
+            quarters=quarters,
+            earnings=earnings,
+            include_financials=include_financials,
+        )
     except Exception as exc:
         return error_result(
             f"bulk download failed: {exc}",
-            "retry with one ticker first or reduce the requested filing counts",
+            "retry or reduce the requested filing counts",
             ["`sec bulk-download AAPL`", "`sec download AAPL --form 10-K --format markdown`"],
             start,
         )
@@ -403,26 +399,26 @@ def download_command(
     _print(download_filing_command(ticker, form=form, file_format=file_format, output_path=output))
 
 
-@app.command("bulk-download", help="Download a filing library for one or more companies.\n\nExample:\n  minerva sec bulk-download AAPL MSFT --output ./comp-analysis")
+@app.command("bulk-download", help="Download a filing library for a single company.\n\nExample:\n  minerva sec bulk-download AAPL --output ./filings")
 def bulk_download_cli_command(
     ctx: typer.Context,
-    tickers: list[str] = typer.Argument(None, help="One or more company tickers."),
+    ticker: str | None = typer.Argument(None, help="Company ticker."),
     output: str | None = typer.Option(None, "--output", help="Output directory."),
     annual: int = typer.Option(5, "--annual", min=0, help="Number of annual 10-K filings."),
     quarters: int = typer.Option(4, "--quarters", min=0, help="Number of quarterly 10-Q filings."),
     earnings: int = typer.Option(4, "--earnings", min=0, help="Number of earnings releases."),
     financials: bool = typer.Option(True, "--financials/--no-financials", help="Include markdown financial statement tables."),
 ) -> None:
-    if not tickers:
+    if not ticker:
         abort_with_help(
             ctx,
-            what_went_wrong="no tickers were provided for `sec bulk-download`",
-            what_to_do="pass one or more tickers after the subcommand",
-            alternatives=["`minerva sec bulk-download AAPL`", "`minerva sec bulk-download AAPL MSFT --output ./comp-analysis`"],
+            what_went_wrong="no ticker was provided for `sec bulk-download`",
+            what_to_do="pass a ticker after the subcommand",
+            alternatives=["`minerva sec bulk-download AAPL`", "`minerva sec bulk-download AAPL --output ./filings`"],
         )
     _print(
         bulk_download_command(
-            tickers=tickers,
+            ticker=ticker,
             output_dir=output,
             annual=annual,
             quarters=quarters,
@@ -573,10 +569,9 @@ def _bulk_download_one(
     earnings: int,
     include_financials: bool,
     include_html: bool = True,
-    nest_ticker: bool = True,
 ) -> list[str]:
     company = Company(ticker)
-    company_root = base_output / ticker.upper() if nest_ticker else base_output
+    company_root = base_output
     company_root.mkdir(parents=True, exist_ok=True)
 
     downloaded = {"10-K": 0, "10-Q": 0, "earnings": 0}
@@ -676,7 +671,7 @@ def _dispatch_help(subcommand: str, alternatives: list[str]) -> CommandResult:
         "13f": "Usage: sec 13f <cik>",
         "financials": "Usage: sec financials <ticker> [--periods 5] [--type income|balance|cash]",
         "download": "Usage: sec download <ticker> [--form 10-K] [--format html|markdown] [--output PATH]",
-        "bulk-download": "Usage: sec bulk-download <ticker> [<ticker2> ...] [--output DIR] [--annual 5] [--quarters 4] [--earnings 4] [--financials true|false]",
+        "bulk-download": "Usage: sec bulk-download <ticker> [--output DIR] [--annual 5] [--quarters 4] [--earnings 4] [--financials true|false]",
     }
     return CommandResult.from_text(
         "",

--- a/tests/test_harness/test_sec.py
+++ b/tests/test_harness/test_sec.py
@@ -240,7 +240,7 @@ def test_bulk_download_command_materializes_latest_results_and_falls_back_to_tex
     monkeypatch.setattr("harness.commands.sec._configure_edgar", lambda settings: None)
 
     result = sec.bulk_download_command(
-        tickers=["AAPL"],
+        ticker="AAPL",
         output_dir=str(tmp_path / "bulk"),
         annual=2,
         quarters=1,
@@ -251,9 +251,9 @@ def test_bulk_download_command_materializes_latest_results_and_falls_back_to_tex
 
     assert result.exit_code == 0
     # 10-K/10-Q are now per-section directories (fallback mode since fake filings have no obj()).
-    assert (tmp_path / "bulk" / "AAPL" / "10-K" / "2025-10-31").is_dir()
-    assert (tmp_path / "bulk" / "AAPL" / "10-K" / "2025-10-31" / "filing.md").read_text(encoding="utf-8") == "# annual 1"
-    assert (tmp_path / "bulk" / "AAPL" / "10-K" / "2024-10-31").is_dir()
-    assert (tmp_path / "bulk" / "AAPL" / "10-K" / "2024-10-31" / "_sections.md").exists()
+    assert (tmp_path / "bulk" / "10-K" / "2025-10-31").is_dir()
+    assert (tmp_path / "bulk" / "10-K" / "2025-10-31" / "filing.md").read_text(encoding="utf-8") == "# annual 1"
+    assert (tmp_path / "bulk" / "10-K" / "2024-10-31").is_dir()
+    assert (tmp_path / "bulk" / "10-K" / "2024-10-31" / "_sections.md").exists()
     # Earnings remain flat files.
-    assert (tmp_path / "bulk" / "AAPL" / "earnings" / "2025-07-24.md").read_text(encoding="utf-8") == "earnings text"
+    assert (tmp_path / "bulk" / "earnings" / "2025-07-24.md").read_text(encoding="utf-8") == "earnings text"


### PR DESCRIPTION
## Problem

`minerva sec bulk-download` defaulted to nesting files under a `{TICKER}/` subfolder. Inside company evidence trees this created `data/sources/{TICKER}/10-K/...` instead of the intended flat `data/sources/10-K/...`. 24 company folders were affected.

## Changes

- Changed `sec bulk-download` from multi-ticker (`list`) to single-ticker
- Removed `nest_ticker` parameter from `_bulk_download_one` — always flat output
- Updated CLI, dispatch, help text, and tests
- Added `scripts/fix_ticker_nesting.py` cleanup script (used to flatten 24 existing trees, 1,718 files, zero conflicts)

## Testing

- All 8 SEC tests passing
- Full suite: 145 passed (1 pre-existing unrelated failure in morning brief v1 script)