### PR TITLE
feat(portfolio): add game_plan field to thesis cards

### DIFF
--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -256,6 +256,7 @@ def set_thesis_command(
     summary: str,
     core_thesis: list[str],
     signals: list[str],
+    game_plan: str | None = None,
     settings: HarnessSettings,
 ) -> CommandResult:
     """Create or replace one thesis card definition."""
@@ -268,6 +269,7 @@ def set_thesis_command(
             summary=summary,
             core_thesis=core_thesis,
             signals=signals,
+            game_plan=game_plan,
         )
     except Exception as exc:
         return error_result(
@@ -438,6 +440,7 @@ def thesis_set_cli(
     summary: str | None = typer.Option(None, "--summary", help="Compact thesis summary."),
     core_thesis: list[str] = typer.Option([], "--core-thesis", help="Core thesis bullet; repeat up to 5."),
     signals: list[str] = typer.Option([], "--signal", help="Signal bullet; repeat up to 5."),
+    game_plan: str | None = typer.Option(None, "--game-plan", help="Game plan for this thesis; omit to preserve existing."),
 ) -> None:
     show_help_if_bare(ctx, card_id=card_id, summary=summary)
     if not card_id:
@@ -451,6 +454,7 @@ def thesis_set_cli(
             summary=summary,
             core_thesis=core_thesis,
             signals=signals,
+            game_plan=game_plan,
             settings=get_settings(),
         )
     )
@@ -551,6 +555,7 @@ def _dispatch_thesis(args: list[str], settings: HarnessSettings) -> CommandResul
             summary=_one_flag_value(parsed, "summary"),
             core_thesis=parsed.get("core-thesis", []),
             signals=parsed.get("signal", []),
+            game_plan=_optional_flag_value(parsed, "game-plan"),
             settings=settings,
         )
     if action == "metric":

--- a/src/harness/portfolio_state.py
+++ b/src/harness/portfolio_state.py
@@ -63,6 +63,7 @@ class ThesisCard(TypedDict):
     core_thesis: list[str]
     key_metrics: list[ThesisMetric]
     signals: list[str]
+    game_plan: NotRequired[str]
     updated_at: str
 
 
@@ -453,6 +454,7 @@ def set_thesis_card(
     summary: str,
     core_thesis: list[str],
     signals: list[str],
+    game_plan: str | None = None,
 ) -> ThesisCard:
     """Create or replace a thesis card definition while preserving metrics."""
     paths = ensure_portfolio_layout(workspace_root)
@@ -467,6 +469,12 @@ def set_thesis_card(
 
     cards = _load_thesis_cards(paths)
     existing = next((card for card in cards if card.get("card_id") == normalized_card_id), None)
+    # Preserve-on-omit: when game_plan is None (flag not passed) keep the existing
+    # value; when an explicit string is passed, strip and use it (empty string clears).
+    if game_plan is None:
+        normalized_game_plan = str(existing.get("game_plan", "")).strip() if existing else ""
+    else:
+        normalized_game_plan = game_plan.strip()
     replacement: ThesisCard = {
         "card_id": normalized_card_id,
         "ticker_symbols": normalized_tickers,
@@ -474,6 +482,7 @@ def set_thesis_card(
         "core_thesis": normalized_core_thesis,
         "key_metrics": list(existing.get("key_metrics", [])) if existing else [],
         "signals": normalized_signals,
+        "game_plan": normalized_game_plan,
         "updated_at": now_utc_iso(),
     }
     updated_cards = [card for card in cards if card.get("card_id") != normalized_card_id]
@@ -854,6 +863,7 @@ def render_thesis_markdown(cards: Sequence[Mapping[str, object]]) -> str:
         tickers = ", ".join(f"`{ticker}`" for ticker in card.get("ticker_symbols", [])) or "None"
         core_thesis = [f"- {item}" for item in card.get("core_thesis", [])] or ["- None"]
         signals = [f"- {item}" for item in card.get("signals", [])] or ["- None"]
+        game_plan = str(card.get("game_plan", "")).strip()
         lines.extend(
             [
                 f"## {card['card_id']}",
@@ -862,6 +872,9 @@ def render_thesis_markdown(cards: Sequence[Mapping[str, object]]) -> str:
                 f"- Updated: {card.get('updated_at', '')}",
                 "",
                 str(card.get("summary", "")).strip() or "(no thesis summary)",
+                "",
+                "### Game Plan",
+                game_plan or "(no game plan)",
                 "",
                 "### Core Thesis",
                 *core_thesis,

--- a/tests/test_harness/test_thesis_cards.py
+++ b/tests/test_harness/test_thesis_cards.py
@@ -104,6 +104,54 @@ class ThesisCardV2Tests(unittest.TestCase):
         self.assertIn("| Period | Date | Value | Source |", rendered)
         self.assertIn("| Q1 FY2027 | 2026-06-02 | 116% | earnings call |", rendered)
 
+    def test_thesis_game_plan_set_preserve_clear_and_render(self) -> None:
+        cards_path = self.workspace / "data" / "01-portfolio" / "current" / "thesis-cards.json"
+        rendered_path = self.workspace / "data" / "01-portfolio" / "current" / "thesis-cards.md"
+
+        # 1. Set with an explicit game plan.
+        card = set_thesis_card(
+            self.workspace,
+            card_id="gtlb",
+            ticker_symbols=["GTLB"],
+            summary="DevSecOps compounder",
+            core_thesis=["Platform consolidation"],
+            signals=["NRR > 120%"],
+            game_plan="Hold to 2028. Add below 25x fwd rev.",
+        )
+        self.assertEqual(card["game_plan"], "Hold to 2028. Add below 25x fwd rev.")
+
+        rendered = rendered_path.read_text(encoding="utf-8")
+        self.assertIn("### Game Plan", rendered)
+        self.assertIn("Hold to 2028. Add below 25x fwd rev.", rendered)
+
+        # 2. Preserve-on-omit: re-set without game_plan keeps the existing value.
+        set_thesis_card(
+            self.workspace,
+            card_id="gtlb",
+            ticker_symbols=["GTLB"],
+            summary="DevSecOps compounder v2",
+            core_thesis=["Platform consolidation"],
+            signals=["NRR > 120%"],
+        )
+        cards = load_json(cards_path, default=[])
+        self.assertEqual(cards[0]["summary"], "DevSecOps compounder v2")
+        self.assertEqual(cards[0]["game_plan"], "Hold to 2028. Add below 25x fwd rev.")
+
+        # 3. Explicit empty string clears the game plan.
+        set_thesis_card(
+            self.workspace,
+            card_id="gtlb",
+            ticker_symbols=["GTLB"],
+            summary="DevSecOps compounder v2",
+            core_thesis=["Platform consolidation"],
+            signals=["NRR > 120%"],
+            game_plan="",
+        )
+        cards = load_json(cards_path, default=[])
+        self.assertEqual(cards[0]["game_plan"], "")
+        rendered = rendered_path.read_text(encoding="utf-8")
+        self.assertIn("(no game plan)", rendered)
+
     def test_thesis_by_ticker_cross_card(self) -> None:
         set_thesis_card(
             self.workspace,


### PR DESCRIPTION
Adds an optional `game_plan` string to thesis cards so each thesis can carry a written game plan.

## Changes (5 spots, as scoped)
- `ThesisCard` TypedDict — `game_plan: NotRequired[str]`
- `set_thesis_card()` — accepts `game_plan`; **preserve-on-omit** (like `key_metrics`); explicit empty string clears
- `render_thesis_markdown()` — emits a `### Game Plan` section
- `set_thesis_command()` + `thesis_set_cli()` — `--game-plan` option threaded through
- `thesis_command` dispatch path — pulls `game-plan` from `_parse_repeated_flag_args`

## Testing
- Existing thesis tests pass (5) + new test covering set/preserve/clear/render (6 total)
- Real CLI round-trip on a throwaway workspace through both code paths (Typer + `minerva run`): set → render (Game Plan section), re-set without flag preserves, empty flag clears

Backward-compatible: cards without `game_plan` read as empty.