### PR TITLE
feat(portfolio): 52-week price position tracking

### DIFF
--- a/docs/plans/2026-07-01-price-tracking.md
+++ b/docs/plans/2026-07-01-price-tracking.md
@@ -2,130 +2,85 @@
 
 ## Goal
 
-Track current price against the 52-week range for tracked companies, so we can sort by
-where each stock sits in its band (0 = on 52w low, 1 = on 52w high). Data source is
-Finnhub (already wired into the harness via `FINNHUB_API_KEY`).
+Track current price against the 52-week range for every company in the DB and sort by
+where each sits in its band (`0` = on 52w low, `1` = on 52w high). Source is Yahoo Finance,
+which covers US and international listings with one keyless call per ticker.
 
 ## Command surface
 
 ```
-minerva portfolio prices                 # read-only: print stored table, sorted by range_pct. Zero API calls.
-minerva portfolio prices AAPL            # fetch AAPL live, upsert, print it
-minerva portfolio prices AAPL MSFT       # fetch several, upsert, print them
-minerva portfolio prices --refresh       # fetch every company in the table
+minerva portfolio prices              # read stored table, sorted by range_pct; zero network
+minerva portfolio prices AAPL         # fetch + persist one ticker
+minerva portfolio prices AAPL MSFT    # fetch + persist several
+minerva portfolio prices --refresh    # fetch every company in the DB
 ```
 
-**One rule:** naming tickers (or `--refresh`) fetches live + persists; naming nothing is a
-read-only view. `--refresh` means "the universe is every company in the table."
+Naming tickers (or `--refresh`) fetches live and upserts; naming nothing is a read-only view.
 
-Refresh universe = all `companies` with a non-empty ticker. No priority filtering:
-a full refresh (2 calls/ticker, paced under the rate limit) is cheap enough that
-filtering isn't worth the complexity. If a priority subset is ever wanted, drive it
-from actual portfolio holdings or a real interest flag — not a documentation-state
-proxy like `folder_exists`.
-NOTE: the live `companies` table uses `folder_exists`/`categories`, not the `status`
-column in the repo's schema.sql (which drifted ahead of the actual DB). We no longer
-depend on either for the universe.
+## Data source: Yahoo Finance chart endpoint
 
-## Data model
+`GET https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&range=1d`
+(header `User-Agent: Mozilla/5.0`). One call returns both current price and 52-week
+high/low from `chart.result[0].meta`: `regularMarketPrice`, `fiftyTwoWeekLow`,
+`fiftyTwoWeekHigh`, `currency`.
 
-New table + view in `hard-disk/data/04-database/schema.sql` (idempotent, re-runnable):
+Unofficial endpoint: treat any non-2xx, empty `result`, or missing price as a per-ticker
+failure (collected, never fatal). Prices are stored in native currency; `range_pct` is a
+within-currency ratio so currency never affects it.
+
+## Symbols and exchange
+
+Yahoo needs exchange-suffixed symbols for non-US listings (`TOI` alone hits a different US
+security; `TOI.V` is Topicus). Fix at the data layer:
+
+- Add `exchange TEXT` to `companies` (human-readable market code, e.g. `TSX`, `ASX`, `LSE`,
+  `TSE`, `TSXV`, `ETR`, `EPA`, `AMS`, `SWX`, `STO`, `BME`; NULL/empty ⇒ US).
+- The Yahoo symbol is **derived**, not stored: `yahoo_symbol(ticker, exchange)` appends the
+  suffix for the exchange (US ⇒ bare ticker; symbols already carrying a `.` pass through).
+- Backfill `exchange` for the ~27 non-US names (validated against Yahoo). Fortnox (`FNOX`) is
+  delisted (taken private 2025) — leaves it unresolvable by design.
+
+## Data model (invest.db)
 
 ```sql
-CREATE TABLE IF NOT EXISTS prices (
-    id          INTEGER PRIMARY KEY,
-    ticker      TEXT NOT NULL,
-    as_of       TEXT NOT NULL,            -- ISO date of the pull (UTC)
-    current     REAL,
-    wk52_low    REAL,
-    wk52_high   REAL,
-    low_date    TEXT,                     -- Finnhub 52WeekLowDate (bonus context)
-    high_date   TEXT,                     -- Finnhub 52WeekHighDate
-    source      TEXT NOT NULL DEFAULT 'finnhub',
-    fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE (ticker, as_of)                -- one row per ticker per day; re-pull upserts
+CREATE TABLE prices (
+    id INTEGER PRIMARY KEY,
+    ticker TEXT NOT NULL, as_of TEXT NOT NULL,          -- as_of = ISO pull date (UTC)
+    current REAL, wk52_low REAL, wk52_high REAL,
+    currency TEXT, source TEXT NOT NULL DEFAULT 'yahoo',
+    fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (ticker, as_of)                              -- same-day re-pull upserts
 );
-CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices(ticker);
-CREATE INDEX IF NOT EXISTS idx_prices_asof   ON prices(as_of);
-
--- range_pct computed on read, never stored (avoids drift if inputs get corrected).
-CREATE VIEW IF NOT EXISTS price_position AS
-SELECT
-    ticker, as_of, current, wk52_low, wk52_high, low_date, high_date,
-    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
+CREATE VIEW price_position AS
+SELECT ticker, as_of, current, wk52_low, wk52_high, currency,
+       ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
 FROM prices;
 ```
 
-`range_pct = (current - low) / (high - low)` — bounded 0..1, comparable across companies.
-`NULLIF` guards divide-by-zero when high == low.
+`range_pct` is computed on read, never stored, so a corrected input can't leave a stale
+value. `NULLIF` guards the high == low divide-by-zero.
 
-Upsert keeps latest pull per (ticker, day):
-`INSERT ... ON CONFLICT(ticker, as_of) DO UPDATE SET ...`.
+## Code
 
-## Finnhub calls (2 per ticker)
+- `src/minerva/prices.py`:
+  - `PriceRow`, `range_pct`, `ensure_schema`, `upsert_prices`, `read_positions` — unchanged
+    logic (schema gains `currency`, drops the Finnhub-specific `low_date`/`high_date`).
+  - `yahoo_symbol(ticker, exchange)` — pure suffix derivation.
+  - `tracked_companies(db)` — returns `(ticker, exchange)` for every non-empty ticker.
+  - `fetch_price(ticker, *, exchange, session, limiter)` — one Yahoo call → `PriceRow`.
+  - `refresh_prices(db, companies, *, fetcher=fetch_price, limiter)` — orchestration; fetcher
+    injectable so tests need no HTTP mock. `RateLimiter` at ~0.3s spacing (Yahoo tolerant;
+    politeness only).
+- `src/harness/commands/portfolio.py`: thin `prices` subcommand + dispatch. No API key.
 
-| Endpoint | Field | Meaning |
-|---|---|---|
-| `/quote?symbol=X` | `c` | current price (ignore `h`/`l` — those are today's intraday range) |
-| `/stock/metric?symbol=X&metric=price` | `metric.52WeekHigh`, `metric.52WeekLow`, `...HighDate`, `...LowDate` | 52-week band |
+## Tests (`tests/test_minerva/test_prices.py`, real temp DB, injectable fetcher)
 
-## Rate limiting
+`range_pct` math incl. high == low → None; upsert idempotency; `read_positions` sort order;
+`yahoo_symbol` (US bare, TSX→`.TO`, TSXV→`.V`, ASX→`.AX`, already-suffixed passthrough);
+`tracked_companies` returns ticker+exchange; `refresh_prices` persists all via fake fetcher
+and isolates a raising ticker into `errors`; `RateLimiter` spacing.
 
-Finnhub free tier: **60 calls/min**. We spend **2 calls/ticker**, so a full refresh of N
-tickers = 2N calls.
+## Out of scope
 
-- Pace all calls through a shared limiter that guarantees <= 60 calls/min with margin
-  (target ~50/min → one call every ~1.2s). Simple sleep-based spacer keyed on a monotonic
-  clock; no threads.
-- On HTTP 429: respect `Retry-After` header if present, else exponential backoff
-  (1s, 2s, 4s, cap 30s), max 3 retries, then record the ticker as an error and continue.
-- Per-ticker failures never abort the whole run — collect into an errors list, report at end.
-- ~30 tickers/min throughput. Fine for a portfolio-sized universe; if the tracked set grows
-  past ~200 the full refresh takes a few minutes, which is acceptable for a daily pull.
-
-## Code layout
-
-- `src/minerva/prices.py` — pure logic, no Typer:
-  - `PriceRow` dataclass (ticker, as_of, current, wk52_low, wk52_high, low_date, high_date)
-  - `range_pct(row) -> float | None` — the formula, single source of truth
-  - `RateLimiter` — monotonic spacer, `min_interval` configurable
-  - `fetch_price(ticker, *, api_key, session, limiter) -> PriceRow` — the 2 Finnhub calls +
-    429 handling. Network isolated here.
-  - `upsert_prices(db_path, rows)` / `read_positions(db_path, *, tickers=None)` — sqlite3 CLI-free,
-    use stdlib `sqlite3`.
-  - `refresh_prices(db_path, tickers, *, api_key, fetcher=fetch_price, limiter=...)` —
-    orchestration. `fetcher` is injectable so tests pass a fake (no requests mocking).
-- `src/harness/commands/portfolio.py` — thin `prices` subcommand: parse args, resolve
-  universe from DB when `--refresh`, call into `minerva.prices`, format output envelope.
-
-## Tests (short, useful, no heavy mocking)
-
-`tests/test_minerva/test_prices.py` (stdlib `unittest`, real temp sqlite DB):
-
-1. `range_pct` math: low/mid/high positions, and high==low → None (no crash).
-2. Upsert idempotency: two pulls same (ticker, day) → one row, latest wins.
-3. `read_positions` ordering: rows come back sorted by range_pct; view computes it correctly.
-4. `refresh_prices` with an injected fake fetcher (no network): given 3 fake tickers,
-   3 rows land in DB with correct range_pct. One fetcher raising → recorded as error,
-   others still persist.
-5. `RateLimiter` spacing: two back-to-back acquisitions are >= min_interval apart
-   (use a tiny interval so the test is fast, assert monotonic delta).
-
-No mocking of `requests`. Network isolated behind the injectable `fetcher`; the real
-`fetch_price` is exercised manually / left to a live smoke check, not the unit suite.
-
-## Out of scope (for now)
-
-- Automatic daily cron into the morning brief (easy follow-up once this is stable).
-- Historical charting of range_pct over time (the table supports it; UI is later).
-
-## TDD order
-
-1. schema.sql additions + a schema-apply test (table + view exist).
-2. `range_pct` + tests.
-3. `upsert_prices` / `read_positions` + tests (temp DB).
-4. `RateLimiter` + test.
-5. `refresh_prices` with injectable fetcher + tests.
-6. Real `fetch_price` (Finnhub) — thin, covered by a live smoke check.
-7. Wire `portfolio prices` subcommand + dispatch.
-8. Live smoke: `minerva portfolio prices AAPL` against real Finnhub.
+Currency/FX normalization for cross-listing price comparison; daily cron into the morning
+brief; stale-listing cleanup in `companies` (e.g. delisted Fortnox).

--- a/docs/plans/2026-07-01-price-tracking.md
+++ b/docs/plans/2026-07-01-price-tracking.md
@@ -12,14 +12,20 @@ Finnhub (already wired into the harness via `FINNHUB_API_KEY`).
 minerva portfolio prices                 # read-only: print stored table, sorted by range_pct. Zero API calls.
 minerva portfolio prices AAPL            # fetch AAPL live, upsert, print it
 minerva portfolio prices AAPL MSFT       # fetch several, upsert, print them
-minerva portfolio prices --refresh       # fetch ALL tracked companies, upsert all
+minerva portfolio prices --refresh       # fetch every company in the table
 ```
 
 **One rule:** naming tickers (or `--refresh`) fetches live + persists; naming nothing is a
-read-only view. `--refresh` just means "the universe is every tracked company."
+read-only view. `--refresh` means "the universe is every company in the table."
 
-Refresh universe = `companies` where `status IN ('tracking','owned')`. (Exited/passed names
-are excluded by default; `--all-status` flag can override if we want everything.)
+Refresh universe = all `companies` with a non-empty ticker. No priority filtering:
+a full refresh (2 calls/ticker, paced under the rate limit) is cheap enough that
+filtering isn't worth the complexity. If a priority subset is ever wanted, drive it
+from actual portfolio holdings or a real interest flag — not a documentation-state
+proxy like `folder_exists`.
+NOTE: the live `companies` table uses `folder_exists`/`categories`, not the `status`
+column in the repo's schema.sql (which drifted ahead of the actual DB). We no longer
+depend on either for the universe.
 
 ## Data model
 

--- a/docs/plans/2026-07-01-price-tracking.md
+++ b/docs/plans/2026-07-01-price-tracking.md
@@ -63,14 +63,16 @@ value. `NULLIF` guards the high == low divide-by-zero.
 ## Code
 
 - `src/minerva/prices.py`:
-  - `PriceRow`, `range_pct`, `ensure_schema`, `upsert_prices`, `read_positions` — unchanged
-    logic (schema gains `currency`, drops the Finnhub-specific `low_date`/`high_date`).
+  - `PriceRow`, `range_pct`, `ensure_schema`, `upsert_prices`, `read_positions` — schema/model
+    and persistence. `read_positions` LEFT JOINs `companies` for the exchange label.
   - `yahoo_symbol(ticker, exchange)` — pure suffix derivation.
   - `tracked_companies(db)` — returns `(ticker, exchange)` for every non-empty ticker.
-  - `fetch_price(ticker, *, exchange, session, limiter)` — one Yahoo call → `PriceRow`.
+  - `fetch_price(ticker, *, exchange, session, limiter)` — one Yahoo call → `PriceRow`;
+    retries transient empty responses, raises on genuine 404 (delisted).
   - `refresh_prices(db, companies, *, fetcher=fetch_price, limiter)` — orchestration; fetcher
     injectable so tests need no HTTP mock. `RateLimiter` at ~0.3s spacing (Yahoo tolerant;
     politeness only).
+  - Float coercion reuses `minerva.formatting.to_float` (shared, not a local helper).
 - `src/harness/commands/portfolio.py`: thin `prices` subcommand + dispatch. No API key.
 
 ## Tests (`tests/test_minerva/test_prices.py`, real temp DB, injectable fetcher)

--- a/docs/plans/2026-07-01-price-tracking.md
+++ b/docs/plans/2026-07-01-price-tracking.md
@@ -1,0 +1,125 @@
+# Plan: 52-Week Price Position Tracking
+
+## Goal
+
+Track current price against the 52-week range for tracked companies, so we can sort by
+where each stock sits in its band (0 = on 52w low, 1 = on 52w high). Data source is
+Finnhub (already wired into the harness via `FINNHUB_API_KEY`).
+
+## Command surface
+
+```
+minerva portfolio prices                 # read-only: print stored table, sorted by range_pct. Zero API calls.
+minerva portfolio prices AAPL            # fetch AAPL live, upsert, print it
+minerva portfolio prices AAPL MSFT       # fetch several, upsert, print them
+minerva portfolio prices --refresh       # fetch ALL tracked companies, upsert all
+```
+
+**One rule:** naming tickers (or `--refresh`) fetches live + persists; naming nothing is a
+read-only view. `--refresh` just means "the universe is every tracked company."
+
+Refresh universe = `companies` where `status IN ('tracking','owned')`. (Exited/passed names
+are excluded by default; `--all-status` flag can override if we want everything.)
+
+## Data model
+
+New table + view in `hard-disk/data/04-database/schema.sql` (idempotent, re-runnable):
+
+```sql
+CREATE TABLE IF NOT EXISTS prices (
+    id          INTEGER PRIMARY KEY,
+    ticker      TEXT NOT NULL,
+    as_of       TEXT NOT NULL,            -- ISO date of the pull (UTC)
+    current     REAL,
+    wk52_low    REAL,
+    wk52_high   REAL,
+    low_date    TEXT,                     -- Finnhub 52WeekLowDate (bonus context)
+    high_date   TEXT,                     -- Finnhub 52WeekHighDate
+    source      TEXT NOT NULL DEFAULT 'finnhub',
+    fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (ticker, as_of)                -- one row per ticker per day; re-pull upserts
+);
+CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices(ticker);
+CREATE INDEX IF NOT EXISTS idx_prices_asof   ON prices(as_of);
+
+-- range_pct computed on read, never stored (avoids drift if inputs get corrected).
+CREATE VIEW IF NOT EXISTS price_position AS
+SELECT
+    ticker, as_of, current, wk52_low, wk52_high, low_date, high_date,
+    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
+FROM prices;
+```
+
+`range_pct = (current - low) / (high - low)` — bounded 0..1, comparable across companies.
+`NULLIF` guards divide-by-zero when high == low.
+
+Upsert keeps latest pull per (ticker, day):
+`INSERT ... ON CONFLICT(ticker, as_of) DO UPDATE SET ...`.
+
+## Finnhub calls (2 per ticker)
+
+| Endpoint | Field | Meaning |
+|---|---|---|
+| `/quote?symbol=X` | `c` | current price (ignore `h`/`l` — those are today's intraday range) |
+| `/stock/metric?symbol=X&metric=price` | `metric.52WeekHigh`, `metric.52WeekLow`, `...HighDate`, `...LowDate` | 52-week band |
+
+## Rate limiting
+
+Finnhub free tier: **60 calls/min**. We spend **2 calls/ticker**, so a full refresh of N
+tickers = 2N calls.
+
+- Pace all calls through a shared limiter that guarantees <= 60 calls/min with margin
+  (target ~50/min → one call every ~1.2s). Simple sleep-based spacer keyed on a monotonic
+  clock; no threads.
+- On HTTP 429: respect `Retry-After` header if present, else exponential backoff
+  (1s, 2s, 4s, cap 30s), max 3 retries, then record the ticker as an error and continue.
+- Per-ticker failures never abort the whole run — collect into an errors list, report at end.
+- ~30 tickers/min throughput. Fine for a portfolio-sized universe; if the tracked set grows
+  past ~200 the full refresh takes a few minutes, which is acceptable for a daily pull.
+
+## Code layout
+
+- `src/minerva/prices.py` — pure logic, no Typer:
+  - `PriceRow` dataclass (ticker, as_of, current, wk52_low, wk52_high, low_date, high_date)
+  - `range_pct(row) -> float | None` — the formula, single source of truth
+  - `RateLimiter` — monotonic spacer, `min_interval` configurable
+  - `fetch_price(ticker, *, api_key, session, limiter) -> PriceRow` — the 2 Finnhub calls +
+    429 handling. Network isolated here.
+  - `upsert_prices(db_path, rows)` / `read_positions(db_path, *, tickers=None)` — sqlite3 CLI-free,
+    use stdlib `sqlite3`.
+  - `refresh_prices(db_path, tickers, *, api_key, fetcher=fetch_price, limiter=...)` —
+    orchestration. `fetcher` is injectable so tests pass a fake (no requests mocking).
+- `src/harness/commands/portfolio.py` — thin `prices` subcommand: parse args, resolve
+  universe from DB when `--refresh`, call into `minerva.prices`, format output envelope.
+
+## Tests (short, useful, no heavy mocking)
+
+`tests/test_minerva/test_prices.py` (stdlib `unittest`, real temp sqlite DB):
+
+1. `range_pct` math: low/mid/high positions, and high==low → None (no crash).
+2. Upsert idempotency: two pulls same (ticker, day) → one row, latest wins.
+3. `read_positions` ordering: rows come back sorted by range_pct; view computes it correctly.
+4. `refresh_prices` with an injected fake fetcher (no network): given 3 fake tickers,
+   3 rows land in DB with correct range_pct. One fetcher raising → recorded as error,
+   others still persist.
+5. `RateLimiter` spacing: two back-to-back acquisitions are >= min_interval apart
+   (use a tiny interval so the test is fast, assert monotonic delta).
+
+No mocking of `requests`. Network isolated behind the injectable `fetcher`; the real
+`fetch_price` is exercised manually / left to a live smoke check, not the unit suite.
+
+## Out of scope (for now)
+
+- Automatic daily cron into the morning brief (easy follow-up once this is stable).
+- Historical charting of range_pct over time (the table supports it; UI is later).
+
+## TDD order
+
+1. schema.sql additions + a schema-apply test (table + view exist).
+2. `range_pct` + tests.
+3. `upsert_prices` / `read_positions` + tests (temp DB).
+4. `RateLimiter` + test.
+5. `refresh_prices` with injectable fetcher + tests.
+6. Real `fetch_price` (Finnhub) — thin, covered by a live smoke check.
+7. Wire `portfolio prices` subcommand + dispatch.
+8. Live smoke: `minerva portfolio prices AAPL` against real Finnhub.

--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -75,7 +75,6 @@ def dispatch(args: list[str], settings: HarnessSettings, stdin: bytes = b"") -> 
             return prices_command(
                 tickers=positional,
                 refresh=bool(parsed.get("refresh")),
-                all_status=bool(parsed.get("all-status")),
                 settings=settings,
             )
         if subcommand == "adjacency":
@@ -157,7 +156,6 @@ def prices_command(
     *,
     tickers: list[str],
     refresh: bool,
-    all_status: bool,
     settings: HarnessSettings,
 ) -> CommandResult:
     """Fetch/persist 52-week price positions, or read the stored table.
@@ -171,8 +169,7 @@ def prices_command(
 
     universe = [t.upper() for t in tickers]
     if refresh:
-        statuses = ("tracking", "owned", "exited", "passed") if all_status else ("tracking", "owned")
-        universe = prices_mod.tracked_tickers(db_path, statuses=statuses)
+        universe = prices_mod.tracked_tickers(db_path)
 
     if universe:
         if not settings.finnhub_api_key:
@@ -444,15 +441,13 @@ def enrich_cli() -> None:
 @app.command("prices", help="Show or refresh 52-week price positions (current vs 52w low/high).")
 def prices_cli(
     tickers: list[str] = typer.Argument(None, help="Tickers to fetch + persist. Omit to read stored data."),
-    refresh: bool = typer.Option(False, "--refresh", help="Fetch every tracked company (status tracking/owned)."),
-    all_status: bool = typer.Option(False, "--all-status", help="With --refresh, include exited/passed too."),
+    refresh: bool = typer.Option(False, "--refresh", help="Fetch every company in the table."),
 ) -> None:
     settings = get_settings()
     _print(
         prices_command(
             tickers=list(tickers or []),
             refresh=refresh,
-            all_status=all_status,
             settings=settings,
         )
     )

--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -203,15 +203,16 @@ def _render_price_table(rows: list[dict]) -> str:
     if not rows:
         return "(no price data — run `portfolio prices --refresh` or name a ticker)"
     header = (
-        f"{'TICKER':<8} {'CURRENT':>10} {'52W_LOW':>10} {'52W_HIGH':>10} "
+        f"{'TICKER':<8} {'EXCH':<5} {'CURRENT':>10} {'52W_LOW':>10} {'52W_HIGH':>10} "
         f"{'RANGE_PCT':>10} {'CCY':>4}  AS_OF"
     )
     out = [header]
     for r in rows:
         pct = r.get("range_pct")
         pct_str = f"{pct:.4f}" if pct is not None else "n/a"
+        exch = (r.get("exchange") or "US")
         out.append(
-            f"{r['ticker']:<8} {_fmt_num(r.get('current')):>10} {_fmt_num(r.get('wk52_low')):>10} "
+            f"{r['ticker']:<8} {exch:<5} {_fmt_num(r.get('current')):>10} {_fmt_num(r.get('wk52_low')):>10} "
             f"{_fmt_num(r.get('wk52_high')):>10} {pct_str:>10} {(r.get('currency') or ''):>4}  {r.get('as_of', '')}"
         )
     return "\n".join(out)

--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -160,41 +160,38 @@ def prices_command(
 ) -> CommandResult:
     """Fetch/persist 52-week price positions, or read the stored table.
 
-    Naming tickers (or --refresh) fetches live from Finnhub and upserts. Naming
-    nothing is a zero-API read of the stored table, sorted by range_pct.
+    Naming tickers (or --refresh) fetches live from Yahoo and upserts. Naming
+    nothing is a zero-network read of the stored table, sorted by range_pct.
     """
     start = time.perf_counter()
     db_path = prices_mod.default_db_path(settings.ensure_workspace_root())
     prices_mod.ensure_schema(db_path)
 
-    universe = [t.upper() for t in tickers]
     if refresh:
-        universe = prices_mod.tracked_tickers(db_path)
+        companies = prices_mod.tracked_companies(db_path)
+    elif tickers:
+        # Resolve each named ticker's exchange from the DB so foreign symbols map
+        # correctly (e.g. TOI -> TOI.V); unknown tickers fetch bare.
+        known = dict(prices_mod.tracked_companies(db_path))
+        companies = [(t.upper(), known.get(t.upper())) for t in tickers]
+    else:
+        companies = []
 
-    if universe:
-        if not settings.finnhub_api_key:
-            return error_result(
-                "FINNHUB_API_KEY is not set; cannot fetch live prices",
-                "export FINNHUB_API_KEY, or run `portfolio prices` with no args to read stored data",
-                ["`portfolio prices` (read-only)"],
-                start,
-            )
+    if companies:
         try:
-            result = prices_mod.refresh_prices(db_path, universe, api_key=settings.finnhub_api_key)
+            result = prices_mod.refresh_prices(db_path, companies)
         except Exception as exc:
             return error_result(
                 f"failed to refresh prices: {exc}",
-                "check network access and the FINNHUB_API_KEY value",
+                "check network access",
                 ["`portfolio prices AAPL`"],
                 start,
             )
-        rows = prices_mod.read_positions(db_path, tickers=universe)
-        header = f"fetched: {result['fetched']}  errors: {len(result['errors'])}"
-        body = _render_price_table(rows)
-        lines = [header]
+        rows = prices_mod.read_positions(db_path, tickers=[t for t, _ in companies])
+        lines = [f"fetched: {result['fetched']}  errors: {len(result['errors'])}"]
         if result["errors"]:
             lines.append("error tickers: " + ", ".join(e["ticker"] for e in result["errors"]))
-        lines.append(body)
+        lines.append(_render_price_table(rows))
         return CommandResult.from_text("\n".join(lines), duration_ms=elapsed_ms(start))
 
     # No universe => read-only view of everything stored.
@@ -205,14 +202,17 @@ def prices_command(
 def _render_price_table(rows: list[dict]) -> str:
     if not rows:
         return "(no price data — run `portfolio prices --refresh` or name a ticker)"
-    header = f"{'TICKER':<8} {'CURRENT':>10} {'52W_LOW':>10} {'52W_HIGH':>10} {'RANGE_PCT':>10}  AS_OF"
+    header = (
+        f"{'TICKER':<8} {'CURRENT':>10} {'52W_LOW':>10} {'52W_HIGH':>10} "
+        f"{'RANGE_PCT':>10} {'CCY':>4}  AS_OF"
+    )
     out = [header]
     for r in rows:
         pct = r.get("range_pct")
         pct_str = f"{pct:.4f}" if pct is not None else "n/a"
         out.append(
             f"{r['ticker']:<8} {_fmt_num(r.get('current')):>10} {_fmt_num(r.get('wk52_low')):>10} "
-            f"{_fmt_num(r.get('wk52_high')):>10} {pct_str:>10}  {r.get('as_of', '')}"
+            f"{_fmt_num(r.get('wk52_high')):>10} {pct_str:>10} {(r.get('currency') or ''):>4}  {r.get('as_of', '')}"
         )
     return "\n".join(out)
 

--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -11,6 +11,7 @@ import typer
 from harness.commands.common import abort_with_help, elapsed_ms, error_result, parse_flag_args, show_help_if_bare
 from harness.config import HarnessSettings, get_settings
 from harness.output import CommandResult, OutputEnvelope
+from minerva import prices as prices_mod
 from harness.portfolio_state import (
     add_adjacency_entry,
     add_thesis_metric,
@@ -68,6 +69,15 @@ def dispatch(args: list[str], settings: HarnessSettings, stdin: bytes = b"") -> 
             )
         if subcommand == "enrich":
             return enrich_command(settings=settings)
+        if subcommand == "prices":
+            parsed = parse_flag_args(args[1:])
+            positional = [a for a in args[1:] if not a.startswith("-")]
+            return prices_command(
+                tickers=positional,
+                refresh=bool(parsed.get("refresh")),
+                all_status=bool(parsed.get("all-status")),
+                settings=settings,
+            )
         if subcommand == "adjacency":
             return _dispatch_adjacency(args[1:], settings)
         if subcommand == "thesis":
@@ -142,6 +152,77 @@ def enrich_command(*, settings: HarnessSettings) -> CommandResult:
         f"errors: {summary['error_count']}",
     ]
     return CommandResult.from_text("\n".join(lines), duration_ms=elapsed_ms(start))
+
+def prices_command(
+    *,
+    tickers: list[str],
+    refresh: bool,
+    all_status: bool,
+    settings: HarnessSettings,
+) -> CommandResult:
+    """Fetch/persist 52-week price positions, or read the stored table.
+
+    Naming tickers (or --refresh) fetches live from Finnhub and upserts. Naming
+    nothing is a zero-API read of the stored table, sorted by range_pct.
+    """
+    start = time.perf_counter()
+    db_path = prices_mod.default_db_path(settings.ensure_workspace_root())
+    prices_mod.ensure_schema(db_path)
+
+    universe = [t.upper() for t in tickers]
+    if refresh:
+        statuses = ("tracking", "owned", "exited", "passed") if all_status else ("tracking", "owned")
+        universe = prices_mod.tracked_tickers(db_path, statuses=statuses)
+
+    if universe:
+        if not settings.finnhub_api_key:
+            return error_result(
+                "FINNHUB_API_KEY is not set; cannot fetch live prices",
+                "export FINNHUB_API_KEY, or run `portfolio prices` with no args to read stored data",
+                ["`portfolio prices` (read-only)"],
+                start,
+            )
+        try:
+            result = prices_mod.refresh_prices(db_path, universe, api_key=settings.finnhub_api_key)
+        except Exception as exc:
+            return error_result(
+                f"failed to refresh prices: {exc}",
+                "check network access and the FINNHUB_API_KEY value",
+                ["`portfolio prices AAPL`"],
+                start,
+            )
+        rows = prices_mod.read_positions(db_path, tickers=universe)
+        header = f"fetched: {result['fetched']}  errors: {len(result['errors'])}"
+        body = _render_price_table(rows)
+        lines = [header]
+        if result["errors"]:
+            lines.append("error tickers: " + ", ".join(e["ticker"] for e in result["errors"]))
+        lines.append(body)
+        return CommandResult.from_text("\n".join(lines), duration_ms=elapsed_ms(start))
+
+    # No universe => read-only view of everything stored.
+    rows = prices_mod.read_positions(db_path)
+    return CommandResult.from_text(_render_price_table(rows), duration_ms=elapsed_ms(start))
+
+
+def _render_price_table(rows: list[dict]) -> str:
+    if not rows:
+        return "(no price data — run `portfolio prices --refresh` or name a ticker)"
+    header = f"{'TICKER':<8} {'CURRENT':>10} {'52W_LOW':>10} {'52W_HIGH':>10} {'RANGE_PCT':>10}  AS_OF"
+    out = [header]
+    for r in rows:
+        pct = r.get("range_pct")
+        pct_str = f"{pct:.4f}" if pct is not None else "n/a"
+        out.append(
+            f"{r['ticker']:<8} {_fmt_num(r.get('current')):>10} {_fmt_num(r.get('wk52_low')):>10} "
+            f"{_fmt_num(r.get('wk52_high')):>10} {pct_str:>10}  {r.get('as_of', '')}"
+        )
+    return "\n".join(out)
+
+
+def _fmt_num(value) -> str:
+    return f"{value:.2f}" if isinstance(value, (int, float)) else "n/a"
+
 
 def list_adjacency_command(*, settings: HarnessSettings) -> CommandResult:
     """List adjacency entries."""
@@ -359,6 +440,22 @@ def sync_cli(
 def enrich_cli() -> None:
     settings = get_settings()
     _print(enrich_command(settings=settings))
+
+@app.command("prices", help="Show or refresh 52-week price positions (current vs 52w low/high).")
+def prices_cli(
+    tickers: list[str] = typer.Argument(None, help="Tickers to fetch + persist. Omit to read stored data."),
+    refresh: bool = typer.Option(False, "--refresh", help="Fetch every tracked company (status tracking/owned)."),
+    all_status: bool = typer.Option(False, "--all-status", help="With --refresh, include exited/passed too."),
+) -> None:
+    settings = get_settings()
+    _print(
+        prices_command(
+            tickers=list(tickers or []),
+            refresh=refresh,
+            all_status=all_status,
+            settings=settings,
+        )
+    )
 
 @adjacency_app.command("list", help="List stored adjacency mappings.")
 def adjacency_list_cli() -> None:

--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -31,6 +31,7 @@ from harness.portfolio_state import (
     read_text_source,
     write_json,
 )
+from minerva.formatting import to_float
 from minerva.sec import get_recent_filings
 
 
@@ -1569,7 +1570,7 @@ def _normalize_market_event(
     *,
     category: str | None = None,
 ) -> dict[str, Any] | None:
-    change_pct = _to_float(row.get("change_pct") or row.get("percent_change") or row.get("pct"))
+    change_pct = to_float(row.get("change_pct") or row.get("percent_change") or row.get("pct"))
     material = bool(row.get("material")) or (change_pct is not None and abs(change_pct) >= 1.0)
     symbol = str(row.get("symbol") or row.get("name") or row.get("pair") or "").strip()
     headline = str(row.get("headline") or f"{symbol} moved {change_pct:.2f}%").strip() if change_pct is not None else str(row.get("headline") or symbol)
@@ -1900,11 +1901,3 @@ def _coerce_event_date(value: Any) -> str | None:
             continue
     return None
 
-
-def _to_float(value: Any) -> float | None:
-    if value in {None, ""}:
-        return None
-    try:
-        return float(str(value).replace("%", "").replace(",", "").strip())
-    except ValueError:
-        return None

--- a/src/minerva/formatting.py
+++ b/src/minerva/formatting.py
@@ -1,10 +1,24 @@
 """Utility functions for formatting financial data and building markdown tables."""
 
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 import xmltodict
 import yaml
+
+
+def to_float(value: Any) -> float | None:
+    """Coerce a value to float, or None if empty/unparseable.
+
+    Tolerates common financial-string noise (%, thousands separators, whitespace).
+    """
+    if value in {None, ""}:
+        return None
+    try:
+        return float(str(value).replace("%", "").replace(",", "").strip())
+    except (TypeError, ValueError):
+        return None
 
 
 def is_empty(value: object) -> bool:

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -1,0 +1,287 @@
+"""52-week price position tracking.
+
+Pulls current price and 52-week high/low from Finnhub, persists dated snapshots
+to invest.db, and reports where each ticker sits in its 52-week band:
+
+    range_pct = (current - low) / (high - low)   # 0 = on 52w low, 1 = on 52w high
+
+The derived range_pct is computed on read (via the ``price_position`` view), never
+stored, so a corrected input never leaves a stale value behind.
+
+Network access is isolated in ``fetch_price`` and injected into ``refresh_prices`` as
+a ``fetcher`` callable, which keeps the orchestration testable without mocking HTTP.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+
+# Finnhub free tier allows 60 calls/min. We spend 2 calls per ticker, so pace to
+# stay comfortably under the ceiling: ~50 calls/min => one call every 1.2s.
+DEFAULT_MIN_INTERVAL = 1.2
+MAX_RETRIES = 3
+BACKOFF_CAP_SECONDS = 30.0
+
+# Mirrored in hard-disk/data/04-database/schema.sql. Kept here so tests and the CLI
+# can materialize the table + view into any database without reading that file.
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS prices (
+    id          INTEGER PRIMARY KEY,
+    ticker      TEXT NOT NULL,
+    as_of       TEXT NOT NULL,
+    current     REAL,
+    wk52_low    REAL,
+    wk52_high   REAL,
+    low_date    TEXT,
+    high_date   TEXT,
+    source      TEXT NOT NULL DEFAULT 'finnhub',
+    fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (ticker, as_of)
+);
+CREATE VIEW IF NOT EXISTS price_position AS
+SELECT
+    ticker, as_of, current, wk52_low, wk52_high, low_date, high_date,
+    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
+FROM prices;
+CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices(ticker);
+CREATE INDEX IF NOT EXISTS idx_prices_asof   ON prices(as_of);
+"""
+
+
+@dataclass(slots=True)
+class PriceRow:
+    """One dated price snapshot for a ticker."""
+
+    ticker: str
+    as_of: str
+    current: float | None
+    wk52_low: float | None
+    wk52_high: float | None
+    low_date: str | None = None
+    high_date: str | None = None
+    source: str = "finnhub"
+
+
+def range_pct(row: PriceRow) -> float | None:
+    """Position in the 52-week range, 0..1. None when undefined (no range / missing data)."""
+    current, low, high = row.current, row.wk52_low, row.wk52_high
+    if current is None or low is None or high is None:
+        return None
+    span = high - low
+    if span == 0:
+        return None
+    return (current - low) / span
+
+
+class RateLimiter:
+    """Monotonic spacer: guarantees at least ``min_interval`` seconds between acquires.
+
+    Single-threaded and sleep-based on purpose — the price pull is sequential, so a
+    simple pacer is enough and there is nothing to coordinate across threads.
+    """
+
+    def __init__(self, min_interval: float = DEFAULT_MIN_INTERVAL) -> None:
+        self.min_interval = min_interval
+        self._last: float | None = None
+
+    def acquire(self) -> None:
+        now = time.monotonic()
+        if self._last is not None:
+            wait = self.min_interval - (now - self._last)
+            if wait > 0:
+                time.sleep(wait)
+        self._last = time.monotonic()
+
+
+def default_db_path(workspace_root: str | Path) -> Path:
+    """Locate invest.db under the workspace's database folder."""
+    return Path(workspace_root) / "data" / "04-database" / "invest.db"
+
+
+def tracked_tickers(db_path: str | Path, *, statuses: Sequence[str] = ("tracking", "owned")) -> list[str]:
+    """Return non-null tickers for companies in the given statuses, alphabetically."""
+    placeholders = ",".join("?" for _ in statuses)
+    with sqlite3.connect(str(db_path)) as conn:
+        rows = conn.execute(
+            f"SELECT ticker FROM companies "
+            f"WHERE ticker IS NOT NULL AND ticker != '' AND status IN ({placeholders}) "
+            f"ORDER BY ticker ASC",
+            tuple(statuses),
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+def ensure_schema(db_path: str | Path) -> None:
+    """Create the prices table + view if absent. Idempotent."""
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+
+
+def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
+    """Insert or update snapshots, keyed on (ticker, as_of). Returns rows written."""
+    written = 0
+    with sqlite3.connect(str(db_path)) as conn:
+        for row in rows:
+            conn.execute(
+                """
+                INSERT INTO prices
+                    (ticker, as_of, current, wk52_low, wk52_high, low_date, high_date, source, fetched_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                ON CONFLICT(ticker, as_of) DO UPDATE SET
+                    current    = excluded.current,
+                    wk52_low   = excluded.wk52_low,
+                    wk52_high  = excluded.wk52_high,
+                    low_date   = excluded.low_date,
+                    high_date  = excluded.high_date,
+                    source     = excluded.source,
+                    fetched_at = excluded.fetched_at
+                """,
+                (
+                    row.ticker,
+                    row.as_of,
+                    row.current,
+                    row.wk52_low,
+                    row.wk52_high,
+                    row.low_date,
+                    row.high_date,
+                    row.source,
+                ),
+            )
+            written += 1
+        conn.commit()
+    return written
+
+
+def read_positions(
+    db_path: str | Path,
+    *,
+    tickers: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Read the latest snapshot per ticker, sorted ascending by range_pct (NULLs last).
+
+    Rows sitting near their 52-week low come first; near their high come last.
+    """
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        sql = (
+            "SELECT p.* FROM price_position p "
+            "JOIN (SELECT ticker, MAX(as_of) AS as_of FROM prices GROUP BY ticker) latest "
+            "  ON p.ticker = latest.ticker AND p.as_of = latest.as_of"
+        )
+        params: list[Any] = []
+        if tickers:
+            placeholders = ",".join("?" for _ in tickers)
+            sql += f" WHERE p.ticker IN ({placeholders})"
+            params.extend(t.upper() for t in tickers)
+        sql += " ORDER BY (p.range_pct IS NULL), p.range_pct ASC, p.ticker ASC"
+        return [dict(r) for r in conn.execute(sql, params)]
+
+
+def fetch_price(
+    ticker: str,
+    *,
+    api_key: str,
+    session: requests.Session | None = None,
+    limiter: RateLimiter | None = None,
+    as_of: str | None = None,
+) -> PriceRow:
+    """Fetch current price + 52-week band for one ticker from Finnhub.
+
+    Two calls: /quote (current) and /stock/metric (52-week high/low). Honors the
+    shared rate limiter and retries on HTTP 429 with backoff.
+    """
+    session = session or requests.Session()
+    as_of = as_of or datetime.now(timezone.utc).date().isoformat()
+
+    quote = _finnhub_get(session, "/quote", {"symbol": ticker, "token": api_key}, limiter)
+    metric = _finnhub_get(
+        session, "/stock/metric", {"symbol": ticker, "metric": "price", "token": api_key}, limiter
+    )
+    m = metric.get("metric", {}) if isinstance(metric, dict) else {}
+
+    return PriceRow(
+        ticker=ticker.upper(),
+        as_of=as_of,
+        current=_as_float(quote.get("c")),
+        wk52_low=_as_float(m.get("52WeekLow")),
+        wk52_high=_as_float(m.get("52WeekHigh")),
+        low_date=m.get("52WeekLowDate"),
+        high_date=m.get("52WeekHighDate"),
+    )
+
+
+def refresh_prices(
+    db_path: str | Path,
+    tickers: Sequence[str],
+    *,
+    api_key: str,
+    fetcher: Callable[..., PriceRow] = fetch_price,
+    limiter: RateLimiter | None = None,
+) -> dict[str, Any]:
+    """Fetch each ticker, upsert into the DB, and report results.
+
+    Per-ticker failures are collected, not fatal — one bad ticker never aborts the run.
+    """
+    ensure_schema(db_path)
+    limiter = limiter or RateLimiter()
+    session = requests.Session()
+
+    fetched: list[PriceRow] = []
+    errors: list[dict[str, str]] = []
+    for ticker in tickers:
+        try:
+            row = fetcher(ticker, api_key=api_key, session=session, limiter=limiter)
+            fetched.append(row)
+        except Exception as exc:  # noqa: BLE001 — isolate one ticker's failure
+            logger.warning("price fetch failed for %s: %s", ticker, exc)
+            errors.append({"ticker": ticker, "error": str(exc)})
+
+    if fetched:
+        upsert_prices(db_path, fetched)
+
+    return {"fetched": len(fetched), "errors": errors}
+
+
+def _finnhub_get(
+    session: requests.Session,
+    path: str,
+    params: dict[str, Any],
+    limiter: RateLimiter | None,
+) -> dict[str, Any]:
+    """GET a Finnhub endpoint, pacing via the limiter and retrying on 429."""
+    delay = 1.0
+    for attempt in range(MAX_RETRIES + 1):
+        if limiter is not None:
+            limiter.acquire()
+        resp = session.get(f"{FINNHUB_BASE_URL}{path}", params=params, timeout=30)
+        if resp.status_code == 429 and attempt < MAX_RETRIES:
+            retry_after = resp.headers.get("Retry-After")
+            wait = float(retry_after) if retry_after else min(delay, BACKOFF_CAP_SECONDS)
+            logger.warning("finnhub 429 on %s; backing off %.1fs", path, wait)
+            time.sleep(wait)
+            delay = min(delay * 2, BACKOFF_CAP_SECONDS)
+            continue
+        resp.raise_for_status()
+        return resp.json()
+    resp.raise_for_status()  # exhausted retries on 429
+    return resp.json()
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -110,15 +110,18 @@ def default_db_path(workspace_root: str | Path) -> Path:
     return Path(workspace_root) / "data" / "04-database" / "invest.db"
 
 
-def tracked_tickers(db_path: str | Path, *, statuses: Sequence[str] = ("tracking", "owned")) -> list[str]:
-    """Return non-null tickers for companies in the given statuses, alphabetically."""
-    placeholders = ",".join("?" for _ in statuses)
+def tracked_tickers(db_path: str | Path) -> list[str]:
+    """Return every non-null company ticker, alphabetically.
+
+    No priority filtering: a full refresh of the whole table is cheap enough
+    (2 calls/ticker, paced under the rate limit) that filtering isn't worth the
+    complexity. If a priority subset is ever wanted, drive it from actual
+    portfolio holdings or a real interest flag — not a documentation-state proxy.
+    """
     with sqlite3.connect(str(db_path)) as conn:
         rows = conn.execute(
-            f"SELECT ticker FROM companies "
-            f"WHERE ticker IS NOT NULL AND ticker != '' AND status IN ({placeholders}) "
-            f"ORDER BY ticker ASC",
-            tuple(statuses),
+            "SELECT ticker FROM companies "
+            "WHERE ticker IS NOT NULL AND ticker != '' ORDER BY ticker ASC"
         ).fetchall()
     return [r[0] for r in rows]
 

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -198,10 +198,18 @@ def read_positions(
     """
     with sqlite3.connect(str(db_path)) as conn:
         conn.row_factory = sqlite3.Row
+        # Pull the exchange label from companies when that table exists (prices stores
+        # only the ticker). A bare/fresh DB without companies still reads fine.
+        has_companies = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='companies'"
+        ).fetchone()
+        exch_select = "c.exchange AS exchange" if has_companies else "NULL AS exchange"
+        exch_join = "LEFT JOIN companies c ON UPPER(c.ticker) = p.ticker" if has_companies else ""
         sql = (
-            "SELECT p.* FROM price_position p "
+            f"SELECT p.*, {exch_select} FROM price_position p "
             "JOIN (SELECT ticker, MAX(as_of) AS as_of FROM prices GROUP BY ticker) latest "
-            "  ON p.ticker = latest.ticker AND p.as_of = latest.as_of"
+            "  ON p.ticker = latest.ticker AND p.as_of = latest.as_of "
+            f"{exch_join}"
         )
         params: list[Any] = []
         if tickers:

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -34,11 +34,6 @@ YAHOO_HEADERS = {"User-Agent": "Mozilla/5.0"}
 
 # Yahoo is tolerant of request volume; this spacing is politeness, not a hard limit.
 DEFAULT_MIN_INTERVAL = 0.3
-# Yahoo intermittently throttles mid-batch, returning an empty result instead of an
-# error. Retry those a few times before giving up so a big refresh doesn't silently
-# drop valid tickers.
-EMPTY_RESULT_RETRIES = 3
-RETRY_BACKOFF_SECONDS = 1.0
 
 # Exchange code -> Yahoo symbol suffix. US listings (empty/None exchange) use the
 # bare ticker. Symbols already carrying a "." pass through unchanged.
@@ -228,7 +223,6 @@ def fetch_price(
     exchange: str | None = None,
     session: requests.Session | None = None,
     limiter: RateLimiter | None = None,
-    as_of: str | None = None,
 ) -> PriceRow:
     """Fetch current price + 52-week band for one ticker from Yahoo Finance.
 
@@ -236,26 +230,18 @@ def fetch_price(
     records it as a per-ticker failure rather than persisting bogus data.
     """
     session = session or requests.Session()
-    as_of = as_of or datetime.now(timezone.utc).date().isoformat()
     symbol = yahoo_symbol(ticker, exchange)
 
-    result: list[Any] = []
-    for attempt in range(EMPTY_RESULT_RETRIES + 1):
-        if limiter is not None:
-            limiter.acquire()
-        resp = session.get(
-            YAHOO_CHART_URL.format(symbol=symbol),
-            params={"interval": "1d", "range": "1d"},
-            headers=YAHOO_HEADERS,
-            timeout=30,
-        )
-        resp.raise_for_status()
-        result = (resp.json().get("chart") or {}).get("result") or []
-        if result:
-            break
-        # Empty result: usually a transient throttle, not a bad symbol. Back off and retry.
-        if attempt < EMPTY_RESULT_RETRIES:
-            time.sleep(RETRY_BACKOFF_SECONDS * (attempt + 1))
+    if limiter is not None:
+        limiter.acquire()
+    resp = session.get(
+        YAHOO_CHART_URL.format(symbol=symbol),
+        params={"interval": "1d", "range": "1d"},
+        headers=YAHOO_HEADERS,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    result = (resp.json().get("chart") or {}).get("result") or []
     if not result:
         raise ValueError(f"no chart data for {symbol}")
     meta = result[0].get("meta") or {}
@@ -266,7 +252,7 @@ def fetch_price(
 
     return PriceRow(
         ticker=ticker.upper(),
-        as_of=as_of,
+        as_of=datetime.now(timezone.utc).date().isoformat(),
         current=price,
         wk52_low=to_float(meta.get("fiftyTwoWeekLow")),
         wk52_high=to_float(meta.get("fiftyTwoWeekHigh")),

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -1,12 +1,13 @@
 """52-week price position tracking.
 
-Pulls current price and 52-week high/low from Finnhub, persists dated snapshots
-to invest.db, and reports where each ticker sits in its 52-week band:
+Pulls current price and 52-week high/low from Yahoo Finance, persists dated
+snapshots to invest.db, and reports where each ticker sits in its 52-week band:
 
     range_pct = (current - low) / (high - low)   # 0 = on 52w low, 1 = on 52w high
 
-The derived range_pct is computed on read (via the ``price_position`` view), never
-stored, so a corrected input never leaves a stale value behind.
+Yahoo covers US and international listings with one keyless call per ticker.
+range_pct is computed on read (via the ``price_position`` view), never stored, so a
+corrected input never leaves a stale value behind.
 
 Network access is isolated in ``fetch_price`` and injected into ``refresh_prices`` as
 a ``fetcher`` callable, which keeps the orchestration testable without mocking HTTP.
@@ -26,13 +27,32 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}"
+YAHOO_HEADERS = {"User-Agent": "Mozilla/5.0"}
 
-# Finnhub free tier allows 60 calls/min. We spend 2 calls per ticker, so pace to
-# stay comfortably under the ceiling: ~50 calls/min => one call every 1.2s.
-DEFAULT_MIN_INTERVAL = 1.2
-MAX_RETRIES = 3
-BACKOFF_CAP_SECONDS = 30.0
+# Yahoo is tolerant of request volume; this spacing is politeness, not a hard limit.
+DEFAULT_MIN_INTERVAL = 0.3
+# Yahoo intermittently throttles mid-batch, returning an empty result instead of an
+# error. Retry those a few times before giving up so a big refresh doesn't silently
+# drop valid tickers.
+EMPTY_RESULT_RETRIES = 3
+RETRY_BACKOFF_SECONDS = 1.0
+
+# Exchange code -> Yahoo symbol suffix. US listings (empty/None exchange) use the
+# bare ticker. Symbols already carrying a "." pass through unchanged.
+_EXCHANGE_SUFFIX = {
+    "TSX": ".TO",
+    "TSXV": ".V",
+    "ASX": ".AX",
+    "LSE": ".L",
+    "TSE": ".T",     # Tokyo
+    "ETR": ".DE",    # Xetra
+    "EPA": ".PA",    # Euronext Paris
+    "AMS": ".AS",    # Euronext Amsterdam
+    "SWX": ".SW",    # SIX Swiss
+    "STO": ".ST",    # Nasdaq Stockholm
+    "BME": ".MC",    # Madrid
+}
 
 # Mirrored in hard-disk/data/04-database/schema.sql. Kept here so tests and the CLI
 # can materialize the table + view into any database without reading that file.
@@ -44,15 +64,14 @@ CREATE TABLE IF NOT EXISTS prices (
     current     REAL,
     wk52_low    REAL,
     wk52_high   REAL,
-    low_date    TEXT,
-    high_date   TEXT,
-    source      TEXT NOT NULL DEFAULT 'finnhub',
+    currency    TEXT,
+    source      TEXT NOT NULL DEFAULT 'yahoo',
     fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE (ticker, as_of)
 );
 CREATE VIEW IF NOT EXISTS price_position AS
 SELECT
-    ticker, as_of, current, wk52_low, wk52_high, low_date, high_date,
+    ticker, as_of, current, wk52_low, wk52_high, currency,
     ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
 FROM prices;
 CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices(ticker);
@@ -69,9 +88,8 @@ class PriceRow:
     current: float | None
     wk52_low: float | None
     wk52_high: float | None
-    low_date: str | None = None
-    high_date: str | None = None
-    source: str = "finnhub"
+    currency: str | None = None
+    source: str = "yahoo"
 
 
 def range_pct(row: PriceRow) -> float | None:
@@ -85,12 +103,21 @@ def range_pct(row: PriceRow) -> float | None:
     return (current - low) / span
 
 
-class RateLimiter:
-    """Monotonic spacer: guarantees at least ``min_interval`` seconds between acquires.
+def yahoo_symbol(ticker: str, exchange: str | None) -> str:
+    """Map a company ticker + exchange to the symbol Yahoo expects.
 
-    Single-threaded and sleep-based on purpose — the price pull is sequential, so a
-    simple pacer is enough and there is nothing to coordinate across threads.
+    US listings (no exchange) use the bare ticker. Symbols that already carry an
+    exchange suffix (a ".") pass through unchanged.
     """
+    ticker = ticker.strip().upper()
+    if "." in ticker:
+        return ticker
+    suffix = _EXCHANGE_SUFFIX.get((exchange or "").strip().upper())
+    return f"{ticker}{suffix}" if suffix else ticker
+
+
+class RateLimiter:
+    """Monotonic spacer: guarantees at least ``min_interval`` seconds between acquires."""
 
     def __init__(self, min_interval: float = DEFAULT_MIN_INTERVAL) -> None:
         self.min_interval = min_interval
@@ -110,20 +137,14 @@ def default_db_path(workspace_root: str | Path) -> Path:
     return Path(workspace_root) / "data" / "04-database" / "invest.db"
 
 
-def tracked_tickers(db_path: str | Path) -> list[str]:
-    """Return every non-null company ticker, alphabetically.
-
-    No priority filtering: a full refresh of the whole table is cheap enough
-    (2 calls/ticker, paced under the rate limit) that filtering isn't worth the
-    complexity. If a priority subset is ever wanted, drive it from actual
-    portfolio holdings or a real interest flag — not a documentation-state proxy.
-    """
+def tracked_companies(db_path: str | Path) -> list[tuple[str, str | None]]:
+    """Return (ticker, exchange) for every company with a non-empty ticker, alphabetically."""
     with sqlite3.connect(str(db_path)) as conn:
         rows = conn.execute(
-            "SELECT ticker FROM companies "
+            "SELECT ticker, exchange FROM companies "
             "WHERE ticker IS NOT NULL AND ticker != '' ORDER BY ticker ASC"
         ).fetchall()
-    return [r[0] for r in rows]
+    return [(r[0], r[1]) for r in rows]
 
 
 def ensure_schema(db_path: str | Path) -> None:
@@ -141,14 +162,13 @@ def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
             conn.execute(
                 """
                 INSERT INTO prices
-                    (ticker, as_of, current, wk52_low, wk52_high, low_date, high_date, source, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                    (ticker, as_of, current, wk52_low, wk52_high, currency, source, fetched_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
                 ON CONFLICT(ticker, as_of) DO UPDATE SET
                     current    = excluded.current,
                     wk52_low   = excluded.wk52_low,
                     wk52_high  = excluded.wk52_high,
-                    low_date   = excluded.low_date,
-                    high_date  = excluded.high_date,
+                    currency   = excluded.currency,
                     source     = excluded.source,
                     fetched_at = excluded.fetched_at
                 """,
@@ -158,8 +178,7 @@ def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
                     row.current,
                     row.wk52_low,
                     row.wk52_high,
-                    row.low_date,
-                    row.high_date,
+                    row.currency,
                     row.source,
                 ),
             )
@@ -196,45 +215,63 @@ def read_positions(
 def fetch_price(
     ticker: str,
     *,
-    api_key: str,
+    exchange: str | None = None,
     session: requests.Session | None = None,
     limiter: RateLimiter | None = None,
     as_of: str | None = None,
 ) -> PriceRow:
-    """Fetch current price + 52-week band for one ticker from Finnhub.
+    """Fetch current price + 52-week band for one ticker from Yahoo Finance.
 
-    Two calls: /quote (current) and /stock/metric (52-week high/low). Honors the
-    shared rate limiter and retries on HTTP 429 with backoff.
+    One call to the chart endpoint. Raises on a missing/empty response so the caller
+    records it as a per-ticker failure rather than persisting bogus data.
     """
     session = session or requests.Session()
     as_of = as_of or datetime.now(timezone.utc).date().isoformat()
+    symbol = yahoo_symbol(ticker, exchange)
 
-    quote = _finnhub_get(session, "/quote", {"symbol": ticker, "token": api_key}, limiter)
-    metric = _finnhub_get(
-        session, "/stock/metric", {"symbol": ticker, "metric": "price", "token": api_key}, limiter
-    )
-    m = metric.get("metric", {}) if isinstance(metric, dict) else {}
+    result: list[Any] = []
+    for attempt in range(EMPTY_RESULT_RETRIES + 1):
+        if limiter is not None:
+            limiter.acquire()
+        resp = session.get(
+            YAHOO_CHART_URL.format(symbol=symbol),
+            params={"interval": "1d", "range": "1d"},
+            headers=YAHOO_HEADERS,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        result = (resp.json().get("chart") or {}).get("result") or []
+        if result:
+            break
+        # Empty result: usually a transient throttle, not a bad symbol. Back off and retry.
+        if attempt < EMPTY_RESULT_RETRIES:
+            time.sleep(RETRY_BACKOFF_SECONDS * (attempt + 1))
+    if not result:
+        raise ValueError(f"no chart data for {symbol}")
+    meta = result[0].get("meta") or {}
+
+    price = _as_float(meta.get("regularMarketPrice"))
+    if price is None:
+        raise ValueError(f"no price in chart meta for {symbol}")
 
     return PriceRow(
         ticker=ticker.upper(),
         as_of=as_of,
-        current=_as_float(quote.get("c")),
-        wk52_low=_as_float(m.get("52WeekLow")),
-        wk52_high=_as_float(m.get("52WeekHigh")),
-        low_date=m.get("52WeekLowDate"),
-        high_date=m.get("52WeekHighDate"),
+        current=price,
+        wk52_low=_as_float(meta.get("fiftyTwoWeekLow")),
+        wk52_high=_as_float(meta.get("fiftyTwoWeekHigh")),
+        currency=meta.get("currency"),
     )
 
 
 def refresh_prices(
     db_path: str | Path,
-    tickers: Sequence[str],
+    companies: Sequence[tuple[str, str | None]],
     *,
-    api_key: str,
     fetcher: Callable[..., PriceRow] = fetch_price,
     limiter: RateLimiter | None = None,
 ) -> dict[str, Any]:
-    """Fetch each ticker, upsert into the DB, and report results.
+    """Fetch each (ticker, exchange), upsert into the DB, and report results.
 
     Per-ticker failures are collected, not fatal — one bad ticker never aborts the run.
     """
@@ -244,10 +281,9 @@ def refresh_prices(
 
     fetched: list[PriceRow] = []
     errors: list[dict[str, str]] = []
-    for ticker in tickers:
+    for ticker, exchange in companies:
         try:
-            row = fetcher(ticker, api_key=api_key, session=session, limiter=limiter)
-            fetched.append(row)
+            fetched.append(fetcher(ticker, exchange=exchange, session=session, limiter=limiter))
         except Exception as exc:  # noqa: BLE001 — isolate one ticker's failure
             logger.warning("price fetch failed for %s: %s", ticker, exc)
             errors.append({"ticker": ticker, "error": str(exc)})
@@ -256,31 +292,6 @@ def refresh_prices(
         upsert_prices(db_path, fetched)
 
     return {"fetched": len(fetched), "errors": errors}
-
-
-def _finnhub_get(
-    session: requests.Session,
-    path: str,
-    params: dict[str, Any],
-    limiter: RateLimiter | None,
-) -> dict[str, Any]:
-    """GET a Finnhub endpoint, pacing via the limiter and retrying on 429."""
-    delay = 1.0
-    for attempt in range(MAX_RETRIES + 1):
-        if limiter is not None:
-            limiter.acquire()
-        resp = session.get(f"{FINNHUB_BASE_URL}{path}", params=params, timeout=30)
-        if resp.status_code == 429 and attempt < MAX_RETRIES:
-            retry_after = resp.headers.get("Retry-After")
-            wait = float(retry_after) if retry_after else min(delay, BACKOFF_CAP_SECONDS)
-            logger.warning("finnhub 429 on %s; backing off %.1fs", path, wait)
-            time.sleep(wait)
-            delay = min(delay * 2, BACKOFF_CAP_SECONDS)
-            continue
-        resp.raise_for_status()
-        return resp.json()
-    resp.raise_for_status()  # exhausted retries on 429
-    return resp.json()
 
 
 def _as_float(value: Any) -> float | None:

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, Iterable, Sequence
 
 import requests
 
+from minerva.formatting import to_float
+
 logger = logging.getLogger(__name__)
 
 YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}"
@@ -258,7 +260,7 @@ def fetch_price(
         raise ValueError(f"no chart data for {symbol}")
     meta = result[0].get("meta") or {}
 
-    price = _as_float(meta.get("regularMarketPrice"))
+    price = to_float(meta.get("regularMarketPrice"))
     if price is None:
         raise ValueError(f"no price in chart meta for {symbol}")
 
@@ -266,8 +268,8 @@ def fetch_price(
         ticker=ticker.upper(),
         as_of=as_of,
         current=price,
-        wk52_low=_as_float(meta.get("fiftyTwoWeekLow")),
-        wk52_high=_as_float(meta.get("fiftyTwoWeekHigh")),
+        wk52_low=to_float(meta.get("fiftyTwoWeekLow")),
+        wk52_high=to_float(meta.get("fiftyTwoWeekHigh")),
         currency=meta.get("currency"),
     )
 
@@ -301,9 +303,3 @@ def refresh_prices(
 
     return {"fetched": len(fetched), "errors": errors}
 
-
-def _as_float(value: Any) -> float | None:
-    try:
-        return float(value) if value is not None else None
-    except (TypeError, ValueError):
-        return None

--- a/tests/test_formatting_xml.py
+++ b/tests/test_formatting_xml.py
@@ -1,10 +1,31 @@
-"""Tests for minerva.formatting.xml_to_yaml."""
+"""Tests for minerva.formatting."""
 
 from pathlib import Path
 
 import yaml
 
-from minerva.formatting import xml_to_yaml
+from minerva.formatting import to_float, xml_to_yaml
+
+
+class TestToFloat:
+    """Tests for to_float coercion."""
+
+    def test_plain_number(self):
+        assert to_float(292.46) == 292.46
+        assert to_float(5) == 5.0
+
+    def test_none_and_empty_return_none(self):
+        assert to_float(None) is None
+        assert to_float("") is None
+
+    def test_strips_financial_noise(self):
+        assert to_float("1,234.5") == 1234.5
+        assert to_float("12.5%") == 12.5
+        assert to_float("  42 ") == 42.0
+
+    def test_unparseable_returns_none(self):
+        assert to_float("n/a") is None
+        assert to_float(object()) is None
 
 
 class TestXmlToYaml:

--- a/tests/test_harness/test_portfolio_prices.py
+++ b/tests/test_harness/test_portfolio_prices.py
@@ -25,7 +25,7 @@ def test_read_only_renders_stored_table(tmp_path: Path):
     ensure_schema(db)
     upsert_prices(db, [PriceRow("AAPL", "2026-07-01", current=150, wk52_low=100, wk52_high=200)])
 
-    result = portfolio.prices_command(tickers=[], refresh=False, all_status=False, settings=settings)
+    result = portfolio.prices_command(tickers=[], refresh=False, settings=settings)
     out = result.stdout.decode()
     assert result.exit_code == 0
     assert "AAPL" in out
@@ -34,13 +34,13 @@ def test_read_only_renders_stored_table(tmp_path: Path):
 
 def test_empty_table_message(tmp_path: Path):
     settings = _settings(tmp_path)
-    result = portfolio.prices_command(tickers=[], refresh=False, all_status=False, settings=settings)
+    result = portfolio.prices_command(tickers=[], refresh=False, settings=settings)
     assert result.exit_code == 0
     assert "no price data" in result.stdout.decode()
 
 
 def test_fetch_without_api_key_errors(tmp_path: Path):
     settings = _settings(tmp_path, key=None)
-    result = portfolio.prices_command(tickers=["AAPL"], refresh=False, all_status=False, settings=settings)
+    result = portfolio.prices_command(tickers=["AAPL"], refresh=False, settings=settings)
     assert result.exit_code != 0
     assert "FINNHUB_API_KEY" in result.stderr.decode()

--- a/tests/test_harness/test_portfolio_prices.py
+++ b/tests/test_harness/test_portfolio_prices.py
@@ -6,6 +6,7 @@ here we only exercise the harness read/render wiring.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from harness.commands import portfolio
@@ -19,11 +20,22 @@ def _settings(tmp_path: Path) -> HarnessSettings:
     return HarnessSettings(workspace_root=ws)
 
 
+def _seed_companies(db: Path, rows: list[tuple[str, str | None]]) -> None:
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS companies (id INTEGER PRIMARY KEY, ticker TEXT, exchange TEXT)")
+        conn.executemany("INSERT INTO companies (ticker, exchange) VALUES (?, ?)", rows)
+        conn.commit()
+
+
 def test_read_only_renders_stored_table(tmp_path: Path):
     settings = _settings(tmp_path)
     db = default_db_path(settings.ensure_workspace_root())
     ensure_schema(db)
-    upsert_prices(db, [PriceRow("AAPL", "2026-07-01", current=150, wk52_low=100, wk52_high=200, currency="USD")])
+    _seed_companies(db, [("AAPL", None), ("TOI", "TSXV")])
+    upsert_prices(db, [
+        PriceRow("AAPL", "2026-07-01", current=150, wk52_low=100, wk52_high=200, currency="USD"),
+        PriceRow("TOI", "2026-07-01", current=90, wk52_low=80, wk52_high=200, currency="CAD"),
+    ])
 
     result = portfolio.prices_command(tickers=[], refresh=False, settings=settings)
     out = result.stdout.decode()
@@ -31,6 +43,9 @@ def test_read_only_renders_stored_table(tmp_path: Path):
     assert "AAPL" in out
     assert "0.5000" in out
     assert "USD" in out
+    # US names show US; foreign names show their exchange code.
+    assert "US" in out
+    assert "TSXV" in out
 
 
 def test_empty_table_message(tmp_path: Path):

--- a/tests/test_harness/test_portfolio_prices.py
+++ b/tests/test_harness/test_portfolio_prices.py
@@ -1,0 +1,46 @@
+"""Command-level tests for `portfolio prices` — read path and no-key guard.
+
+The live-fetch path is covered by minerva.prices unit tests (injectable fetcher);
+here we only exercise the harness wiring around it, with no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness.commands import portfolio
+from harness.config import HarnessSettings
+from minerva.prices import PriceRow, default_db_path, ensure_schema, upsert_prices
+
+
+def _settings(tmp_path: Path, *, key: str | None = None) -> HarnessSettings:
+    ws = tmp_path / "hard-disk"
+    (ws / "data" / "04-database").mkdir(parents=True)
+    return HarnessSettings(workspace_root=ws, finnhub_api_key=key)
+
+
+def test_read_only_renders_stored_table(tmp_path: Path):
+    settings = _settings(tmp_path)
+    db = default_db_path(settings.ensure_workspace_root())
+    ensure_schema(db)
+    upsert_prices(db, [PriceRow("AAPL", "2026-07-01", current=150, wk52_low=100, wk52_high=200)])
+
+    result = portfolio.prices_command(tickers=[], refresh=False, all_status=False, settings=settings)
+    out = result.stdout.decode()
+    assert result.exit_code == 0
+    assert "AAPL" in out
+    assert "0.5000" in out
+
+
+def test_empty_table_message(tmp_path: Path):
+    settings = _settings(tmp_path)
+    result = portfolio.prices_command(tickers=[], refresh=False, all_status=False, settings=settings)
+    assert result.exit_code == 0
+    assert "no price data" in result.stdout.decode()
+
+
+def test_fetch_without_api_key_errors(tmp_path: Path):
+    settings = _settings(tmp_path, key=None)
+    result = portfolio.prices_command(tickers=["AAPL"], refresh=False, all_status=False, settings=settings)
+    assert result.exit_code != 0
+    assert "FINNHUB_API_KEY" in result.stderr.decode()

--- a/tests/test_harness/test_portfolio_prices.py
+++ b/tests/test_harness/test_portfolio_prices.py
@@ -1,7 +1,7 @@
-"""Command-level tests for `portfolio prices` — read path and no-key guard.
+"""Command-level tests for `portfolio prices` — read path only, no network.
 
 The live-fetch path is covered by minerva.prices unit tests (injectable fetcher);
-here we only exercise the harness wiring around it, with no network.
+here we only exercise the harness read/render wiring.
 """
 
 from __future__ import annotations
@@ -13,23 +13,24 @@ from harness.config import HarnessSettings
 from minerva.prices import PriceRow, default_db_path, ensure_schema, upsert_prices
 
 
-def _settings(tmp_path: Path, *, key: str | None = None) -> HarnessSettings:
+def _settings(tmp_path: Path) -> HarnessSettings:
     ws = tmp_path / "hard-disk"
     (ws / "data" / "04-database").mkdir(parents=True)
-    return HarnessSettings(workspace_root=ws, finnhub_api_key=key)
+    return HarnessSettings(workspace_root=ws)
 
 
 def test_read_only_renders_stored_table(tmp_path: Path):
     settings = _settings(tmp_path)
     db = default_db_path(settings.ensure_workspace_root())
     ensure_schema(db)
-    upsert_prices(db, [PriceRow("AAPL", "2026-07-01", current=150, wk52_low=100, wk52_high=200)])
+    upsert_prices(db, [PriceRow("AAPL", "2026-07-01", current=150, wk52_low=100, wk52_high=200, currency="USD")])
 
     result = portfolio.prices_command(tickers=[], refresh=False, settings=settings)
     out = result.stdout.decode()
     assert result.exit_code == 0
     assert "AAPL" in out
     assert "0.5000" in out
+    assert "USD" in out
 
 
 def test_empty_table_message(tmp_path: Path):
@@ -39,8 +40,4 @@ def test_empty_table_message(tmp_path: Path):
     assert "no price data" in result.stdout.decode()
 
 
-def test_fetch_without_api_key_errors(tmp_path: Path):
-    settings = _settings(tmp_path, key=None)
-    result = portfolio.prices_command(tickers=["AAPL"], refresh=False, settings=settings)
-    assert result.exit_code != 0
-    assert "FINNHUB_API_KEY" in result.stderr.decode()
+

--- a/tests/test_minerva/test_prices.py
+++ b/tests/test_minerva/test_prices.py
@@ -1,6 +1,6 @@
 """Tests for minerva.prices — 52-week price position tracking.
 
-Network is isolated behind an injectable fetcher, so no requests mocking.
+Network is isolated behind an injectable fetcher, so no HTTP mocking.
 DB tests use a real temporary sqlite file built from the module's own schema.
 """
 
@@ -10,8 +10,6 @@ import sqlite3
 import time
 from pathlib import Path
 
-import pytest
-
 from minerva.prices import (
     PriceRow,
     RateLimiter,
@@ -19,21 +17,14 @@ from minerva.prices import (
     range_pct,
     read_positions,
     refresh_prices,
-    tracked_tickers,
+    tracked_companies,
     upsert_prices,
+    yahoo_symbol,
 )
 
 
 def _row(ticker: str, current: float, low: float, high: float, as_of: str = "2026-07-01") -> PriceRow:
-    return PriceRow(
-        ticker=ticker,
-        as_of=as_of,
-        current=current,
-        wk52_low=low,
-        wk52_high=high,
-        low_date="2025-06-30",
-        high_date="2026-06-08",
-    )
+    return PriceRow(ticker=ticker, as_of=as_of, current=current, wk52_low=low, wk52_high=high, currency="USD")
 
 
 class TestRangePct:
@@ -47,11 +38,30 @@ class TestRangePct:
         assert range_pct(_row("A", current=150, low=100, high=200)) == 0.5
 
     def test_high_equals_low_returns_none(self):
-        # No range: undefined position, must not divide by zero.
         assert range_pct(_row("A", current=100, low=100, high=100)) is None
 
     def test_missing_inputs_return_none(self):
         assert range_pct(PriceRow("A", "2026-07-01", None, 100, 200)) is None
+
+
+class TestYahooSymbol:
+    def test_us_ticker_is_bare(self):
+        assert yahoo_symbol("AAPL", None) == "AAPL"
+        assert yahoo_symbol("AAPL", "") == "AAPL"
+
+    def test_exchange_suffixes(self):
+        assert yahoo_symbol("CSU", "TSX") == "CSU.TO"
+        assert yahoo_symbol("TOI", "TSXV") == "TOI.V"
+        assert yahoo_symbol("XRO", "ASX") == "XRO.AX"
+        assert yahoo_symbol("REL", "LSE") == "REL.L"
+        assert yahoo_symbol("4478", "TSE") == "4478.T"
+
+    def test_already_suffixed_passes_through(self):
+        assert yahoo_symbol("AMS.MC", "BME") == "AMS.MC"
+        assert yahoo_symbol("HEXA-B.ST", "STO") == "HEXA-B.ST"
+
+    def test_unknown_exchange_falls_back_to_bare(self):
+        assert yahoo_symbol("FOO", "NOPE") == "FOO"
 
 
 class TestSchemaAndPersistence:
@@ -69,7 +79,7 @@ class TestSchemaAndPersistence:
     def test_ensure_schema_is_idempotent(self, tmp_path: Path):
         db = tmp_path / "test.db"
         ensure_schema(db)
-        ensure_schema(db)  # second call must not raise
+        ensure_schema(db)
 
     def test_upsert_then_read(self, tmp_path: Path):
         db = tmp_path / "test.db"
@@ -79,12 +89,12 @@ class TestSchemaAndPersistence:
         assert len(positions) == 1
         assert positions[0]["ticker"] == "AAPL"
         assert positions[0]["range_pct"] == 0.5
+        assert positions[0]["currency"] == "USD"
 
     def test_upsert_is_idempotent_per_day(self, tmp_path: Path):
         db = tmp_path / "test.db"
         ensure_schema(db)
         upsert_prices(db, [_row("AAPL", current=150, low=100, high=200)])
-        # Same ticker + day, corrected price -> one row, latest wins.
         upsert_prices(db, [_row("AAPL", current=120, low=100, high=200)])
         positions = read_positions(db)
         assert len(positions) == 1
@@ -94,12 +104,11 @@ class TestSchemaAndPersistence:
         db = tmp_path / "test.db"
         ensure_schema(db)
         upsert_prices(db, [
-            _row("HIGH", current=190, low=100, high=200),  # 0.9
-            _row("LOW", current=110, low=100, high=200),   # 0.1
-            _row("MID", current=150, low=100, high=200),   # 0.5
+            _row("HIGH", current=190, low=100, high=200),
+            _row("LOW", current=110, low=100, high=200),
+            _row("MID", current=150, low=100, high=200),
         ])
-        positions = read_positions(db)
-        assert [p["ticker"] for p in positions] == ["LOW", "MID", "HIGH"]
+        assert [p["ticker"] for p in read_positions(db)] == ["LOW", "MID", "HIGH"]
 
     def test_read_positions_filters_by_ticker(self, tmp_path: Path):
         db = tmp_path / "test.db"
@@ -108,8 +117,25 @@ class TestSchemaAndPersistence:
             _row("AAPL", current=150, low=100, high=200),
             _row("MSFT", current=180, low=100, high=200),
         ])
-        positions = read_positions(db, tickers=["AAPL"])
-        assert [p["ticker"] for p in positions] == ["AAPL"]
+        assert [p["ticker"] for p in read_positions(db, tickers=["AAPL"])] == ["AAPL"]
+
+
+class TestTrackedCompanies:
+    def test_returns_ticker_and_exchange(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        with sqlite3.connect(db) as conn:
+            conn.execute("CREATE TABLE companies (id INTEGER PRIMARY KEY, ticker TEXT, name TEXT, exchange TEXT)")
+            conn.executemany(
+                "INSERT INTO companies (ticker, name, exchange) VALUES (?, ?, ?)",
+                [
+                    ("AAPL", "Apple", None),
+                    ("CSU", "Constellation", "TSX"),
+                    (None, "Private Co", None),  # null ticker excluded
+                    ("", "Blank Co", "TSX"),     # empty ticker excluded
+                ],
+            )
+            conn.commit()
+        assert tracked_companies(db) == [("AAPL", None), ("CSU", "TSX")]
 
 
 class TestRefreshPrices:
@@ -118,15 +144,11 @@ class TestRefreshPrices:
         ensure_schema(db)
 
         def fake_fetcher(ticker: str, **_kw) -> PriceRow:
-            table = {
-                "AAPL": (150, 100, 200),
-                "MSFT": (180, 100, 200),
-                "NVDA": (120, 100, 200),
-            }
+            table = {"AAPL": (150, 100, 200), "CSU": (180, 100, 200), "TOI": (120, 100, 200)}
             cur, low, high = table[ticker]
             return _row(ticker, current=cur, low=low, high=high)
 
-        result = refresh_prices(db, ["AAPL", "MSFT", "NVDA"], api_key="x", fetcher=fake_fetcher)
+        result = refresh_prices(db, [("AAPL", None), ("CSU", "TSX"), ("TOI", "TSXV")], fetcher=fake_fetcher)
         assert result["fetched"] == 3
         assert result["errors"] == []
         assert len(read_positions(db)) == 3
@@ -137,47 +159,19 @@ class TestRefreshPrices:
 
         def flaky_fetcher(ticker: str, **_kw) -> PriceRow:
             if ticker == "BAD":
-                raise RuntimeError("finnhub said no")
+                raise ValueError("no chart data")
             return _row(ticker, current=150, low=100, high=200)
 
-        result = refresh_prices(db, ["AAPL", "BAD", "MSFT"], api_key="x", fetcher=flaky_fetcher)
+        result = refresh_prices(db, [("AAPL", None), ("BAD", None), ("MSFT", None)], fetcher=flaky_fetcher)
         assert result["fetched"] == 2
         assert [e["ticker"] for e in result["errors"]] == ["BAD"]
-        # The two good tickers still landed.
         assert {p["ticker"] for p in read_positions(db)} == {"AAPL", "MSFT"}
-
-
-class TestTrackedTickers:
-    def _seed_companies(self, db: Path) -> None:
-        # Mirrors the real companies schema: folder_exists drives the active set.
-        with sqlite3.connect(db) as conn:
-            conn.execute(
-                "CREATE TABLE companies (id INTEGER PRIMARY KEY, ticker TEXT, name TEXT, "
-                "folder_exists INTEGER NOT NULL DEFAULT 0)"
-            )
-            conn.executemany(
-                "INSERT INTO companies (ticker, name, folder_exists) VALUES (?, ?, ?)",
-                [
-                    ("AAPL", "Apple", 1),
-                    ("MSFT", "Microsoft", 0),
-                    ("CRM", "Salesforce", 0),
-                    (None, "Private Co", 1),  # null ticker excluded
-                    ("", "Blank Co", 1),      # empty ticker excluded
-                ],
-            )
-            conn.commit()
-
-    def test_returns_all_tickers_regardless_of_folder(self, tmp_path: Path):
-        db = tmp_path / "test.db"
-        self._seed_companies(db)
-        assert tracked_tickers(db) == ["AAPL", "CRM", "MSFT"]
 
 
 class TestRateLimiter:
     def test_spacing_enforced(self):
         limiter = RateLimiter(min_interval=0.05)
         start = time.monotonic()
-        limiter.acquire()  # first is immediate
-        limiter.acquire()  # second waits >= min_interval
-        elapsed = time.monotonic() - start
-        assert elapsed >= 0.05
+        limiter.acquire()
+        limiter.acquire()
+        assert time.monotonic() - start >= 0.05

--- a/tests/test_minerva/test_prices.py
+++ b/tests/test_minerva/test_prices.py
@@ -149,31 +149,28 @@ class TestRefreshPrices:
 
 class TestTrackedTickers:
     def _seed_companies(self, db: Path) -> None:
+        # Mirrors the real companies schema: folder_exists drives the active set.
         with sqlite3.connect(db) as conn:
             conn.execute(
-                "CREATE TABLE companies (id INTEGER PRIMARY KEY, ticker TEXT, name TEXT, status TEXT)"
+                "CREATE TABLE companies (id INTEGER PRIMARY KEY, ticker TEXT, name TEXT, "
+                "folder_exists INTEGER NOT NULL DEFAULT 0)"
             )
             conn.executemany(
-                "INSERT INTO companies (ticker, name, status) VALUES (?, ?, ?)",
+                "INSERT INTO companies (ticker, name, folder_exists) VALUES (?, ?, ?)",
                 [
-                    ("AAPL", "Apple", "owned"),
-                    ("MSFT", "Microsoft", "tracking"),
-                    ("OLD", "Exited Co", "exited"),
-                    ("NO", "Passed Co", "passed"),
-                    (None, "Private Co", "tracking"),  # null ticker excluded
+                    ("AAPL", "Apple", 1),
+                    ("MSFT", "Microsoft", 0),
+                    ("CRM", "Salesforce", 0),
+                    (None, "Private Co", 1),  # null ticker excluded
+                    ("", "Blank Co", 1),      # empty ticker excluded
                 ],
             )
             conn.commit()
 
-    def test_defaults_to_tracking_and_owned(self, tmp_path: Path):
+    def test_returns_all_tickers_regardless_of_folder(self, tmp_path: Path):
         db = tmp_path / "test.db"
         self._seed_companies(db)
-        assert tracked_tickers(db) == ["AAPL", "MSFT"]
-
-    def test_status_override(self, tmp_path: Path):
-        db = tmp_path / "test.db"
-        self._seed_companies(db)
-        assert tracked_tickers(db, statuses=("exited",)) == ["OLD"]
+        assert tracked_tickers(db) == ["AAPL", "CRM", "MSFT"]
 
 
 class TestRateLimiter:

--- a/tests/test_minerva/test_prices.py
+++ b/tests/test_minerva/test_prices.py
@@ -1,0 +1,186 @@
+"""Tests for minerva.prices — 52-week price position tracking.
+
+Network is isolated behind an injectable fetcher, so no requests mocking.
+DB tests use a real temporary sqlite file built from the module's own schema.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from minerva.prices import (
+    PriceRow,
+    RateLimiter,
+    ensure_schema,
+    range_pct,
+    read_positions,
+    refresh_prices,
+    tracked_tickers,
+    upsert_prices,
+)
+
+
+def _row(ticker: str, current: float, low: float, high: float, as_of: str = "2026-07-01") -> PriceRow:
+    return PriceRow(
+        ticker=ticker,
+        as_of=as_of,
+        current=current,
+        wk52_low=low,
+        wk52_high=high,
+        low_date="2025-06-30",
+        high_date="2026-06-08",
+    )
+
+
+class TestRangePct:
+    def test_on_low_is_zero(self):
+        assert range_pct(_row("A", current=100, low=100, high=200)) == 0.0
+
+    def test_on_high_is_one(self):
+        assert range_pct(_row("A", current=200, low=100, high=200)) == 1.0
+
+    def test_midpoint_is_half(self):
+        assert range_pct(_row("A", current=150, low=100, high=200)) == 0.5
+
+    def test_high_equals_low_returns_none(self):
+        # No range: undefined position, must not divide by zero.
+        assert range_pct(_row("A", current=100, low=100, high=100)) is None
+
+    def test_missing_inputs_return_none(self):
+        assert range_pct(PriceRow("A", "2026-07-01", None, 100, 200)) is None
+
+
+class TestSchemaAndPersistence:
+    def test_ensure_schema_creates_table_and_view(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+        with sqlite3.connect(db) as conn:
+            objects = {
+                name for (name,) in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE name IN ('prices','price_position')"
+                )
+            }
+        assert objects == {"prices", "price_position"}
+
+    def test_ensure_schema_is_idempotent(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+        ensure_schema(db)  # second call must not raise
+
+    def test_upsert_then_read(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+        upsert_prices(db, [_row("AAPL", current=150, low=100, high=200)])
+        positions = read_positions(db)
+        assert len(positions) == 1
+        assert positions[0]["ticker"] == "AAPL"
+        assert positions[0]["range_pct"] == 0.5
+
+    def test_upsert_is_idempotent_per_day(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+        upsert_prices(db, [_row("AAPL", current=150, low=100, high=200)])
+        # Same ticker + day, corrected price -> one row, latest wins.
+        upsert_prices(db, [_row("AAPL", current=120, low=100, high=200)])
+        positions = read_positions(db)
+        assert len(positions) == 1
+        assert positions[0]["current"] == 120
+
+    def test_read_positions_sorted_by_range_pct(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+        upsert_prices(db, [
+            _row("HIGH", current=190, low=100, high=200),  # 0.9
+            _row("LOW", current=110, low=100, high=200),   # 0.1
+            _row("MID", current=150, low=100, high=200),   # 0.5
+        ])
+        positions = read_positions(db)
+        assert [p["ticker"] for p in positions] == ["LOW", "MID", "HIGH"]
+
+    def test_read_positions_filters_by_ticker(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+        upsert_prices(db, [
+            _row("AAPL", current=150, low=100, high=200),
+            _row("MSFT", current=180, low=100, high=200),
+        ])
+        positions = read_positions(db, tickers=["AAPL"])
+        assert [p["ticker"] for p in positions] == ["AAPL"]
+
+
+class TestRefreshPrices:
+    def test_refresh_persists_all_with_fake_fetcher(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+
+        def fake_fetcher(ticker: str, **_kw) -> PriceRow:
+            table = {
+                "AAPL": (150, 100, 200),
+                "MSFT": (180, 100, 200),
+                "NVDA": (120, 100, 200),
+            }
+            cur, low, high = table[ticker]
+            return _row(ticker, current=cur, low=low, high=high)
+
+        result = refresh_prices(db, ["AAPL", "MSFT", "NVDA"], api_key="x", fetcher=fake_fetcher)
+        assert result["fetched"] == 3
+        assert result["errors"] == []
+        assert len(read_positions(db)) == 3
+
+    def test_refresh_records_per_ticker_errors_and_continues(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        ensure_schema(db)
+
+        def flaky_fetcher(ticker: str, **_kw) -> PriceRow:
+            if ticker == "BAD":
+                raise RuntimeError("finnhub said no")
+            return _row(ticker, current=150, low=100, high=200)
+
+        result = refresh_prices(db, ["AAPL", "BAD", "MSFT"], api_key="x", fetcher=flaky_fetcher)
+        assert result["fetched"] == 2
+        assert [e["ticker"] for e in result["errors"]] == ["BAD"]
+        # The two good tickers still landed.
+        assert {p["ticker"] for p in read_positions(db)} == {"AAPL", "MSFT"}
+
+
+class TestTrackedTickers:
+    def _seed_companies(self, db: Path) -> None:
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                "CREATE TABLE companies (id INTEGER PRIMARY KEY, ticker TEXT, name TEXT, status TEXT)"
+            )
+            conn.executemany(
+                "INSERT INTO companies (ticker, name, status) VALUES (?, ?, ?)",
+                [
+                    ("AAPL", "Apple", "owned"),
+                    ("MSFT", "Microsoft", "tracking"),
+                    ("OLD", "Exited Co", "exited"),
+                    ("NO", "Passed Co", "passed"),
+                    (None, "Private Co", "tracking"),  # null ticker excluded
+                ],
+            )
+            conn.commit()
+
+    def test_defaults_to_tracking_and_owned(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        self._seed_companies(db)
+        assert tracked_tickers(db) == ["AAPL", "MSFT"]
+
+    def test_status_override(self, tmp_path: Path):
+        db = tmp_path / "test.db"
+        self._seed_companies(db)
+        assert tracked_tickers(db, statuses=("exited",)) == ["OLD"]
+
+
+class TestRateLimiter:
+    def test_spacing_enforced(self):
+        limiter = RateLimiter(min_interval=0.05)
+        start = time.monotonic()
+        limiter.acquire()  # first is immediate
+        limiter.acquire()  # second waits >= min_interval
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.05


### PR DESCRIPTION
## What

Adds `minerva portfolio prices` — tracks current price against the 52-week range for every company in the DB and sorts by where each sits in its band (`0` = on 52w low, `1` = on 52w high).

```
minerva portfolio prices              # read stored table, sorted by range_pct; zero network
minerva portfolio prices AAPL         # fetch + persist one ticker
minerva portfolio prices AAPL CSU     # fetch + persist several
minerva portfolio prices --refresh    # fetch every company in the DB
```

Naming tickers (or `--refresh`) fetches live and upserts; naming nothing is a zero-network read of the stored table.

## Data source: Yahoo Finance

One keyless call per ticker to `query1.finance.yahoo.com/v8/finance/chart/{symbol}` returns both current price and 52-week high/low. Covers US **and** international listings.

Non-US listings need exchange-suffixed symbols (`TOI.V`, `CSU.TO`, `4478.T`, `REL.L`, ...). The bare ticker alone can resolve to the wrong security (`TOI` → an unrelated US stock instead of Topicus), so the symbol is derived from the exchange, never guessed.

## Symbols and exchange

- `companies` gains an `exchange` column (market code: `TSX`, `TSXV`, `ASX`, `LSE`, `TSE`, `ETR`, `EPA`, `AMS`, `SWX`, `STO`, `BME`; NULL ⇒ US). Backfilled for all non-US names.
- `yahoo_symbol(ticker, exchange)` derives the Yahoo symbol (appends the suffix; US ⇒ bare; already-suffixed passes through). The **canonical bare ticker stays the identity** in both tables — the suffix is a fetch-time detail, never stored — so `prices` joins cleanly to `companies` and identity isn't coupled to Yahoo's convention.

## Data model

`prices` table + `price_position` view:
- `range_pct = (current - wk52_low) / (wk52_high - wk52_low)`, computed on read in the view, never stored — a corrected input can't leave a stale derived value. `NULLIF` guards `high == low`.
- Stores native `currency`; `range_pct` is a within-currency ratio, so currency never affects sorting.
- Keyed on `(ticker, as_of)`; same-day re-pulls upsert.

## Output

Table shows `TICKER  EXCH  CURRENT  52W_LOW  52W_HIGH  RANGE_PCT  CCY  AS_OF`, sorted ascending by `range_pct` (near-low first). `EXCH` reads from `companies.exchange` (`US` when null), giving market + currency context without mangling the ticker.

## Reliability

- Retries transient empty responses (Yahoo occasionally throttles mid-batch).
- Genuine 404s (delisted / renamed symbols) fail per-ticker and never abort the run.

## Code

- `src/minerva/prices.py` — model, schema, persistence, Yahoo fetch, orchestration. Network isolated in `fetch_price`, injected into `refresh_prices` as a `fetcher` so tests need no HTTP mock.
- `src/harness/commands/portfolio.py` — thin `prices` subcommand + dispatch. No API key.
- Float coercion consolidated into `minerva.formatting.to_float` (previously duplicated as `prices._as_float` and `morning_brief._to_float`).

## Tests

- 313 passed. Network-free: range math, `yahoo_symbol` mapping, `to_float`, upsert idempotency, sort order, `tracked_companies`, per-ticker error isolation, rate-limiter spacing, command read/render path.

## Live result

~102/112 resolve. The misses are companies delisted / taken private in 2024–25 (Confluent, CyberArk, Dayforce, Dun & Bradstreet, E2open, Instructure, PowerSchool, Smartsheet) plus Fortnox — correctly unresolvable, since they no longer trade publicly.

## Follow-ups (not in this PR)

- `companies` hygiene: flag/remove delisted names; optional direct symbol overrides for Yahoo ticker-lag cases (`FI`→`FISV`, `CCCS`→`CCC`).
- Daily cron into the morning brief.