### PR TITLE
fix: bound concurrent news collectors

### DIFF
--- a/docs/21-news-cli-plan.md
+++ b/docs/21-news-cli-plan.md
@@ -45,7 +45,7 @@ Promote the morning-brief news ingestion and deterministic duplicate lookup into
 - Give each collector a physically isolated ephemeral source root containing its own `raw/`, `candidates/`, `lookups/`, and `logs/` directories. Render `NEWS_DIR` to that root, and forbid collectors from inspecting or changing any parent, sibling, or other source files. Collectors call `news exist --input` and redirect compact results to files in their own root; no candidate JSON is embedded in shell commands.
 - After all collectors exit, aggregate source `raw/*.md` files into the central run `raw/` directory in deterministic lexical order. Treat duplicate filenames as a fatal collision rather than overwriting; collector-generated and shell-generated error artifacts use this same path.
 - Change ingestion to `run news ingest ...`, preserving the report, JSON stats file, duplicate count, and cleanup rule: delete the temporary run directory only after successful ingestion (or a successful no-input path).
-- Use one shared collector shell helper with one `openclaw agent` invocation and no automatic retries. Launch every configured standard and IR collector before a single shared wait—there is intentionally no IR batch or replacement concurrency ceiling (the current 48 IR feeds are expected). Preserve one window/tab per browser agent.
+- Use one shared collector shell helper with one `openclaw agent` invocation and no automatic retries. Run standard and IR collectors through one configurable global pool: `MINERVA_MAX_COLLECTORS` defaults to 8 and can be raised without changing code as Gateway capacity grows. Preserve one window/tab per browser agent.
 - Configure collector timeouts with positive-integer environment variables validated before temporary state is created: `MINERVA_BROWSER_TIMEOUT` defaults to 900 seconds and `MINERVA_WEBFETCH_TIMEOUT` defaults to 300 seconds, both safely below the 30-minute no-output watchdog by default.
 
 ## Prompt behavior
@@ -72,7 +72,7 @@ Focused tests will cover:
 - existence lookup by URL and article key, unseen candidates, empty URLs, malformed JSON, stdin/`--input`, missing database/table behavior, and deterministic in-batch URL/article-key deduplication;
 - proof that existence checks are read-only/query-only and do not change database files;
 - URL-index creation in new and migrated schemas, plus clear errors for malformed source registries while absent optional registries remain valid;
-- shell and prompt integration: physically isolated per-source roots, behavior under a cross-source deletion attempt, deterministic collision-safe raw aggregation (including errors), direct CLI ingestion, one shared no-retry collector helper, all IR collectors launched before one shared wait with no concurrency ceiling, validated configurable timeout defaults, one-window/one-tab browser instructions, URL fetches before web-fetch writes, no arbitrary item caps, the official `gemini-3.6-flash` summarization model, and successful-cleanup semantics.
+- shell and prompt integration: physically isolated per-source roots, behavior under a cross-source deletion attempt, deterministic collision-safe raw aggregation (including errors), direct CLI ingestion, one shared no-retry collector helper, a validated configurable global collector pool, validated configurable timeout defaults, one-window/one-tab browser instructions, URL fetches before web-fetch writes, no arbitrary item caps, the official `gemini-3.6-flash` summarization model, and successful-cleanup semantics.
 
 ## Verification gates
 

--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -10,10 +10,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 RUN_DATE="${1:-$(date +%F)}"
 MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-900}"
 MINERVA_WEBFETCH_TIMEOUT="${MINERVA_WEBFETCH_TIMEOUT:-300}"
-for timeout_name in MINERVA_BROWSER_TIMEOUT MINERVA_WEBFETCH_TIMEOUT; do
-  timeout_value="${!timeout_name}"
-  if ! [[ "${timeout_value}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "${timeout_name} must be a positive integer" >&2
+MINERVA_MAX_COLLECTORS="${MINERVA_MAX_COLLECTORS:-8}"
+for integer_name in \
+  MINERVA_BROWSER_TIMEOUT \
+  MINERVA_WEBFETCH_TIMEOUT \
+  MINERVA_MAX_COLLECTORS; do
+  integer_value="${!integer_name}"
+  if ! [[ "${integer_value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${integer_name} must be a positive integer" >&2
     exit 1
   fi
 done
@@ -266,6 +270,17 @@ PY
 
   # Allocate the physical root before launch so duplicate/unsafe source IDs
   # cannot make two concurrent collectors share files.
+  wait_for_collectors() {
+    if [[ "${#PIDS[@]}" -eq 0 ]]; then
+      return 0
+    fi
+    echo "  waiting for collector batch (${#PIDS[@]} agents)..."
+    for pid in "${PIDS[@]}"; do
+      wait "$pid" 2>/dev/null || true
+    done
+    PIDS=()
+  }
+
   launch_source() {
     local prompt_template="$1" timeout="$2" source_id="$3" source_name="$4"
     local url="$5" collection_scope="$6"
@@ -287,6 +302,9 @@ PY
       "${source_id}" "${source_name}" "${url}" "${collection_scope}" \
       "${source_root}" &
     PIDS+=("$!")
+    if [[ "${#PIDS[@]}" -ge "${MINERVA_MAX_COLLECTORS}" ]]; then
+      wait_for_collectors
+    fi
   }
 
   # Copy source artifacts in lexical source/file order only after every agent
@@ -329,9 +347,9 @@ PY
     done < <(jq -c '.[]' "${NEWS_SOURCES}")
   fi
 
-  # Launch all configured IR feeds immediately. The full set intentionally
-  # shares the same final wait as the other collectors; there is no batching or
-  # replacement concurrency ceiling.
+  # IR feeds share the same configurable collector pool as standard sources.
+  # The limit protects the Gateway from client-startup contention and can be
+  # raised without changing code as capacity grows.
   if [[ -f "${IR_REGISTRY}" ]]; then
     while IFS= read -r entry; do
       ticker=$(echo "$entry" | jq -r '.security_id')
@@ -348,13 +366,9 @@ PY
     done < <(jq -c '.[]' "${IR_REGISTRY}")
   fi
 
-  # Wait once, after all standard and IR collectors have been launched.
+  # Wait for the final partial collector batch.
   echo "  waiting for news agents..."
-  if [[ "${#PIDS[@]}" -gt 0 ]]; then
-    for pid in "${PIDS[@]}"; do
-      wait "$pid" 2>/dev/null || true
-    done
-  fi
+  wait_for_collectors
 
   aggregate_source_raw
 

--- a/tests/test_harness/test_news.py
+++ b/tests/test_harness/test_news.py
@@ -581,10 +581,11 @@ def test_morning_brief_shell_and_prompts_use_news_cli_contract() -> None:
     assert 'local prompt_template="$1" timeout="$2"' in script
     assert 'MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-900}"' in script
     assert 'MINERVA_WEBFETCH_TIMEOUT="${MINERVA_WEBFETCH_TIMEOUT:-300}"' in script
+    assert 'MINERVA_MAX_COLLECTORS="${MINERVA_MAX_COLLECTORS:-8}"' in script
     assert 'launch_source "${BROWSER_PROMPT_TEMPLATE}" "${MINERVA_BROWSER_TIMEOUT}"' in script
     assert 'launch_source "${WEBFETCH_PROMPT_TEMPLATE}" "${MINERVA_WEBFETCH_TIMEOUT}"' in script
-    assert "there is no batching or" in script
-    assert "replacement concurrency ceiling" in script
+    assert '"${#PIDS[@]}" -ge "${MINERVA_MAX_COLLECTORS}"' in script
+    assert "wait_for_collectors()" in script
     assert '--concurrency 4' in script
 
     for prompt in (browser_prompt, webfetch_prompt):

--- a/tests/test_news_collection.py
+++ b/tests/test_news_collection.py
@@ -192,6 +192,7 @@ def _run_wrapper(
         ("MINERVA_BROWSER_TIMEOUT", "0"),
         ("MINERVA_BROWSER_TIMEOUT", "not-a-number"),
         ("MINERVA_WEBFETCH_TIMEOUT", "-1"),
+        ("MINERVA_MAX_COLLECTORS", "0"),
     ],
 )
 def test_collector_timeout_validation_precedes_temp_state(
@@ -253,6 +254,7 @@ def test_collectors_are_isolated_launch_all_ir_and_aggregate_every_artifact(
         extra_env={
             "EXPECTED_IR_COUNT": str(len(tickers)),
             "BROKEN_SOURCE": "broken-feed",
+            "MINERVA_MAX_COLLECTORS": "8",
         },
     )
 


### PR DESCRIPTION
## Summary
- replace unbounded 54-client startup with one configurable global collector pool
- default `MINERVA_MAX_COLLECTORS` to 8 while allowing operators to raise it without code changes
- preserve per-source isolation, one-window behavior, and collision-safe aggregation

## Live finding
A full cron run with 54 simultaneous `openclaw` clients produced zero collector sessions/artifacts after six minutes because the clients contended during startup. The bounded pool addresses the measured failure rather than assuming the host can absorb unlimited clients.

## Verification
- `uv run pytest -q` — 396 passed
- focused collector/news tests — 28 passed
- `bash -n scripts/run_morning_brief.sh`
- `git diff --check`