### PR TITLE
fix: skip non-US companies in Finnhub company-news + redact token from error log

### DIFF
--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -1809,6 +1809,8 @@ def _load_finnhub_payload(
             ).strip()
             if not finnhub_sym:
                 continue
+            if not security.get("sec_registered"):
+                continue
             try:
                 time_mod.sleep(delay)
                 cn_response = session.get(
@@ -1823,7 +1825,12 @@ def _load_finnhub_payload(
                     item["_finnhub_symbol"] = finnhub_sym
                 company_news.extend(items)
             except Exception as exc:
-                logger.warning("failed to fetch company news for %s: %s", finnhub_sym, exc)
+                status = getattr(getattr(exc, "response", None), "status_code", None)
+                logger.warning(
+                    "skipping company-news for %s: %s",
+                    finnhub_sym,
+                    f"HTTP {status}" if status else type(exc).__name__,
+                )
 
     return {
         "earnings": earnings_payload.get("earningsCalendar", earnings_payload.get("earnings", [])),


### PR DESCRIPTION
## What

Two targeted fixes in `_load_finnhub_payload` (morning_brief.py):

**1. Skip non-SEC-registered companies**
Added `if not security.get("sec_registered"): continue` before the Finnhub `company-news` call. Home-exchange-only symbols (`.AX`, `.ST`, `.V`, `.KS`, etc.) return 403 on the current Finnhub plan — this filter silently skips them. Only `sec_registered=True` entries (US-listed + ADRs like TSM/SPOT) proceed.

**2. Redact API token from error log**
The previous `logger.warning(..., exc)` call logged the full `HTTPError` string, which includes the full URL with the API token as a query param. Now logs only `HTTP {status}` or the exception class name.

## Context
- Portfolio was re-enriched via `portfolio sync` + `portfolio enrich` before this fix — all securities now have correct `sec_registered` metadata.
- Non-US names in the universe: AIM.AX, KPG.AX, HEM.ST, TOI.V, ZDC.V, 000660.KS, 005930.KS — all will be silently skipped.
- US-listed ADRs (TSM, SPOT, BKNG) remain unaffected (`sec_registered=True`).