### PR TITLE
feat: support OpenAI models in extract-files

### DIFF
--- a/src/harness/commands/extract.py
+++ b/src/harness/commands/extract.py
@@ -1,4 +1,4 @@
-"""LLM extraction commands backed by Gemini."""
+"""LLM extraction commands backed by Gemini or OpenAI."""
 
 from __future__ import annotations
 
@@ -45,6 +45,8 @@ EXTRACT_FILES_HELP = (
     "  minerva extract-files --questions-file questions.md \\\n"
     "    --files 'data/sources/**/*.md' --out data/extractions/summary \\\n"
     "    --model gemini-3-flash --thinking minimal --concurrency 4\n"
+    "  minerva extract-files -q questions.md -f 'data/**/*.md' -o out \\\n"
+    "    --model gpt-5.5 --concurrency 2\n"
 )
 
 DEFAULT_MODEL = "gemini-3-flash"
@@ -53,6 +55,9 @@ DEFAULT_CONCURRENCY = 4
 MODEL_ALIASES: dict[str, str] = {
     # OpenClaw/user-facing shorthand; Google GenAI expects the preview model id today.
     "gemini-3-flash": "gemini-3-flash-preview",
+    # Accept provider-qualified OpenClaw-style names while sending OpenAI its model id.
+    "openai/gpt-5.5": "gpt-5.5",
+    "openai/gpt-5.4": "gpt-5.4",
 }
 UNSUPPORTED_TEXT_EXTRACTION_EXTENSIONS: frozenset[str] = frozenset(
     {
@@ -123,13 +128,9 @@ def extract_command(
 ) -> CommandResult:
     start = time.perf_counter()
     active_settings = settings or get_settings()
-    if not active_settings.gemini_api_key:
-        return error_result(
-            "GEMINI_API_KEY is not set",
-            "set GEMINI_API_KEY and retry",
-            ["`export GEMINI_API_KEY=...`"],
-            start,
-        )
+    api_key = _api_key_for_model(active_settings, model)
+    if not api_key:
+        return _missing_api_key_result(model, start)
     try:
         prompt_pack = _build_prompt_pack(question=question, questions_file=questions_file)
         document_text = _read_document_text(file_path=file_path, stdin=stdin)
@@ -143,7 +144,7 @@ def extract_command(
             model=model,
             max_tokens=max_tokens,
             thinking=resolved_thinking,
-            api_key=active_settings.gemini_api_key,
+            api_key=api_key,
         )
     except _UsageError as exc:
         return error_result(
@@ -162,7 +163,7 @@ def extract_command(
     except Exception as exc:  # noqa: BLE001
         return error_result(
             f"extraction failed: {exc}",
-            "verify the input source, Gemini API key, and model name, then retry",
+            "verify the input source, API key, and model name, then retry",
             [
                 "`extract \"What is the revenue by segment?\" --file apple-10k.md`",
                 "`extract --questions-file questions.md --file apple-10k.md`",
@@ -183,7 +184,7 @@ def extract_cli_command(
         "-q",
         help="Markdown file containing the question/prompt pack to apply to the input document.",
     ),
-    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Gemini model to use."),
+    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Model to use (Gemini or OpenAI)."),
     max_tokens: int = typer.Option(DEFAULT_MAX_TOKENS, "--max-tokens", help="Maximum output tokens."),
     thinking: str | None = typer.Option(
         None,
@@ -276,13 +277,9 @@ def extract_files_command(
 ) -> CommandResult:
     start = time.perf_counter()
     active_settings = settings or get_settings()
-    if not active_settings.gemini_api_key:
-        return error_result(
-            "GEMINI_API_KEY is not set",
-            "set GEMINI_API_KEY and retry",
-            ["`export GEMINI_API_KEY=...`"],
-            start,
-        )
+    api_key = _api_key_for_model(active_settings, model)
+    if not api_key:
+        return _missing_api_key_result(model, start)
     if not out:
         return error_result(
             "no output directory was provided",
@@ -355,7 +352,7 @@ def extract_files_command(
             model=model,
             max_tokens=max_tokens,
             thinking=resolved_thinking,
-            api_key=active_settings.gemini_api_key,
+            api_key=api_key,
             concurrency=concurrency,
         )
     )
@@ -412,7 +409,7 @@ def extract_files_cli_command(
         "-q",
         help="Markdown file containing the question/prompt pack to apply to each source file.",
     ),
-    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Gemini model to use."),
+    model: str = typer.Option(DEFAULT_MODEL, "--model", help="Model to use (Gemini or OpenAI)."),
     max_tokens: int = typer.Option(DEFAULT_MAX_TOKENS, "--max-tokens", help="Maximum output tokens per file."),
     thinking: str | None = typer.Option(
         None,
@@ -745,8 +742,35 @@ def _api_model_name(model: str) -> str:
     return MODEL_ALIASES.get(model, model)
 
 
+def _is_openai_model(model: str) -> bool:
+    api_model = _api_model_name(model)
+    return model.startswith("openai/") or api_model.startswith(("gpt-", "chatgpt-", "o1", "o3", "o4"))
+
+
+def _api_key_for_model(settings: HarnessSettings, model: str) -> str | None:
+    if _is_openai_model(model):
+        return settings.openai_api_key
+    return settings.gemini_api_key
+
+
+def _missing_api_key_result(model: str, start: float) -> CommandResult:
+    if _is_openai_model(model):
+        return error_result(
+            "OPENAI_API_KEY is not set",
+            "set OPENAI_API_KEY and retry, or choose a Gemini model with GEMINI_API_KEY configured",
+            ["`export OPENAI_API_KEY=...`", "`--model gemini-3-flash`"],
+            start,
+        )
+    return error_result(
+        "GEMINI_API_KEY is not set",
+        "set GEMINI_API_KEY and retry, or choose an OpenAI model with OPENAI_API_KEY configured",
+        ["`export GEMINI_API_KEY=...`", "`--model gpt-5.5`"],
+        start,
+    )
+
+
 # ---------------------------------------------------------------------------
-# Gemini call
+# Model calls
 # ---------------------------------------------------------------------------
 
 
@@ -760,6 +784,25 @@ def _generate_answer(
     api_key: str,
 ) -> str:
     _ = document_text  # the prompt already includes it; this preserves a tap point for tests
+    if _is_openai_model(model):
+        return _generate_openai_answer(prompt=prompt, model=model, max_tokens=max_tokens, api_key=api_key)
+    return _generate_gemini_answer(
+        prompt=prompt,
+        model=model,
+        max_tokens=max_tokens,
+        thinking=thinking,
+        api_key=api_key,
+    )
+
+
+def _generate_gemini_answer(
+    *,
+    prompt: str,
+    model: str,
+    max_tokens: int,
+    thinking: str | None,
+    api_key: str,
+) -> str:
     try:
         from google import genai
     except ModuleNotFoundError as exc:
@@ -771,6 +814,40 @@ def _generate_answer(
     if not text:
         raise ValueError("Gemini returned an empty response")
     return str(text)
+
+
+def _generate_openai_answer(*, prompt: str, model: str, max_tokens: int, api_key: str) -> str:
+    try:
+        import openai
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise RuntimeError("openai is not installed") from exc
+
+    client = openai.OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model=_api_model_name(model),
+        input=prompt,
+        max_output_tokens=max_tokens,
+    )
+    text = _openai_response_text(response)
+    if not text:
+        raise ValueError("OpenAI returned an empty response")
+    return text
+
+
+def _openai_response_text(response: Any) -> str:
+    output_text = getattr(response, "output_text", None)
+    if output_text:
+        return str(output_text)
+
+    parts: list[str] = []
+    for item in getattr(response, "output", []) or []:
+        for content in getattr(item, "content", []) or []:
+            text = getattr(content, "text", None)
+            if text:
+                parts.append(str(text))
+            elif isinstance(content, dict) and content.get("text"):
+                parts.append(str(content["text"]))
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/src/harness/config.py
+++ b/src/harness/config.py
@@ -16,6 +16,7 @@ class HarnessSettings(BaseModel):
     edgar_identity: str | None = None
     parallel_api_key: str | None = None
     gemini_api_key: str | None = None
+    openai_api_key: str | None = None
     finnhub_api_key: str | None = None
     minerva_plot_theme: str = "minerva-classic"
 
@@ -39,6 +40,7 @@ def get_settings() -> HarnessSettings:
         edgar_identity=os.getenv("EDGAR_IDENTITY"),
         parallel_api_key=os.getenv("PARALLEL_API_KEY"),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
         finnhub_api_key=os.getenv("FINNHUB_API_KEY"),
         minerva_plot_theme=os.getenv("MINERVA_PLOT_THEME", "minerva-classic"),
     )

--- a/tests/test_harness/test_extract.py
+++ b/tests/test_harness/test_extract.py
@@ -106,6 +106,30 @@ def test_extract_command_passes_through_model_and_max_tokens(tmp_path: Path, mon
     assert captured["max_tokens"] == 2048
 
 
+def test_extract_command_gpt55_uses_openai_key_without_gemini_key(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, openai_api_key="openai-test-key")
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("body", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_command(
+        question="Q",
+        file_path=str(file_path),
+        model="gpt-5.5",
+        settings=settings,
+    )
+
+    assert result.exit_code == 0
+    assert captured["api_key"] == "openai-test-key"
+    assert captured["model"] == "gpt-5.5"
+
+
 def test_extract_questions_file_preserves_markdown_formatting(tmp_path: Path, monkeypatch) -> None:
     settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
     questions_file = tmp_path / "questions.md"
@@ -258,6 +282,11 @@ def test_build_thinking_config_unknown_model_with_thinking_raises() -> None:
 def test_api_model_name_maps_user_facing_gemini_3_flash_alias() -> None:
     assert extract._api_model_name("gemini-3-flash") == "gemini-3-flash-preview"
     assert extract._api_model_name("gemini-3-flash-preview") == "gemini-3-flash-preview"
+
+
+def test_api_model_name_maps_provider_qualified_openai_alias() -> None:
+    assert extract._api_model_name("openai/gpt-5.5") == "gpt-5.5"
+    assert extract._api_model_name("gpt-5.5") == "gpt-5.5"
 
 
 def test_extract_command_default_thinking_for_gemini_3_flash(tmp_path: Path, monkeypatch) -> None:
@@ -628,6 +657,87 @@ def test_extract_files_passes_model_thinking_max_tokens(tmp_path: Path, monkeypa
     assert captured[0]["model"] == "gemini-3-pro"
     assert captured[0]["thinking"] == "medium"
     assert captured[0]["max_tokens"] == 1024
+
+
+def test_extract_files_gpt55_uses_openai_key_without_gemini_key(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, openai_api_key="openai-test-key")
+    src = tmp_path / "source.md"
+    src.write_text("body", encoding="utf-8")
+    out = tmp_path / "out"
+    captured: list[dict] = []
+
+    def fake_generate(**kwargs):
+        captured.append(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(src)],
+        out=str(out),
+        model="gpt-5.5",
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 0, result.stderr.decode("utf-8")
+    assert captured[0]["model"] == "gpt-5.5"
+    assert captured[0]["api_key"] == "openai-test-key"
+    assert captured[0]["thinking"] is None
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["model"] == "gpt-5.5"
+    assert manifest["api_model"] == "gpt-5.5"
+
+
+def test_extract_files_gpt55_reports_missing_openai_key(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="gemini-test-key")
+    src = tmp_path / "source.md"
+    src.write_text("body", encoding="utf-8")
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(src)],
+        out=str(tmp_path / "out"),
+        model="gpt-5.5",
+        settings=settings,
+    )
+
+    assert result.exit_code == 1
+    assert b"OPENAI_API_KEY" in result.stderr
+
+
+def test_generate_openai_answer_uses_responses_api(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+
+            class Response:
+                output_text = "openai answer"
+
+            return Response()
+
+    class FakeClient:
+        def __init__(self, *, api_key: str):
+            captured["api_key"] = api_key
+            self.responses = FakeResponses()
+
+    monkeypatch.setattr("openai.OpenAI", FakeClient)
+
+    answer = extract._generate_openai_answer(
+        prompt="prompt",
+        model="openai/gpt-5.5",
+        max_tokens=123,
+        api_key="key",
+    )
+
+    assert answer == "openai answer"
+    assert captured["api_key"] == "key"
+    assert captured["model"] == "gpt-5.5"
+    assert captured["input"] == "prompt"
+    assert captured["max_output_tokens"] == 123
 
 
 def test_extract_files_mirrors_relative_paths(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- route OpenAI model names like gpt-5.5/gpt-4o through the OpenAI Responses API
- use OPENAI_API_KEY for OpenAI models while preserving Gemini defaults
- add tests for OpenAI model aliases, key selection, manifest output, and Responses API plumbing

## Validation
- uv run pytest tests/test_harness/test_extract.py -q
- uv run pytest tests/test_harness -q -k 'not wrapper_orchestrates_command_sequence_with_optional_sources and not wrapper_runs_macro_collect_when_no_macro_source_is_provided'
- live gpt-4o smoke reached OpenAI API but returned insufficient_quota (429) from configured key