### PR TITLE
fix: pass OpenAI reasoning effort for extract-files

### DIFF
--- a/src/harness/commands/extract.py
+++ b/src/harness/commands/extract.py
@@ -86,6 +86,8 @@ SYSTEM_PROMPT = (
 )
 
 VALID_THINKING_LEVELS: frozenset[str] = frozenset({"off", "minimal", "low", "medium", "high", "adaptive"})
+OPENAI_REASONING_EFFORTS: frozenset[str] = frozenset({"minimal", "low", "medium", "high"})
+OPENAI_THINKING_LEVELS: frozenset[str] = OPENAI_REASONING_EFFORTS | {"off"}
 
 app = typer.Typer(help=EXTRACT_HELP, no_args_is_help=False, invoke_without_command=True)
 extract_files_app = typer.Typer(help=EXTRACT_FILES_HELP, no_args_is_help=False, invoke_without_command=True)
@@ -687,6 +689,14 @@ def _build_thinking_config(model: str, thinking: str | None):
             f"unknown thinking level `{thinking}` (expected one of {sorted(VALID_THINKING_LEVELS)})"
         )
 
+    if _is_openai_model(model):
+        if thinking in OPENAI_THINKING_LEVELS:
+            return None  # OpenAI reasoning is passed directly in _generate_openai_answer.
+        raise ValueError(
+            f"`--thinking {thinking}` is not supported for OpenAI models; "
+            "use off|minimal|low|medium|high"
+        )
+
     try:
         from google.genai import types as genai_types
     except ModuleNotFoundError as exc:  # pragma: no cover
@@ -785,7 +795,7 @@ def _generate_answer(
 ) -> str:
     _ = document_text  # the prompt already includes it; this preserves a tap point for tests
     if _is_openai_model(model):
-        return _generate_openai_answer(prompt=prompt, model=model, max_tokens=max_tokens, api_key=api_key)
+        return _generate_openai_answer(prompt=prompt, model=model, max_tokens=max_tokens, thinking=thinking, api_key=api_key)
     return _generate_gemini_answer(
         prompt=prompt,
         model=model,
@@ -816,18 +826,21 @@ def _generate_gemini_answer(
     return str(text)
 
 
-def _generate_openai_answer(*, prompt: str, model: str, max_tokens: int, api_key: str) -> str:
+def _generate_openai_answer(*, prompt: str, model: str, max_tokens: int, thinking: str | None = None, api_key: str) -> str:
     try:
         import openai
     except ModuleNotFoundError as exc:  # pragma: no cover
         raise RuntimeError("openai is not installed") from exc
 
     client = openai.OpenAI(api_key=api_key)
-    response = client.responses.create(
-        model=_api_model_name(model),
-        input=prompt,
-        max_output_tokens=max_tokens,
-    )
+    kwargs: dict[str, Any] = {
+        "model": _api_model_name(model),
+        "input": prompt,
+        "max_output_tokens": max_tokens,
+    }
+    if thinking in OPENAI_REASONING_EFFORTS:
+        kwargs["reasoning"] = {"effort": thinking}
+    response = client.responses.create(**kwargs)
     text = _openai_response_text(response)
     if not text:
         raise ValueError("OpenAI returned an empty response")

--- a/tests/test_harness/test_extract.py
+++ b/tests/test_harness/test_extract.py
@@ -265,6 +265,17 @@ def test_build_thinking_config_gemini_25_rejects_levels() -> None:
         extract._build_thinking_config("gemini-2.5-pro", "minimal")
 
 
+def test_build_thinking_config_openai_accepts_reasoning_levels() -> None:
+    assert extract._build_thinking_config("gpt-5.5", "off") is None
+    assert extract._build_thinking_config("gpt-5.5", "minimal") is None
+    assert extract._build_thinking_config("gpt-5.5", "high") is None
+
+
+def test_build_thinking_config_openai_rejects_adaptive() -> None:
+    with pytest.raises(ValueError, match="OpenAI"):
+        extract._build_thinking_config("gpt-5.5", "adaptive")
+
+
 def test_build_thinking_config_invalid_level_raises() -> None:
     with pytest.raises(ValueError):
         extract._build_thinking_config("gemini-3-flash", "nonsense")
@@ -690,6 +701,36 @@ def test_extract_files_gpt55_uses_openai_key_without_gemini_key(tmp_path: Path, 
     assert manifest["api_model"] == "gpt-5.5"
 
 
+def test_extract_files_gpt55_passes_openai_thinking(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, openai_api_key="openai-test-key")
+    src = tmp_path / "source.md"
+    src.write_text("body", encoding="utf-8")
+    out = tmp_path / "out"
+    captured: list[dict] = []
+
+    def fake_generate(**kwargs):
+        captured.append(kwargs)
+        return "answer"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+
+    result = extract.extract_files_command(
+        question="Q",
+        files=[str(src)],
+        out=str(out),
+        model="gpt-5.5",
+        thinking="high",
+        concurrency=1,
+        settings=settings,
+    )
+
+    assert result.exit_code == 0, result.stderr.decode("utf-8")
+    assert captured[0]["model"] == "gpt-5.5"
+    assert captured[0]["thinking"] == "high"
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["thinking"] == "high"
+
+
 def test_extract_files_gpt55_reports_missing_openai_key(tmp_path: Path) -> None:
     settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="gemini-test-key")
     src = tmp_path / "source.md"
@@ -738,6 +779,37 @@ def test_generate_openai_answer_uses_responses_api(monkeypatch) -> None:
     assert captured["model"] == "gpt-5.5"
     assert captured["input"] == "prompt"
     assert captured["max_output_tokens"] == 123
+
+
+def test_generate_openai_answer_passes_reasoning_effort(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+
+            class Response:
+                output_text = "openai answer"
+
+            return Response()
+
+    class FakeClient:
+        def __init__(self, *, api_key: str):
+            captured["api_key"] = api_key
+            self.responses = FakeResponses()
+
+    monkeypatch.setattr("openai.OpenAI", FakeClient)
+
+    answer = extract._generate_openai_answer(
+        prompt="prompt",
+        model="gpt-5.5",
+        max_tokens=123,
+        thinking="high",
+        api_key="key",
+    )
+
+    assert answer == "openai answer"
+    assert captured["reasoning"] == {"effort": "high"}
 
 
 def test_extract_files_mirrors_relative_paths(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem
`minerva extract-files --model gpt-5.5 --thinking high` validated the thinking flag but did not forward it to OpenAI's Responses API. Charlie's local scoring run needed a patch so gpt-5.5 could actually use high reasoning.

## Fix
- Add OpenAI-specific thinking validation
- Pass `reasoning={"effort": ...}` for OpenAI `minimal|low|medium|high`
- Treat `--thinking off` as no reasoning payload
- Reject `--thinking adaptive` for OpenAI instead of silently dropping it
- Add regression coverage for OpenAI thinking validation, extract-files propagation, and Responses API kwargs

## Validation
```
uv run pytest tests/test_harness/test_extract.py -q
50 passed

uv run pytest tests/test_harness -q
176 passed

Live smoke:
minerva extract-files --model gpt-5.5 --thinking high ...
status: ok
```