### PR TITLE
feat: add minerva valuation irr command

### DIFF
--- a/src/harness/commands/valuation.py
+++ b/src/harness/commands/valuation.py
@@ -26,6 +26,7 @@ VALUATION_HELP = (
     "Examples:\n"
     "  minerva valuation dcf --revenue 394e9 --growth 0.06,0.05,0.04 --margins 0.28,0.29,0.30 --wacc 0.10 --terminal-growth 0.03 --shares 15.5e9 --net-cash 57e9\n"
     "  minerva valuation comps --ntm-revenue 420e9 --ntm-ebitda 140e9 --ntm-fcf 110e9 --shares 15.5e9 --net-cash 57e9 --ev-rev 8.5 --ev-ebitda 25 --p-fcf 30\n"
+    "  minerva valuation implied-return --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04 --risk-free 0.043\n"
     "  minerva valuation report --ticker AAPL --config valuation.json --output valuation.md\n"
 )
 
@@ -104,6 +105,18 @@ def dispatch(
             wacc=float(parsed["wacc"]),
             terminal_growth=float(parsed["terminal-growth"]),
             years=int(parsed.get("years", 5)),
+            export_path=str(parsed["export"]) if "export" in parsed else None,
+            settings=settings,
+        )
+    if subcommand == "implied-return":
+        required = ["value", "cash-flows", "terminal-growth"]
+        if missing := [name for name in required if name not in parsed]:
+            return _dispatch_help("implied-return", missing)
+        return run_implied_return_command(
+            value=float(parsed["value"]),
+            cash_flows_csv=str(parsed["cash-flows"]),
+            terminal_growth=float(parsed["terminal-growth"]),
+            risk_free=float(parsed["risk-free"]) if "risk-free" in parsed else None,
             export_path=str(parsed["export"]) if "export" in parsed else None,
             settings=settings,
         )
@@ -328,6 +341,49 @@ def run_reverse_dcf_command(
             f"assumptions_note: {result.assumptions_note}",
         ]
     )
+    output += maybe_export_text(output, export_path)
+    return CommandResult.from_text(output, duration_ms=elapsed_ms(start))
+
+def run_implied_return_command(
+    *,
+    value: float,
+    cash_flows_csv: str,
+    terminal_growth: float,
+    risk_free: float | None = None,
+    export_path: str | None = None,
+    settings: HarnessSettings,
+) -> CommandResult:
+    start: float = time.perf_counter()
+    try:
+        from minerva.formatting import format_pct
+        from minerva.valuation import run_implied_return
+
+        result = run_implied_return(
+            current_value=value,
+            cash_distributions=parse_csv_floats(cash_flows_csv),
+            terminal_growth=terminal_growth,
+            risk_free_rate=risk_free,
+        )
+    except Exception as exc:
+        return error_result(
+            f"failed to solve implied return: {exc}",
+            "provide a positive value, non-negative annual cash flows, and a valid terminal growth rate",
+            ["`valuation reverse-dcf --price ...`", "`valuation dcf --revenue ...`"],
+            start,
+        )
+
+    lines: list[str] = [
+        "## Market-Implied Equity Return",
+        "",
+        f"current_value: {result.current_value:,.2f}",
+        f"implied_return: {format_pct(result.implied_return * 100)}",
+    ]
+    if result.equity_risk_premium is not None:
+        lines.append(
+            f"equity_risk_premium: {format_pct(result.equity_risk_premium * 100)}"
+        )
+    lines.append(f"assumptions_note: {result.assumptions_note}")
+    output: str = "\n".join(lines)
     output += maybe_export_text(output, export_path)
     return CommandResult.from_text(output, duration_ms=elapsed_ms(start))
 
@@ -629,6 +685,61 @@ def reverse_dcf_command(
         )
     )
 
+@app.command(
+    "implied-return",
+    help=(
+        "Solve for the annual equity return implied by current value and shareholder cash distributions.\n\n"
+        "Example:\n"
+        "  minerva valuation implied-return --value 5000 --cash-flows 180,190,205 "
+        "--terminal-growth 0.04 --risk-free 0.043"
+    ),
+)
+def implied_return_command(
+    ctx: typer.Context,
+    value: float | None = typer.Option(
+        None,
+        "--value",
+        help="Current index or equity value in the same units as cash flows.",
+    ),
+    cash_flows: str | None = typer.Option(
+        None,
+        "--cash-flows",
+        help="Annual shareholder cash distributions (e.g. dividends plus buybacks) as CSV values.",
+    ),
+    terminal_growth: float | None = typer.Option(
+        None,
+        "--terminal-growth",
+        help="Perpetual growth rate after the final cash distribution.",
+    ),
+    risk_free: float | None = typer.Option(
+        None,
+        "--risk-free",
+        help="Optional risk-free rate used to calculate equity risk premium.",
+    ),
+    export: str | None = typer.Option(None, "--export", help="Save full output to file."),
+) -> None:
+    settings = get_settings()
+    if None in {value, cash_flows, terminal_growth}:
+        abort_with_help(
+            ctx,
+            what_went_wrong="missing required implied-return inputs",
+            what_to_do="provide current value, annual cash distributions, and terminal growth",
+            alternatives=[
+                "`minerva valuation implied-return --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04`",
+                "`minerva valuation reverse-dcf --price 220 ...`",
+            ],
+        )
+    _print(
+        run_implied_return_command(
+            value=float(value),
+            cash_flows_csv=str(cash_flows),
+            terminal_growth=float(terminal_growth),
+            risk_free=risk_free,
+            export_path=export,
+            settings=settings,
+        )
+    )
+
 @app.command("sotp", help="Run a sum-of-the-parts valuation.\n\nExample:\n  minerva valuation sotp --segments segments.json --net-cash 57e9 --shares 15.5e9")
 def sotp_command(
     ctx: typer.Context,
@@ -679,6 +790,7 @@ def _dispatch_help(subcommand: str, missing: list[str]) -> CommandResult:
         "dcf": "valuation dcf --revenue <float> --growth <csv> --margins <csv> --wacc <float> --terminal-growth <float> --shares <float> --net-cash <float> [--fcf <float>] [--export PATH]",
         "comps": "valuation comps --ntm-revenue <float> --ntm-ebitda <float> --ntm-fcf <float> --shares <float> --net-cash <float> --ev-rev <float> --ev-ebitda <float> --p-fcf <float> [--export PATH]",
         "reverse-dcf": "valuation reverse-dcf --price <float> --shares <float> --net-cash <float> --base-revenue <float> --margins <csv> --wacc <float> --terminal-growth <float> [--export PATH]",
+        "implied-return": "valuation implied-return --value <float> --cash-flows <csv> --terminal-growth <float> [--risk-free <float>] [--export PATH]",
         "sotp": "valuation sotp --segments <json-or-path> --net-cash <float> --shares <float> [--export PATH]",
         "report": "valuation report --ticker <ticker> --config <json-file> --output <markdown-file>",
     }

--- a/src/harness/commands/valuation.py
+++ b/src/harness/commands/valuation.py
@@ -27,6 +27,7 @@ VALUATION_HELP = (
     "  minerva valuation dcf --revenue 394e9 --growth 0.06,0.05,0.04 --margins 0.28,0.29,0.30 --wacc 0.10 --terminal-growth 0.03 --shares 15.5e9 --net-cash 57e9\n"
     "  minerva valuation comps --ntm-revenue 420e9 --ntm-ebitda 140e9 --ntm-fcf 110e9 --shares 15.5e9 --net-cash 57e9 --ev-rev 8.5 --ev-ebitda 25 --p-fcf 30\n"
     "  minerva valuation irr --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04 --risk-free 0.043\n"
+    "  minerva valuation irr --value 5000 --base-cash-flow 170 --growth 0.06 --years 5 --terminal-growth 0.04\n"
     "  minerva valuation report --ticker AAPL --config valuation.json --output valuation.md\n"
 )
 
@@ -109,13 +110,16 @@ def dispatch(
             settings=settings,
         )
     if subcommand == "irr":
-        required = ["value", "cash-flows", "terminal-growth"]
+        required = ["value", "terminal-growth"]
         if missing := [name for name in required if name not in parsed]:
             return _dispatch_help("irr", missing)
         return run_irr_command(
             value=float(parsed["value"]),
-            cash_flows_csv=str(parsed["cash-flows"]),
             terminal_growth=float(parsed["terminal-growth"]),
+            cash_flows_csv=str(parsed["cash-flows"]) if "cash-flows" in parsed else None,
+            base_cash_flow=float(parsed["base-cash-flow"]) if "base-cash-flow" in parsed else None,
+            growth=float(parsed["growth"]) if "growth" in parsed else None,
+            years=int(parsed.get("years", 5)),
             risk_free=float(parsed["risk-free"]) if "risk-free" in parsed else None,
             export_path=str(parsed["export"]) if "export" in parsed else None,
             settings=settings,
@@ -347,8 +351,11 @@ def run_reverse_dcf_command(
 def run_irr_command(
     *,
     value: float,
-    cash_flows_csv: str,
     terminal_growth: float,
+    cash_flows_csv: str | None = None,
+    base_cash_flow: float | None = None,
+    growth: float | None = None,
+    years: int = 5,
     risk_free: float | None = None,
     export_path: str | None = None,
     settings: HarnessSettings,
@@ -358,17 +365,39 @@ def run_irr_command(
         from minerva.formatting import format_pct
         from minerva.valuation import run_implied_return
 
+        if years <= 0:
+            raise ValueError("--years must be greater than zero")
+        generated_input_supplied: bool = base_cash_flow is not None or growth is not None
+        if cash_flows_csv is not None and generated_input_supplied:
+            raise ValueError(
+                "--cash-flows cannot be combined with --base-cash-flow or --growth"
+            )
+        if cash_flows_csv is not None:
+            cash_distributions: list[float] = parse_csv_floats(cash_flows_csv)
+        else:
+            if base_cash_flow is None or growth is None:
+                raise ValueError(
+                    "generated cash flows require both --base-cash-flow and --growth"
+                )
+            cash_distributions = [
+                base_cash_flow * (1 + growth) ** year
+                for year in range(1, years + 1)
+            ]
+
         result = run_implied_return(
             current_value=value,
-            cash_distributions=parse_csv_floats(cash_flows_csv),
+            cash_distributions=cash_distributions,
             terminal_growth=terminal_growth,
             risk_free_rate=risk_free,
         )
     except Exception as exc:
         return error_result(
             f"failed to solve valuation IRR: {exc}",
-            "provide a positive value, non-negative annual cash flows, and a valid terminal growth rate",
-            ["`valuation reverse-dcf --price ...`", "`valuation dcf --revenue ...`"],
+            "provide either annual cash flows or a base cash flow with growth, plus a positive value and valid terminal growth rate",
+            [
+                "`valuation irr --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04`",
+                "`valuation irr --value 5000 --base-cash-flow 170 --growth 0.06 --terminal-growth 0.04`",
+            ],
             start,
         )
 
@@ -689,9 +718,11 @@ def reverse_dcf_command(
     "irr",
     help=(
         "Solve for the equity IRR implied by current value and shareholder cash distributions.\n\n"
-        "Example:\n"
+        "Examples:\n"
         "  minerva valuation irr --value 5000 --cash-flows 180,190,205 "
-        "--terminal-growth 0.04 --risk-free 0.043"
+        "--terminal-growth 0.04 --risk-free 0.043\n"
+        "  minerva valuation irr --value 5000 --base-cash-flow 170 --growth 0.06 "
+        "--years 5 --terminal-growth 0.04"
     ),
 )
 def irr_command(
@@ -706,6 +737,21 @@ def irr_command(
         "--cash-flows",
         help="Annual shareholder cash distributions (e.g. dividends plus buybacks) as CSV values.",
     ),
+    base_cash_flow: float | None = typer.Option(
+        None,
+        "--base-cash-flow",
+        help="Year 0 shareholder cash distribution used with --growth.",
+    ),
+    growth: float | None = typer.Option(
+        None,
+        "--growth",
+        help="Annual cash distribution growth rate as a decimal, used with --base-cash-flow.",
+    ),
+    years: int = typer.Option(
+        5,
+        "--years",
+        help="Number of annual cash distributions to generate (default: 5).",
+    ),
     terminal_growth: float | None = typer.Option(
         None,
         "--terminal-growth",
@@ -719,26 +765,30 @@ def irr_command(
     export: str | None = typer.Option(None, "--export", help="Save full output to file."),
 ) -> None:
     settings = get_settings()
-    if None in {value, cash_flows, terminal_growth}:
+    if None in {value, terminal_growth}:
         abort_with_help(
             ctx,
             what_went_wrong="missing required IRR inputs",
-            what_to_do="provide current value, annual cash distributions, and terminal growth",
+            what_to_do="provide current value, terminal growth, and one cash flow input mode",
             alternatives=[
                 "`minerva valuation irr --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04`",
-                "`minerva valuation reverse-dcf --price 220 ...`",
+                "`minerva valuation irr --value 5000 --base-cash-flow 170 --growth 0.06 --terminal-growth 0.04`",
             ],
         )
-    _print(
-        run_irr_command(
-            value=float(value),
-            cash_flows_csv=str(cash_flows),
-            terminal_growth=float(terminal_growth),
-            risk_free=risk_free,
-            export_path=export,
-            settings=settings,
-        )
+    result: CommandResult = run_irr_command(
+        value=float(value),
+        terminal_growth=float(terminal_growth),
+        cash_flows_csv=cash_flows,
+        base_cash_flow=base_cash_flow,
+        growth=growth,
+        years=years,
+        risk_free=risk_free,
+        export_path=export,
+        settings=settings,
     )
+    _print(result)
+    if result.exit_code:
+        raise typer.Exit(result.exit_code)
 
 @app.command("sotp", help="Run a sum-of-the-parts valuation.\n\nExample:\n  minerva valuation sotp --segments segments.json --net-cash 57e9 --shares 15.5e9")
 def sotp_command(
@@ -790,7 +840,7 @@ def _dispatch_help(subcommand: str, missing: list[str]) -> CommandResult:
         "dcf": "valuation dcf --revenue <float> --growth <csv> --margins <csv> --wacc <float> --terminal-growth <float> --shares <float> --net-cash <float> [--fcf <float>] [--export PATH]",
         "comps": "valuation comps --ntm-revenue <float> --ntm-ebitda <float> --ntm-fcf <float> --shares <float> --net-cash <float> --ev-rev <float> --ev-ebitda <float> --p-fcf <float> [--export PATH]",
         "reverse-dcf": "valuation reverse-dcf --price <float> --shares <float> --net-cash <float> --base-revenue <float> --margins <csv> --wacc <float> --terminal-growth <float> [--export PATH]",
-        "irr": "valuation irr --value <float> --cash-flows <csv> --terminal-growth <float> [--risk-free <float>] [--export PATH]",
+        "irr": "valuation irr --value <float> (--cash-flows <csv> | --base-cash-flow <float> --growth <decimal> [--years <int>]) --terminal-growth <float> [--risk-free <float>] [--export PATH]",
         "sotp": "valuation sotp --segments <json-or-path> --net-cash <float> --shares <float> [--export PATH]",
         "report": "valuation report --ticker <ticker> --config <json-file> --output <markdown-file>",
     }

--- a/src/harness/commands/valuation.py
+++ b/src/harness/commands/valuation.py
@@ -26,7 +26,7 @@ VALUATION_HELP = (
     "Examples:\n"
     "  minerva valuation dcf --revenue 394e9 --growth 0.06,0.05,0.04 --margins 0.28,0.29,0.30 --wacc 0.10 --terminal-growth 0.03 --shares 15.5e9 --net-cash 57e9\n"
     "  minerva valuation comps --ntm-revenue 420e9 --ntm-ebitda 140e9 --ntm-fcf 110e9 --shares 15.5e9 --net-cash 57e9 --ev-rev 8.5 --ev-ebitda 25 --p-fcf 30\n"
-    "  minerva valuation implied-return --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04 --risk-free 0.043\n"
+    "  minerva valuation irr --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04 --risk-free 0.043\n"
     "  minerva valuation report --ticker AAPL --config valuation.json --output valuation.md\n"
 )
 
@@ -108,11 +108,11 @@ def dispatch(
             export_path=str(parsed["export"]) if "export" in parsed else None,
             settings=settings,
         )
-    if subcommand == "implied-return":
+    if subcommand == "irr":
         required = ["value", "cash-flows", "terminal-growth"]
         if missing := [name for name in required if name not in parsed]:
-            return _dispatch_help("implied-return", missing)
-        return run_implied_return_command(
+            return _dispatch_help("irr", missing)
+        return run_irr_command(
             value=float(parsed["value"]),
             cash_flows_csv=str(parsed["cash-flows"]),
             terminal_growth=float(parsed["terminal-growth"]),
@@ -344,7 +344,7 @@ def run_reverse_dcf_command(
     output += maybe_export_text(output, export_path)
     return CommandResult.from_text(output, duration_ms=elapsed_ms(start))
 
-def run_implied_return_command(
+def run_irr_command(
     *,
     value: float,
     cash_flows_csv: str,
@@ -366,14 +366,14 @@ def run_implied_return_command(
         )
     except Exception as exc:
         return error_result(
-            f"failed to solve implied return: {exc}",
+            f"failed to solve valuation IRR: {exc}",
             "provide a positive value, non-negative annual cash flows, and a valid terminal growth rate",
             ["`valuation reverse-dcf --price ...`", "`valuation dcf --revenue ...`"],
             start,
         )
 
     lines: list[str] = [
-        "## Market-Implied Equity Return",
+        "## Implied Equity IRR",
         "",
         f"current_value: {result.current_value:,.2f}",
         f"implied_return: {format_pct(result.implied_return * 100)}",
@@ -686,15 +686,15 @@ def reverse_dcf_command(
     )
 
 @app.command(
-    "implied-return",
+    "irr",
     help=(
-        "Solve for the annual equity return implied by current value and shareholder cash distributions.\n\n"
+        "Solve for the equity IRR implied by current value and shareholder cash distributions.\n\n"
         "Example:\n"
-        "  minerva valuation implied-return --value 5000 --cash-flows 180,190,205 "
+        "  minerva valuation irr --value 5000 --cash-flows 180,190,205 "
         "--terminal-growth 0.04 --risk-free 0.043"
     ),
 )
-def implied_return_command(
+def irr_command(
     ctx: typer.Context,
     value: float | None = typer.Option(
         None,
@@ -722,15 +722,15 @@ def implied_return_command(
     if None in {value, cash_flows, terminal_growth}:
         abort_with_help(
             ctx,
-            what_went_wrong="missing required implied-return inputs",
+            what_went_wrong="missing required IRR inputs",
             what_to_do="provide current value, annual cash distributions, and terminal growth",
             alternatives=[
-                "`minerva valuation implied-return --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04`",
+                "`minerva valuation irr --value 5000 --cash-flows 180,190,205 --terminal-growth 0.04`",
                 "`minerva valuation reverse-dcf --price 220 ...`",
             ],
         )
     _print(
-        run_implied_return_command(
+        run_irr_command(
             value=float(value),
             cash_flows_csv=str(cash_flows),
             terminal_growth=float(terminal_growth),
@@ -790,7 +790,7 @@ def _dispatch_help(subcommand: str, missing: list[str]) -> CommandResult:
         "dcf": "valuation dcf --revenue <float> --growth <csv> --margins <csv> --wacc <float> --terminal-growth <float> --shares <float> --net-cash <float> [--fcf <float>] [--export PATH]",
         "comps": "valuation comps --ntm-revenue <float> --ntm-ebitda <float> --ntm-fcf <float> --shares <float> --net-cash <float> --ev-rev <float> --ev-ebitda <float> --p-fcf <float> [--export PATH]",
         "reverse-dcf": "valuation reverse-dcf --price <float> --shares <float> --net-cash <float> --base-revenue <float> --margins <csv> --wacc <float> --terminal-growth <float> [--export PATH]",
-        "implied-return": "valuation implied-return --value <float> --cash-flows <csv> --terminal-growth <float> [--risk-free <float>] [--export PATH]",
+        "irr": "valuation irr --value <float> --cash-flows <csv> --terminal-growth <float> [--risk-free <float>] [--export PATH]",
         "sotp": "valuation sotp --segments <json-or-path> --net-cash <float> --shares <float> [--export PATH]",
         "report": "valuation report --ticker <ticker> --config <json-file> --output <markdown-file>",
     }

--- a/src/minerva/valuation.py
+++ b/src/minerva/valuation.py
@@ -1,7 +1,10 @@
 """Valuation models and calculation engine for equity analysis.
 
-Supports DCF, comparable company analysis, reverse DCF, and sum-of-the-parts.
+Supports DCF, comparable company analysis, reverse DCF, market-implied returns,
+and sum-of-the-parts.
 """
+
+import math
 
 from pydantic import BaseModel, Field
 
@@ -101,6 +104,15 @@ class ReverseDCFResult(BaseModel):
     implied_revenue_growth: float = Field(description="Constant annual growth rate implied")
     implied_year5_revenue: float
     implied_year5_fcf: float
+    assumptions_note: str
+
+
+class ImpliedReturnResult(BaseModel):
+    """Annual equity return implied by value and shareholder distributions."""
+
+    current_value: float
+    implied_return: float
+    equity_risk_premium: float | None = None
     assumptions_note: str
 
 
@@ -270,6 +282,93 @@ def run_reverse_dcf(
         assumptions_note=(
             f"Assumes FCF margins expanding to {final_margin:.0%} by year {projection_years}, "
             f"WACC={wacc:.1%}, terminal growth={terminal_growth:.1%}"
+        ),
+    )
+
+
+def run_implied_return(
+    current_value: float,
+    cash_distributions: list[float],
+    terminal_growth: float,
+    risk_free_rate: float | None = None,
+) -> ImpliedReturnResult:
+    """Solve for the annual equity return implied by shareholder distributions."""
+    inputs: list[float] = [current_value, terminal_growth, *cash_distributions]
+    if risk_free_rate is not None:
+        inputs.append(risk_free_rate)
+    if not all(math.isfinite(value) for value in inputs):
+        raise ValueError("all inputs must be finite")
+    if current_value <= 0:
+        raise ValueError("current_value must be greater than zero")
+    if not cash_distributions:
+        raise ValueError("cash_distributions must contain at least one annual value")
+    if any(distribution < 0 for distribution in cash_distributions):
+        raise ValueError("cash_distributions must be non-negative")
+    if not any(cash_distributions):
+        raise ValueError("cash_distributions must contain at least one positive value")
+    if terminal_growth <= -1:
+        raise ValueError("terminal_growth must be greater than -100%")
+    if risk_free_rate is not None and risk_free_rate <= -1:
+        raise ValueError("risk_free_rate must be greater than -100%")
+
+    final_distribution: float = cash_distributions[-1]
+
+    def _present_value(equity_return: float) -> float:
+        discount_factor: float = 1.0
+        present_value: float = 0.0
+        for distribution in cash_distributions:
+            discount_factor /= 1 + equity_return
+            if distribution:
+                present_value += distribution * discount_factor
+        if final_distribution:
+            terminal_distribution: float = final_distribution * (1 + terminal_growth)
+            present_value += (
+                terminal_distribution
+                / (equity_return - terminal_growth)
+                * discount_factor
+            )
+        return present_value
+
+    low: float = math.nextafter(terminal_growth, math.inf)
+    if _present_value(low) <= current_value:
+        raise ValueError(
+            "no implied return greater than terminal_growth satisfies the supplied value"
+        )
+
+    high: float = max(
+        0.10,
+        terminal_growth + max(0.01, abs(1 + terminal_growth) * 0.01),
+    )
+    for _ in range(256):
+        if _present_value(high) <= current_value:
+            break
+        high = (1 + high) * 2 - 1
+        if not math.isfinite(high):
+            raise ValueError("could not bracket an implied return for the supplied inputs")
+    else:
+        raise ValueError("could not bracket an implied return for the supplied inputs")
+
+    for _ in range(200):
+        mid: float = low + (high - low) / 2
+        if _present_value(mid) > current_value:
+            low = mid
+        else:
+            high = mid
+        if high - low <= 1e-12 * max(1.0, abs(mid)):
+            break
+
+    implied_return: float = low + (high - low) / 2
+    equity_risk_premium: float | None = (
+        implied_return - risk_free_rate if risk_free_rate is not None else None
+    )
+    return ImpliedReturnResult(
+        current_value=current_value,
+        implied_return=implied_return,
+        equity_risk_premium=equity_risk_premium,
+        assumptions_note=(
+            f"Assumes {len(cash_distributions)} annual year-end cash distributions, "
+            f"a perpetuity growing at {terminal_growth:.1%} after year "
+            f"{len(cash_distributions)}, and a constant annual equity return."
         ),
     )
 

--- a/tests/test_harness/test_valuation.py
+++ b/tests/test_harness/test_valuation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from harness.commands.valuation import (
     _load_segments_payload,
+    dispatch,
     run_comps_command,
     run_dcf_command,
     run_report_command,
@@ -73,6 +74,51 @@ def test_reverse_dcf_command_returns_expected_summary(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "current_price: $25.00" in output
     assert "implied_revenue_growth: 35.0%" in output
+
+
+def test_implied_return_cli_reports_known_return_and_optional_erp(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path)
+    args = [
+        "implied-return",
+        "--value",
+        "78.60684769775676",
+        "--cash-flows",
+        "4,5,6",
+        "--terminal-growth",
+        "0.03",
+    ]
+
+    without_risk_free = dispatch(args, settings=settings)
+    with_risk_free = dispatch([*args, "--risk-free", "0.04"], settings=settings)
+
+    output_without_risk_free = without_risk_free.stdout.decode("utf-8")
+    output = with_risk_free.stdout.decode("utf-8")
+    assert without_risk_free.exit_code == 0
+    assert "implied_return: 10.0%" in output_without_risk_free
+    assert with_risk_free.exit_code == 0
+    assert "current_value: 78.61" in output
+    assert "implied_return: 10.0%" in output
+    assert "equity_risk_premium: 6.0%" in output
+    assert "equity_risk_premium" not in output_without_risk_free
+
+
+def test_implied_return_cli_rejects_negative_cash_distribution(tmp_path: Path) -> None:
+    result = dispatch(
+        [
+            "implied-return",
+            "--value",
+            "100",
+            "--cash-flows",
+            "5,-1,6",
+            "--terminal-growth",
+            "0.03",
+        ],
+        settings=HarnessSettings(workspace_root=tmp_path),
+    )
+
+    assert result.exit_code == 1
+    assert "What went wrong: failed to solve implied return" in result.stderr.decode("utf-8")
+    assert "cash_distributions must be non-negative" in result.stderr.decode("utf-8")
 
 
 def test_sotp_command_returns_expected_summary_and_table(tmp_path: Path) -> None:

--- a/tests/test_harness/test_valuation.py
+++ b/tests/test_harness/test_valuation.py
@@ -76,10 +76,10 @@ def test_reverse_dcf_command_returns_expected_summary(tmp_path: Path) -> None:
     assert "implied_revenue_growth: 35.0%" in output
 
 
-def test_implied_return_cli_reports_known_return_and_optional_erp(tmp_path: Path) -> None:
+def test_irr_cli_reports_known_return_and_optional_erp(tmp_path: Path) -> None:
     settings = HarnessSettings(workspace_root=tmp_path)
     args = [
-        "implied-return",
+        "irr",
         "--value",
         "78.60684769775676",
         "--cash-flows",
@@ -102,10 +102,10 @@ def test_implied_return_cli_reports_known_return_and_optional_erp(tmp_path: Path
     assert "equity_risk_premium" not in output_without_risk_free
 
 
-def test_implied_return_cli_rejects_negative_cash_distribution(tmp_path: Path) -> None:
+def test_irr_cli_rejects_negative_cash_distribution(tmp_path: Path) -> None:
     result = dispatch(
         [
-            "implied-return",
+            "irr",
             "--value",
             "100",
             "--cash-flows",
@@ -117,7 +117,7 @@ def test_implied_return_cli_rejects_negative_cash_distribution(tmp_path: Path) -
     )
 
     assert result.exit_code == 1
-    assert "What went wrong: failed to solve implied return" in result.stderr.decode("utf-8")
+    assert "What went wrong: failed to solve valuation IRR" in result.stderr.decode("utf-8")
     assert "cash_distributions must be non-negative" in result.stderr.decode("utf-8")
 
 

--- a/tests/test_harness/test_valuation.py
+++ b/tests/test_harness/test_valuation.py
@@ -121,6 +121,101 @@ def test_irr_cli_rejects_negative_cash_distribution(tmp_path: Path) -> None:
     assert "cash_distributions must be non-negative" in result.stderr.decode("utf-8")
 
 
+def test_irr_cli_generates_cash_flows_from_year_zero_base_with_default_years(
+    tmp_path: Path,
+) -> None:
+    result = dispatch(
+        [
+            "irr",
+            "--value",
+            "78.85714285714286",
+            "--base-cash-flow",
+            "4",
+            "--growth",
+            "0.10",
+            "--terminal-growth",
+            "0.03",
+        ],
+        settings=HarnessSettings(workspace_root=tmp_path),
+    )
+
+    assert result.exit_code == 0
+    assert "implied_return: 10.0%" in result.stdout.decode("utf-8")
+
+
+def test_irr_cli_rejects_mixed_cash_flow_input_modes(tmp_path: Path) -> None:
+    result = dispatch(
+        [
+            "irr",
+            "--value",
+            "100",
+            "--cash-flows",
+            "5,6,7",
+            "--base-cash-flow",
+            "5",
+            "--growth",
+            "0.10",
+            "--terminal-growth",
+            "0.03",
+        ],
+        settings=HarnessSettings(workspace_root=tmp_path),
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "--cash-flows cannot be combined with --base-cash-flow or --growth"
+        in result.stderr.decode("utf-8")
+    )
+
+
+def test_irr_cli_requires_base_cash_flow_and_growth_together(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path)
+
+    for incomplete_mode in (
+        ["--base-cash-flow", "5"],
+        ["--growth", "0.10"],
+    ):
+        result = dispatch(
+            [
+                "irr",
+                "--value",
+                "100",
+                *incomplete_mode,
+                "--terminal-growth",
+                "0.03",
+            ],
+            settings=settings,
+        )
+
+        assert result.exit_code == 1
+        assert (
+            "generated cash flows require both --base-cash-flow and --growth"
+            in result.stderr.decode("utf-8")
+        )
+
+
+def test_irr_cli_requires_positive_years_for_generated_cash_flows(tmp_path: Path) -> None:
+    result = dispatch(
+        [
+            "irr",
+            "--value",
+            "100",
+            "--base-cash-flow",
+            "5",
+            "--growth",
+            "0.10",
+            "--years",
+            "0",
+            "--terminal-growth",
+            "0.03",
+        ],
+        settings=HarnessSettings(workspace_root=tmp_path),
+    )
+
+    assert result.exit_code == 1
+    assert "--years must be greater than zero" in result.stderr.decode("utf-8")
+
+
 def test_sotp_command_returns_expected_summary_and_table(tmp_path: Path) -> None:
     settings = HarnessSettings(workspace_root=tmp_path)
     segments = json.dumps(

--- a/tests/test_minerva/test_valuation.py
+++ b/tests/test_minerva/test_valuation.py
@@ -1,0 +1,65 @@
+"""Focused tests for valuation calculations."""
+
+import pytest
+
+from minerva.valuation import run_implied_return
+
+
+def _value_for_return(
+    cash_distributions: list[float],
+    equity_return: float,
+    terminal_growth: float,
+) -> float:
+    years: int = len(cash_distributions)
+    explicit_value: float = sum(
+        distribution / (1 + equity_return) ** year
+        for year, distribution in enumerate(cash_distributions, start=1)
+    )
+    terminal_value: float = (
+        cash_distributions[-1]
+        * (1 + terminal_growth)
+        / (equity_return - terminal_growth)
+        / (1 + equity_return) ** years
+    )
+    return explicit_value + terminal_value
+
+
+def test_run_implied_return_solves_known_return_and_equity_risk_premium() -> None:
+    cash_distributions = [4.0, 5.0, 6.0]
+    expected_return: float = 0.25
+    terminal_growth: float = 0.03
+    current_value: float = _value_for_return(
+        cash_distributions,
+        expected_return,
+        terminal_growth,
+    )
+
+    result = run_implied_return(
+        current_value=current_value,
+        cash_distributions=cash_distributions,
+        terminal_growth=terminal_growth,
+        risk_free_rate=0.04,
+    )
+
+    assert result.current_value == current_value
+    assert result.implied_return == pytest.approx(expected_return, abs=1e-10)
+    assert result.equity_risk_premium == pytest.approx(0.21, abs=1e-10)
+    assert result.implied_return > terminal_growth
+
+
+def test_run_implied_return_rejects_negative_cash_distribution() -> None:
+    with pytest.raises(ValueError, match="cash_distributions must be non-negative"):
+        run_implied_return(
+            current_value=100.0,
+            cash_distributions=[5.0, -1.0, 6.0],
+            terminal_growth=0.03,
+        )
+
+
+def test_run_implied_return_reports_no_solution_above_terminal_growth() -> None:
+    with pytest.raises(ValueError, match="no implied return greater than terminal_growth"):
+        run_implied_return(
+            current_value=20.0,
+            cash_distributions=[10.0, 0.0],
+            terminal_growth=0.03,
+        )


### PR DESCRIPTION
## Summary
- add `minerva valuation irr` for Damodaran-style implied equity return solves
- accept either explicit annual distributions via `--cash-flows` or generate them from Year 0 `--base-cash-flow`, constant `--growth`, and `--years`
- optionally calculate equity risk premium from a supplied risk-free rate
- validate mutually exclusive input modes and support direct CLI and `minerva run` dispatch
- add focused calculation and CLI tests

## Verification
- `uv run pytest tests/test_minerva/test_valuation.py tests/test_harness/test_valuation.py tests/test_harness/test_cli.py -q`
- 21 passed