### PR TITLE
fix: show concise error on partial CLI invocations

### DIFF
--- a/src/harness/commands/common.py
+++ b/src/harness/commands/common.py
@@ -95,7 +95,6 @@ def abort_with_help(
             what_went_wrong,
             what_to_do,
             alternatives,
-            help_text=ctx.get_help(),
         )
     )
     raise typer.Exit(exit_code)

--- a/tests/test_harness/test_cli.py
+++ b/tests/test_harness/test_cli.py
@@ -57,13 +57,12 @@ def test_dispatch_command_rejects_unknown_commands_without_subprocess(tmp_path: 
     assert "Available alternatives:" in stderr
 
 
-def test_direct_cli_missing_args_show_full_help_for_valuation_dcf() -> None:
+def test_direct_cli_missing_args_show_concise_error_for_valuation_dcf() -> None:
     result = runner.invoke(app, ["valuation", "dcf"])
 
     assert result.exit_code == 1
     assert "What went wrong:" in result.stdout
-    assert "Usage:" in result.stdout
-    assert "Run a discounted cash flow valuation." in result.stdout
+    assert "Usage:" not in result.stdout
 
 
 def test_direct_cli_missing_args_show_full_help_for_research() -> None:


### PR DESCRIPTION
## Problem
Partial CLI invocations (e.g. `minerva extract-files -f foo.md -o out` without a question) dumped the full help panel (~40 lines) above the structured error. Wastes context when the 3-line error is self-sufficient.

## Fix
Stop passing `help_text=ctx.get_help()` in `abort_with_help`. The `format_error` signature keeps its `help_text` kwarg for future use — we just don't supply it.

Affects all 35 `abort_with_help` call sites across 9 command files. Bare invocations (`minerva extract-files` with zero args) still show clean help via `show_help_if_bare`.

## Validation
- 170 passed (excluding 2 pre-existing morning-brief failures)
- Manual spot-check: extract, extract-files, sec, valuation — all concise