### PR TITLE
feat(brief): persist Finnhub news in invest.db

### DIFF
--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -31,6 +31,7 @@ NEWS_RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/morning-brief-${RUN_DATE}-XXXXXX")"
 NEWS_SOURCE_ROOTS_DIR="${NEWS_RUN_DIR}/sources"
 REPORT_DIR="${WORKSPACE_ROOT}/reports/03-daily-news/${RUN_DATE}"
 INVEST_DB="${INVEST_DB:-${WORKSPACE_ROOT}/data/04-database/invest.db}"
+export INVEST_DB
 INGEST_OK=0
 cleanup_run_dir() {
   # Remove the temp run dir only when ingest into invest.db succeeded.
@@ -50,6 +51,8 @@ MINERVA_BRIEF_MARKET_PROVIDER="${MINERVA_BRIEF_MARKET_PROVIDER:-finnhub}"
 MINERVA_SKIP_STATUS_CHECK="${MINERVA_SKIP_STATUS_CHECK:-0}"
 MINERVA_SKIP_NEWS="${MINERVA_SKIP_NEWS:-0}"
 MINERVA_ALLOW_THIN_BRIEF="${MINERVA_ALLOW_THIN_BRIEF:-0}"
+NEWS_SOURCES="${MINERVA_NEWS_SOURCES:-${ROOT_DIR}/hard-disk/data/02-news/news-sources.json}"
+IR_REGISTRY="${MINERVA_IR_REGISTRY:-${ROOT_DIR}/hard-disk/data/01-portfolio/current/ir-registry.json}"
 
 IFS=' ' read -r -a MINERVA_RUNNER_ARR <<< "${MINERVA_RUNNER}"
 printf -v NEWS_EXIST_RUNNER '%q ' "${MINERVA_RUNNER_ARR[@]}" news exist
@@ -104,8 +107,6 @@ else
 
   BROWSER_PROMPT_TEMPLATE="${ROOT_DIR}/scripts/prompts/collect_news.md"
   WEBFETCH_PROMPT_TEMPLATE="${ROOT_DIR}/scripts/prompts/collect_news_webfetch.md"
-  NEWS_SOURCES="${MINERVA_NEWS_SOURCES:-${ROOT_DIR}/hard-disk/data/02-news/news-sources.json}"
-  IR_REGISTRY="${MINERVA_IR_REGISTRY:-${ROOT_DIR}/hard-disk/data/01-portfolio/current/ir-registry.json}"
   PIDS=()
 
   if [[ -f "${NEWS_SOURCES}" ]] && ! jq -e '
@@ -414,32 +415,43 @@ echo "── Phase 2c: Ingest into invest.db ──"
 
 ingest_report="${NEWS_RUN_DIR}/logs/ingest.log"
 ingest_stats="${NEWS_RUN_DIR}/logs/ingest.json"
-if [[ "${RAW_COUNT}" -gt 0 ]]; then
-  if run news ingest \
-      --raw-dir "${NEWS_RUN_DIR}/raw" \
-      --summaries-dir "${NEWS_RUN_DIR}/summaries" \
-      --db "${INVEST_DB}" \
-      --news-sources "${NEWS_SOURCES}" \
-      --ir-registry "${IR_REGISTRY}" \
-      --report "${ingest_report}" > "${ingest_stats}"; then
-    INGEST_OK=1
-    echo "  ingest stats: $(cat "${ingest_stats}")"
-  else
-    echo "news ingest: failed (temp run dir preserved at ${NEWS_RUN_DIR})" >&2
-    exit 1
-  fi
-else
-  # Nothing to ingest, but the temp dir is safe to remove.
-  echo '{"eligible": 0}' > "${ingest_stats}"
+# Run even when collection produced no raw articles. Besides ingestion, this
+# creates or migrates the supported news schema before Phase 4 persistence.
+if run news ingest \
+    --raw-dir "${NEWS_RUN_DIR}/raw" \
+    --summaries-dir "${NEWS_RUN_DIR}/summaries" \
+    --db "${INVEST_DB}" \
+    --news-sources "${NEWS_SOURCES}" \
+    --ir-registry "${IR_REGISTRY}" \
+    --report "${ingest_report}" > "${ingest_stats}"; then
   INGEST_OK=1
+  echo "  ingest stats: $(cat "${ingest_stats}")"
+else
+  echo "news ingest: failed (temp run dir preserved at ${NEWS_RUN_DIR})" >&2
+  exit 1
 fi
 
 echo ""
 
 if [[ "${MINERVA_SKIP_NEWS}" != "1" && "${MINERVA_ALLOW_THIN_BRIEF}" != "1" ]]; then
   eligible_count=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("eligible", 0))' "${ingest_stats}" 2>/dev/null || echo 0)
-  if [[ "${eligible_count}" -eq 0 ]]; then
-    echo "news: no eligible articles were ingested" >&2
+  market_raw="${REPORT_DIR}/data/raw/market.json"
+  finnhub_news_count=$(python3 - "${market_raw}" <<'PY' 2>/dev/null || echo 0
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+print(sum(
+    isinstance(event, dict)
+    and event.get("event_type") in {"market-news", "company-news"}
+    for event in payload.get("events", [])
+))
+PY
+)
+  if [[ "${eligible_count}" -eq 0 && "${finnhub_news_count}" -eq 0 ]]; then
+    echo "news: no eligible crawler articles or Finnhub news summaries were collected" >&2
     echo "news: refusing to continue without article evidence; set MINERVA_ALLOW_THIN_BRIEF=1 to allow a thin brief" >&2
     echo "news: temp run directory preserved at ${NEWS_RUN_DIR}" >&2
     INGEST_OK=0
@@ -452,7 +464,7 @@ echo ""
 # ── PHASE 4: Evidence preparation ──
 echo "── Phase 4: Evidence preparation ──"
 
-run brief prep --date "${RUN_DATE}"
+run brief prep --date "${RUN_DATE}" --db "${INVEST_DB}"
 
 # Manifest check (relaxed: macro and ir no longer required)
 MANIFEST_PATH="${REPORT_DIR}/data/raw/manifest.json"

--- a/src/harness/commands/brief.py
+++ b/src/harness/commands/brief.py
@@ -1,3 +1,4 @@
+# ruff: noqa: BLE001
 """Morning brief evidence collection commands."""
 
 from __future__ import annotations
@@ -95,7 +96,11 @@ def dispatch(args: list[str], settings: HarnessSettings, stdin: bytes = b"") -> 
             )
         if subcommand == "prep":
             parsed = parse_flag_args(args[1:])
-            return prep_command(run_date=parse_iso_date(str(parsed.get("date") or "")), settings=settings)
+            return prep_command(
+                run_date=parse_iso_date(str(parsed.get("date") or "")),
+                db_path=Path(str(parsed["db"])) if "db" in parsed else None,
+                settings=settings,
+            )
         if subcommand == "audit":
             parsed = parse_flag_args(args[1:])
             return audit_command(run_date=parse_iso_date(str(parsed.get("date") or "")), settings=settings)
@@ -282,12 +287,32 @@ def market_command(
         )
     return CommandResult.from_text(_summary_lines(summary), duration_ms=elapsed_ms(start))
 
-def prep_command(*, run_date, settings: HarnessSettings) -> CommandResult:
+def prep_command(
+    *, run_date, settings: HarnessSettings, db_path: Path | None = None
+) -> CommandResult:
     """Prepare agent-ready evidence from collected sources."""
     start = time.perf_counter()
-    
+
     try:
-        summary = prepare_evidence(settings.ensure_workspace_root(), run_date=run_date)
+        summary = prepare_evidence(
+            settings.ensure_workspace_root(),
+            run_date=run_date,
+            db_path=db_path or settings.resolved_invest_db,
+        )
+    except RuntimeError as exc:
+        if "news table has an unsupported schema" in str(exc):
+            return error_result(
+                f"failed to prepare evidence: {exc}",
+                "repair or recreate the malformed news database, then retry",
+                ["back up the database before repairing its `news` table"],
+                start,
+            )
+        return error_result(
+            f"failed to prepare evidence: {exc}",
+            "run the collection commands first, then retry",
+            ["`brief filings --date 2026-04-08`", "`brief prep --date 2026-04-08`"],
+            start,
+        )
     except Exception as exc:
         return error_result(
             f"failed to prepare evidence: {exc}",
@@ -394,9 +419,20 @@ def market_cli(
     _print(market_command(run_date=parse_iso_date(date_arg), source=source, provider=provider, settings=settings))
 
 @app.command("prep", help="Prepare the agent-ready evidence pack.")
-def prep_cli(date_arg: str | None = typer.Option(None, "--date", help="Run date.")) -> None:
+def prep_cli(
+    date_arg: str | None = typer.Option(None, "--date", help="Run date."),
+    db_path: Path | None = typer.Option(  # noqa: B008
+        None, "--db", help="Path to invest.db."
+    ),
+) -> None:
     settings = get_settings()
-    _print(prep_command(run_date=parse_iso_date(date_arg), settings=settings))
+    _print(
+        prep_command(
+            run_date=parse_iso_date(date_arg),
+            db_path=db_path,
+            settings=settings,
+        )
+    )
 
 @app.command("audit", help="Run a bounded miss-check after prep.")
 def audit_cli(date_arg: str | None = typer.Option(None, "--date", help="Run date.")) -> None:

--- a/src/harness/config.py
+++ b/src/harness/config.py
@@ -18,12 +18,20 @@ class HarnessSettings(BaseModel):
     gemini_api_key: str | None = None
     openai_api_key: str | None = None
     finnhub_api_key: str | None = None
+    invest_db: Path | None = None
     minerva_plot_theme: str = "minerva-classic"
 
     @property
     def resolved_workspace_root(self) -> Path:
         """Return the absolute workspace root."""
         return self.workspace_root.resolve()
+
+    @property
+    def resolved_invest_db(self) -> Path:
+        """Return the configured invest DB or the workspace-local default."""
+        if self.invest_db is not None:
+            return self.invest_db.expanduser().resolve()
+        return self.resolved_workspace_root / "data" / "04-database" / "invest.db"
 
     def ensure_workspace_root(self) -> Path:
         """Create the workspace root if it does not exist yet."""
@@ -42,5 +50,6 @@ def get_settings() -> HarnessSettings:
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
         openai_api_key=os.getenv("OPENAI_API_KEY"),
         finnhub_api_key=os.getenv("FINNHUB_API_KEY"),
+        invest_db=(Path(value) if (value := os.getenv("INVEST_DB")) else None),
         minerva_plot_theme=os.getenv("MINERVA_PLOT_THEME", "minerva-classic"),
     )

--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -1,13 +1,17 @@
+# ruff: noqa: BLE001, DTZ007, TRY004
 """Morning market brief evidence collection and preparation."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import math
 import re
+import sqlite3
 import time as time_mod
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -16,8 +20,13 @@ from xml.etree import ElementTree
 import requests
 from lxml import html as lxml_html
 
-logger = logging.getLogger(__name__)
-
+from harness.news_store import (
+    FINNHUB_SUMMARY_ONLY_SECTION,
+    canonical_news_url,
+    ensure_canonical_news_schema,
+    is_finnhub_summary_only_section,
+    resolve_news_db_path,
+)
 from harness.portfolio_state import (
     NON_SECURITY_TICKERS,
     append_jsonl,
@@ -26,13 +35,14 @@ from harness.portfolio_state import (
     load_json,
     load_payload,
     now_utc_iso,
-    parse_iso_date,
     portfolio_paths,
     read_text_source,
     write_json,
 )
 from minerva.formatting import to_float
 from minerva.sec import get_recent_filings
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_FILING_FORMS = ["8-K", "10-K", "10-Q", "SC 13D", "SC 13D/A", "SC 13G", "SC 13G/A"]
@@ -42,6 +52,7 @@ DEFAULT_QUOTE_SYMBOLS = [
     "XLK", "XLF", "XLE", "XLV",
 ]
 FINNHUB_CALL_DELAY_SECONDS = 0.1
+MAX_FINNHUB_SUMMARY_CHARS = 4_000
 IR_HTML_NAV_PATTERNS = (
     r"home",
     r"about(?: us)?",
@@ -519,6 +530,7 @@ def collect_market(
     )
     events = normalize_market_events(payload, run_date)
     sorted_events = sorted(events, key=lambda item: (item["event_date"], item.get("category", ""), item["headline"]))
+    collected_at = now_utc_iso()
 
     raw_path = run_paths.raw_dir / "market.json"
     rendered_path = run_paths.rendered_dir / "market.md"
@@ -526,7 +538,7 @@ def collect_market(
         raw_path,
         {
             "date": run_date.isoformat(),
-            "collected_at": now_utc_iso(),
+            "collected_at": collected_at,
             "provider": provider,
             "source": source,
             "payload": payload,
@@ -548,11 +560,233 @@ def collect_market(
             "degraded_reasons": degraded_reasons,
         },
     )
-    return {"status": status, "event_count": len(sorted_events), "raw_path": raw_path}
+    return {
+        "status": status,
+        "event_count": len(sorted_events),
+        "raw_path": raw_path,
+    }
 
 
-def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
-    """Build an agent-ready evidence pack from collected sources."""
+def persist_market_news(
+    workspace_root: Path,
+    events: list[dict[str, Any]],
+    *,
+    run_date: date,
+    collected_at: str | None = None,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    """Persist normalized Finnhub-style news events into the canonical store.
+
+    Market-price observations and every other event type are deliberately
+    excluded. Finnhub supplies only a summary, so the same bounded summary is
+    stored in ``content`` and ``summary`` and identified as such by ``section``.
+    """
+    resolved_db_path = resolve_news_db_path(workspace_root, db_path)
+    news_events = [
+        event
+        for event in events
+        if str(event.get("event_type") or "").strip().casefold()
+        in {"market-news", "company-news"}
+        and str(event.get("headline") or "").strip()
+    ]
+    stats: dict[str, Any] = {
+        "eligible": len(news_events),
+        "inserted": 0,
+        "duplicates": 0,
+        "db_path": str(resolved_db_path),
+    }
+    if not news_events:
+        return stats
+
+    collection_timestamp = _collection_timestamp_for_run(
+        collected_at or now_utc_iso(), run_date
+    )
+    resolved_db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(resolved_db_path)
+    try:
+        ensure_canonical_news_schema(connection)
+        existing_articles_by_url: dict[str, str] = {}
+        existing_quality_by_url: dict[str, tuple[int, int]] = {}
+        for stored_key, stored_url, section, content_length in connection.execute(
+            "SELECT article_key, url, section, length(content) FROM news "
+            "WHERE url != '' ORDER BY article_key"
+        ):
+            normalized_existing_url = canonical_news_url(stored_url)
+            if not normalized_existing_url:
+                continue
+            quality = (
+                int(not is_finnhub_summary_only_section(section)),
+                int(content_length or 0),
+            )
+            prior_quality = existing_quality_by_url.get(normalized_existing_url)
+            prior_key = existing_articles_by_url.get(normalized_existing_url, "")
+            if (
+                prior_quality is None
+                or quality > prior_quality
+                or (quality == prior_quality and str(stored_key) < prior_key)
+            ):
+                existing_articles_by_url[normalized_existing_url] = str(stored_key)
+                existing_quality_by_url[normalized_existing_url] = quality
+        for event in sorted(news_events, key=_finnhub_news_persistence_sort_key):
+            title = str(event.get("headline") or "").strip()
+            publisher = (
+                str(
+                    event.get("news_source")
+                    or _event_metadata_value(event, "source")
+                    or "Finnhub"
+                ).strip()
+                or "Finnhub"
+            )
+            url = str(
+                event.get("reference_url")
+                or _event_metadata_value(event, "url")
+                or ""
+            ).strip()
+            normalized_url = canonical_news_url(url)
+            if normalized_url and normalized_url in existing_articles_by_url:
+                event["persisted_article_key"] = existing_articles_by_url[
+                    normalized_url
+                ]
+                stats["duplicates"] += 1
+                continue
+
+            published_at, published_at_raw = _finnhub_publication(event, run_date)
+            summary = _bounded_finnhub_summary(
+                event.get("summary") or _event_metadata_value(event, "summary")
+            )
+            article_key = _finnhub_article_key(
+                normalized_url=normalized_url,
+                publisher=publisher,
+                published_at=published_at,
+                title=title,
+            )
+            event["persisted_article_key"] = article_key
+            cursor = connection.execute(
+                "INSERT OR IGNORE INTO news "
+                "(article_key, published_at, published_at_raw, title, content, summary, "
+                "source, url, section, collected_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    article_key,
+                    published_at,
+                    published_at_raw,
+                    title,
+                    summary,
+                    summary,
+                    publisher,
+                    url,
+                    FINNHUB_SUMMARY_ONLY_SECTION,
+                    collection_timestamp,
+                ),
+            )
+            if cursor.rowcount == 1:
+                stats["inserted"] += 1
+                if normalized_url:
+                    existing_articles_by_url[normalized_url] = article_key
+            else:
+                stats["duplicates"] += 1
+        connection.commit()
+    finally:
+        connection.close()
+    return stats
+
+
+def _event_metadata_value(event: dict[str, Any], key: str) -> Any:
+    metadata = event.get("metadata")
+    return metadata.get(key) if isinstance(metadata, dict) else None
+
+
+def _finnhub_news_persistence_sort_key(event: dict[str, Any]) -> tuple[Any, ...]:
+    event_type = str(event.get("event_type") or "").strip().casefold()
+    raw_url = str(
+        event.get("reference_url") or _event_metadata_value(event, "url") or ""
+    ).strip()
+    # Prefer company routing context, then the cleanest supplied URL. Remaining
+    # fields make the winner deterministic even if provider response order moves.
+    type_rank = 0 if event_type == "company-news" else 1
+    return (
+        canonical_news_url(raw_url),
+        type_rank,
+        len(raw_url),
+        raw_url.casefold(),
+        str(event.get("security_id") or "").casefold(),
+        str(event.get("headline") or "").casefold(),
+        str(event.get("news_source") or _event_metadata_value(event, "source") or "").casefold(),
+        str(event.get("summary") or _event_metadata_value(event, "summary") or ""),
+    )
+
+
+def _finnhub_publication(event: dict[str, Any], run_date: date) -> tuple[int, str]:
+    raw_value = _event_metadata_value(event, "datetime")
+    if raw_value not in (None, ""):
+        raw_text = str(raw_value).strip()
+        try:
+            numeric_value = float(raw_text)
+            if math.isfinite(numeric_value) and numeric_value >= 0:
+                return int(numeric_value), raw_text
+        except (TypeError, ValueError):
+            pass
+        try:
+            parsed = datetime.fromisoformat(raw_text)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return int(parsed.timestamp()), raw_text
+        except ValueError:
+            pass
+
+    event_day = _coerce_event_date(event.get("event_date")) or run_date.isoformat()
+    fallback = datetime.combine(
+        date.fromisoformat(event_day), datetime.min.time(), tzinfo=UTC
+    )
+    return int(fallback.timestamp()), event_day
+
+
+def _collection_timestamp_for_run(raw_timestamp: str, run_date: date) -> str:
+    """Keep collection time/offset while making the date match the brief run."""
+    try:
+        parsed = datetime.fromisoformat(raw_timestamp.strip())
+    except ValueError:
+        parsed = datetime.combine(run_date, datetime.min.time(), tzinfo=UTC)
+    else:
+        parsed = datetime.combine(run_date, parsed.timetz())
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+    return parsed.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _bounded_finnhub_summary(raw_summary: Any) -> str:
+    summary = str(raw_summary or "").strip()
+    if len(summary) <= MAX_FINNHUB_SUMMARY_CHARS:
+        return summary
+    marker = "\n[Finnhub summary truncated deterministically]"
+    prefix_limit = MAX_FINNHUB_SUMMARY_CHARS - len(marker)
+    return f"{summary[:prefix_limit].rstrip()}{marker}"
+
+
+def _finnhub_article_key(
+    *,
+    normalized_url: str,
+    publisher: str,
+    published_at: int,
+    title: str,
+) -> str:
+    if normalized_url:
+        identity = f"url|{normalized_url}"
+    else:
+        normalized_title = re.sub(r"\s+", " ", title.strip().casefold())
+        identity = (
+            f"fallback|{publisher.strip().casefold()}|{published_at}|{normalized_title}"
+        )
+    return hashlib.sha256(f"finnhub|{identity}".encode()).hexdigest()
+
+
+def prepare_evidence(
+    workspace_root: Path,
+    *,
+    run_date: date,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build an agent-ready evidence pack and persist Finnhub summaries."""
     ensure_portfolio_layout(workspace_root)
     run_paths = ensure_daily_run_layout(workspace_root, run_date)
     paths = portfolio_paths(workspace_root)
@@ -561,36 +795,83 @@ def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
     adjacency_map = load_json(paths.adjacency_map, default=[])
     thesis_cards = load_json(paths.thesis_cards, default=[])
 
-    source_payloads = {name: _load_raw_source(run_paths, name) for name in ("filings", "earnings", "macro", "ir", "market")}
-    source_events = {name: payload.get("events", []) for name, payload in source_payloads.items()}
+    source_payloads = {
+        name: _load_raw_source(run_paths, name)
+        for name in ("filings", "earnings", "macro", "ir", "market")
+    }
+    market_payload = source_payloads["market"]
+    market_events = [
+        event for event in market_payload.get("events", []) if isinstance(event, dict)
+    ]
+    news_persistence = persist_market_news(
+        workspace_root,
+        market_events,
+        run_date=run_date,
+        collected_at=str(market_payload.get("collected_at") or "") or None,
+        db_path=db_path,
+    )
+    market_payload["events"] = market_events
+    market_payload["news_persistence"] = news_persistence
+    write_json(run_paths.raw_dir / "market.json", market_payload)
 
+    source_events = {
+        name: payload.get("events", []) for name, payload in source_payloads.items()
+    }
+    enriched_source_events: list[tuple[str, dict[str, Any]]] = []
+    for source_name, events in source_events.items():
+        for event in events:
+            if isinstance(event, dict):
+                enriched_source_events.append(
+                    (
+                        source_name,
+                        enrich_event_relationships(
+                            dict(event), universe, adjacency_map
+                        ),
+                    )
+                )
+
+    linked_news_urls = {
+        canonical_news_url(event.get("reference_url"))
+        for _, event in enriched_source_events
+        if _is_current_news_event(event, run_date)
+        and str(event.get("security_id") or "").strip()
+        and canonical_news_url(event.get("reference_url"))
+    }
     all_events: list[dict[str, Any]] = []
     suppressed: list[dict[str, Any]] = []
     seen: set[str] = set()
-    seen_news_urls: set[str] = set()
-    for source_name, events in source_events.items():
-        for event in events:
-            enriched = enrich_event_relationships(dict(event), universe, adjacency_map)
-            dedupe_key = build_event_key(enriched)
-            if dedupe_key in seen:
-                suppressed.append({"reason": "duplicate", "event": enriched})
+    seen_news_contexts: set[tuple[str, str]] = set()
+    for source_name, enriched in enriched_source_events:
+        if enriched.get("event_date") not in {"", run_date.isoformat()}:
+            suppressed.append({"reason": "stale", "event": enriched})
+            continue
+        if not enriched.get("headline"):
+            suppressed.append({"reason": "missing-headline", "event": enriched})
+            continue
+        dedupe_key = build_event_key(enriched)
+        if dedupe_key in seen:
+            suppressed.append({"reason": "duplicate", "event": enriched})
+            continue
+        event_type = str(enriched.get("event_type") or "").strip().casefold()
+        if event_type in {"market-news", "company-news"}:
+            news_url = canonical_news_url(enriched.get("reference_url"))
+            security_id = str(enriched.get("security_id") or "").strip().casefold()
+            if news_url and not security_id and news_url in linked_news_urls:
+                suppressed.append(
+                    {"reason": "duplicate-url-unlinked", "event": enriched}
+                )
                 continue
-            news_url = str(enriched.get("reference_url") or "").strip()
-            event_type = str(enriched.get("event_type") or "").lower()
-            if event_type in {"market-news", "company-news"} and news_url:
-                if news_url in seen_news_urls:
-                    suppressed.append({"reason": "duplicate-url", "event": enriched})
-                    continue
-                seen_news_urls.add(news_url)
-            if enriched.get("event_date") not in {"", run_date.isoformat()}:
-                suppressed.append({"reason": "stale", "event": enriched})
+            news_context = (news_url, security_id)
+            if news_url and news_context in seen_news_contexts:
+                suppressed.append(
+                    {"reason": "duplicate-url-association", "event": enriched}
+                )
                 continue
-            if not enriched.get("headline"):
-                suppressed.append({"reason": "missing-headline", "event": enriched})
-                continue
-            seen.add(dedupe_key)
-            enriched["source_name"] = source_name
-            all_events.append(enriched)
+            if news_url:
+                seen_news_contexts.add(news_context)
+        seen.add(dedupe_key)
+        enriched["source_name"] = source_name
+        all_events.append(enriched)
 
     sorted_events = sorted(
         all_events,
@@ -620,6 +901,7 @@ def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
         "thesis_cards": {key: thesis_map[key] for key in sorted(thesis_map)},
         "thesis_ticker_index": thesis_ticker_index,
         "source_status": manifest.get("sources", {}),
+        "news_persistence": news_persistence,
     }
 
     universe_path = run_paths.structured_dir / "universe.json"
@@ -645,9 +927,16 @@ def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
             "source_status_path": str(source_status_path),
             "evidence_path": str(evidence_path),
             "universe_path": str(universe_path),
+            "news_persistence": news_persistence,
         },
     )
-    return {"status": "success", "event_count": len(sorted_events), "prepared_path": prepared_path}
+    return {
+        "status": "success",
+        "event_count": len(sorted_events),
+        "news_inserted_count": news_persistence["inserted"],
+        "news_duplicate_count": news_persistence["duplicates"],
+        "prepared_path": prepared_path,
+    }
 
 
 def audit_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
@@ -937,6 +1226,15 @@ def enrich_event_relationships(
     event.setdefault("relationship", relationship_for_security(security_id, universe, adjacency_map))
     event.setdefault("group", group_for_event(event))
     return event
+
+
+def _is_current_news_event(event: dict[str, Any], run_date: date) -> bool:
+    event_type = str(event.get("event_type") or "").strip().casefold()
+    return (
+        event_type in {"market-news", "company-news"}
+        and event.get("event_date") in {"", run_date.isoformat()}
+        and bool(str(event.get("headline") or "").strip())
+    )
 
 
 def build_event_key(event: dict[str, Any]) -> str:
@@ -1592,7 +1890,10 @@ def _normalize_market_event(
 def normalize_news_events(news_items: list[dict[str, Any]], run_date: date) -> list[dict[str, Any]]:
     """Convert Finnhub general news items into shared event schema."""
     events: list[dict[str, Any]] = []
-    cutoff_ts = datetime.combine(run_date, datetime.min.time(), tzinfo=timezone.utc).timestamp() - 18 * 3600
+    cutoff_ts = (
+        datetime.combine(run_date, datetime.min.time(), tzinfo=UTC).timestamp()
+        - 18 * 3600
+    )
     for item in news_items:
         ts = item.get("datetime", 0)
         if isinstance(ts, (int, float)) and ts < cutoff_ts:
@@ -1619,7 +1920,10 @@ def normalize_news_events(news_items: list[dict[str, Any]], run_date: date) -> l
 def normalize_company_news_events(news_items: list[dict[str, Any]], run_date: date) -> list[dict[str, Any]]:
     """Convert Finnhub company news items into shared event schema."""
     events: list[dict[str, Any]] = []
-    cutoff_ts = datetime.combine(run_date, datetime.min.time(), tzinfo=timezone.utc).timestamp() - 18 * 3600
+    cutoff_ts = (
+        datetime.combine(run_date, datetime.min.time(), tzinfo=UTC).timestamp()
+        - 18 * 3600
+    )
     for item in news_items:
         ts = item.get("datetime", 0)
         if isinstance(ts, (int, float)) and ts < cutoff_ts:
@@ -1891,7 +2195,7 @@ def _coerce_event_date(value: Any) -> str | None:
     if not raw:
         return None
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).date().isoformat()
+        return datetime.fromisoformat(raw).date().isoformat()
     except ValueError:
         pass
     for fmt in ("%a, %d %b %Y %H:%M:%S %z", "%Y-%m-%d"):

--- a/src/harness/morning_brief_synthesis.py
+++ b/src/harness/morning_brief_synthesis.py
@@ -20,11 +20,16 @@ import sqlite3
 import subprocess
 import sys
 import uuid
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Any, Callable, Sequence
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from typing import Any
+
+from harness.news_store import (
+    canonical_news_url,
+    is_finnhub_summary_only_section,
+)
 
 DEFAULT_MODEL = "gpt-5.6-sol"
 DEFAULT_REASONING = "high"
@@ -71,18 +76,30 @@ class CandidateTitle:
 
     def title_record(self) -> dict[str, Any]:
         """Return the compact, summary-free article-choice record for pass 1."""
+        summary_only = bool(self.metadata.get("summary_only"))
+        if self.kind == "article":
+            candidate_class = (
+                "secondary_finnhub_summary_only"
+                if summary_only
+                else "collected_sqlite_article"
+            )
+        else:
+            event_type = str(self.metadata.get("event_type") or "").casefold()
+            candidate_class = (
+                "secondary_prepared_company_news"
+                if event_type == "company-news"
+                else "secondary_prepared_market_news"
+            )
         record: dict[str, Any] = {
             "id": self.id,
             "kind": self.kind,
             "source": self.source,
             "published": self.published,
             "title": self.title,
-            "article_candidate_class": (
-                "collected_sqlite_article"
-                if self.kind == "article"
-                else "secondary_prepared_market_news"
-            ),
+            "article_candidate_class": candidate_class,
         }
+        if summary_only:
+            record["evidence_depth"] = "summary_only"
         if self.article_key is not None:
             record["article_key"] = self.article_key
         for key in (
@@ -118,7 +135,7 @@ class RoutingPlan:
 def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateTitle]:
     """Read every article first collected on ``run_date`` without reading its body.
 
-    ``collected_at`` is canonical ISO text written by ``ingest_news.py``.  Its
+    ``collected_at`` is canonical ISO text written by ``harness.news``. Its
     leading calendar date is the collection run's date even when the timestamp
     includes an offset, so a prefix comparison avoids silently shifting a local
     collection into another UTC date.
@@ -136,7 +153,8 @@ def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateT
     try:
         rows = connection.execute(
             """
-            SELECT article_key, source, published_at, published_at_raw, title, url
+            SELECT article_key, source, published_at, published_at_raw, title, url,
+                   section
             FROM news
             WHERE substr(collected_at, 1, 10) = ?
             ORDER BY source COLLATE NOCASE,
@@ -162,11 +180,14 @@ def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateT
                 kind="article",
                 article_key=article_key,
                 source=str(row["source"]),
-                published=published_raw or published_iso,
+                published=_publication_display(published_raw, published_iso),
                 title=str(row["title"]),
                 metadata={
                     "published_at": published_iso,
+                    "published_at_raw": published_raw,
                     "url": str(row["url"] or "").strip(),
+                    "section": str(row["section"] or "").strip(),
+                    "summary_only": is_finnhub_summary_only_section(row["section"]),
                 },
             )
         )
@@ -208,7 +229,22 @@ def load_prepared_event_titles(
         security_id = str(
             raw_event.get("security_id") or raw_event.get("ticker") or ""
         ).strip()
-        stable_key = "|".join((source, security_id, title, event_date))
+        event_type = str(raw_event.get("event_type") or "").strip().casefold()
+        stable_identity: list[str] = [source, security_id, title, event_date]
+        if event_type in ARTICLE_EVENT_TYPES:
+            stable_identity.extend(
+                (
+                    event_type,
+                    str(raw_event.get("persisted_article_key") or "").strip(),
+                    canonical_news_url(
+                        raw_event.get("reference_url")
+                        or raw_event.get("source_url")
+                        or _nested_value(raw_event, "metadata", "url")
+                    ),
+                    _prepared_news_source_label(raw_event),
+                )
+            )
+        stable_key = "|".join(stable_identity)
         candidate_id = f"event:{hashlib.sha256(stable_key.encode('utf-8')).hexdigest()}"
         if candidate_id in seen_ids:
             continue
@@ -242,34 +278,151 @@ def load_prepared_event_titles(
 def build_title_universe(
     db_path: Path, prepared_path: Path, run_date: date
 ) -> list[CandidateTitle]:
-    """Build all fresh collected articles and current prepared events."""
-    return query_fresh_article_titles(db_path, run_date) + load_prepared_event_titles(
-        prepared_path, run_date
+    """Build one candidate per article plus unmatched prepared events.
+
+    A Finnhub article is represented in both SQLite and prepared evidence. The
+    SQLite candidate is the durable record (and may itself be summary-only),
+    while the prepared event contributes ticker/portfolio routing metadata.
+    """
+    articles = query_fresh_article_titles(db_path, run_date)
+    prepared_events = load_prepared_event_titles(prepared_path, run_date)
+    article_by_record = {
+        _article_record_key(article, _collected_source_label(article.source)): article
+        for article in articles
+    }
+    article_by_key = {
+        article.article_key: article
+        for article in articles
+        if article.article_key is not None
+    }
+    merged_by_id = {article.id: article for article in articles}
+    unmatched_events: list[CandidateTitle] = []
+
+    for event in prepared_events:
+        event_type = str(event.metadata.get("event_type") or "").strip().casefold()
+        if event_type not in ARTICLE_EVENT_TYPES:
+            unmatched_events.append(event)
+            continue
+        source_label = _prepared_news_source_label(event.metadata)
+        persisted_key = str(
+            event.metadata.get("persisted_article_key") or ""
+        ).strip()
+        matching_article = article_by_key.get(persisted_key)
+        if matching_article is None:
+            matching_article = article_by_record.get(
+                _article_record_key(event, source_label)
+            )
+        if matching_article is None:
+            unmatched_events.append(event)
+            continue
+        current = merged_by_id[matching_article.id]
+        merged_by_id[matching_article.id] = _merge_article_with_prepared_event(
+            current, event
+        )
+
+    merged_articles = [merged_by_id[article.id] for article in articles]
+    return [*merged_articles, *unmatched_events]
+
+
+def _merge_article_with_prepared_event(
+    article: CandidateTitle, event: CandidateTitle
+) -> CandidateTitle:
+    durable_metadata = {
+        key: article.metadata.get(key)
+        for key in (
+            "url",
+            "published_at",
+            "published_at_raw",
+            "section",
+            "summary_only",
+        )
+    }
+    metadata = dict(article.metadata)
+    contexts = [
+        dict(context)
+        for context in metadata.get("prepared_event_contexts", [])
+        if isinstance(context, dict)
+    ]
+    existing_rank = int(metadata.get("_prepared_routing_rank") or 0)
+    event_rank = _prepared_event_routing_rank(event)
+    if event_rank > existing_rank:
+        metadata.update(event.metadata)
+    else:
+        for key, value in event.metadata.items():
+            if value not in (None, "", [], {}):
+                metadata.setdefault(key, value)
+    metadata.update(durable_metadata)
+    context = _prepared_event_context(event)
+    context_identity = json.dumps(context, ensure_ascii=False, sort_keys=True)
+    existing_context_identities = {
+        json.dumps(item, ensure_ascii=False, sort_keys=True) for item in contexts
+    }
+    if context_identity not in existing_context_identities:
+        contexts.append(context)
+    metadata["prepared_event_contexts"] = contexts
+    metadata["_prepared_routing_rank"] = max(existing_rank, event_rank)
+    prepared_event_ids = [
+        str(item)
+        for item in metadata.get("persisted_prepared_event_ids", [])
+        if str(item)
+    ]
+    if event.id not in prepared_event_ids:
+        prepared_event_ids.append(event.id)
+    metadata["persisted_prepared_event_ids"] = prepared_event_ids
+    return CandidateTitle(
+        id=article.id,
+        kind="article",
+        title=article.title,
+        source=article.source,
+        published=article.published,
+        article_key=article.article_key,
+        metadata=metadata,
     )
+
+
+def _prepared_event_routing_rank(candidate: CandidateTitle) -> int:
+    role = str(candidate.metadata.get("portfolio_role") or "").strip().casefold()
+    if role in PORTFOLIO_ROLES:
+        return 3
+    event_type = str(candidate.metadata.get("event_type") or "").strip().casefold()
+    return 2 if event_type == "company-news" else 1
+
+
+def _prepared_event_context(candidate: CandidateTitle) -> dict[str, Any]:
+    event = candidate.metadata
+    context = _compact_event_details(event)
+    context["prepared_event_id"] = candidate.id
+    context["title"] = candidate.title
+    source = _prepared_news_source_label(event)
+    if source != "Unknown":
+        context["news_source"] = source
+    url = str(event.get("reference_url") or event.get("source_url") or "").strip()
+    if url:
+        context["url"] = url
+    return context
 
 
 def partition_candidates(candidates: Sequence[CandidateTitle]) -> RoutingPlan:
     """Partition candidates before pass 1 using the approved routing hierarchy.
 
-    Collected SQLite articles always compete in pass 1. A prepared event linked
-    to a holding/watchlist security bypasses pass 1 even when it is article-like;
-    otherwise market moves bypass, unlinked ``market-news`` records compete as
-    secondary article candidates, and every remaining prepared event advances as
-    an ``other_auto_event``.
+    SQLite articles normally compete in pass 1. An article enriched from its
+    matching prepared event retains holding/watchlist routing and bypasses pass
+    1; otherwise market moves bypass, unlinked ``market-news`` records compete
+    as secondary article candidates, and every remaining prepared event advances
+    as an ``other_auto_event``.
     """
     article_candidates: list[CandidateTitle] = []
     automatic_events: list[RoutedEvent] = []
     for candidate in candidates:
-        if candidate.kind == "article":
-            article_candidates.append(candidate)
-            continue
-
         event_type = str(candidate.metadata.get("event_type") or "").strip().casefold()
         portfolio_role = (
             str(candidate.metadata.get("portfolio_role") or "").strip().casefold()
         )
         if portfolio_role in PORTFOLIO_ROLES:
             routing_class = ROUTING_AUTO_PORTFOLIO
+        elif candidate.kind == "article":
+            article_candidates.append(candidate)
+            continue
         elif event_type == "market":
             routing_class = ROUTING_AUTO_MARKET
         elif event_type == "market-news":
@@ -388,9 +541,11 @@ def build_shortlist_prompt(candidates: Sequence[CandidateTitle], run_date: date)
         "read-through, or materially economic, political, or geopolitical. Reject lifestyle, "
         "sports, celebrity, and other non-investor fluff. Semantically deduplicate overlapping "
         "headlines: select one representative of the same development, preferring a "
-        "collected_sqlite_article over a secondary_prepared_market_news record because the former "
-        "has richer collected evidence. A secondary market-news record may be selected when it is "
-        "the only coverage or is materially distinct. Rank and balance sources on merit, not quotas. "
+        "collected_sqlite_article over secondary_finnhub_summary_only or "
+        "secondary_prepared_market_news because only collected_sqlite_article represents richer "
+        "crawler-collected reporting. Finnhub summary-only rows contain only a provider summary "
+        "despite being stored in SQLite. A secondary record may be selected when it is the only "
+        "coverage or is materially distinct. Rank and balance sources on merit, not quotas. "
         "Do not draft the brief, summarize unsupported details, or invent IDs.\n\n"
         "Return exactly one strict JSON object and no markdown or commentary. Include exactly one "
         "concise editorial reason with every selected ID:\n"
@@ -489,34 +644,55 @@ def query_shortlisted_evidence(
                 raise SynthesisError(
                     f"shortlisted article disappeared from SQLite: {candidate.id}"
                 )
-            summary = str(row["summary"] or "").strip()
-            content = str(row["content"] or "").strip()
-            if summary:
-                evidence_text = summary
-                evidence_kind = "summary"
-            else:
-                evidence_text = _bounded_text(content, max_content_chars)
-                evidence_kind = "bounded_content_fallback"
             evidence.append(
-                {
-                    "id": candidate.id,
-                    "kind": "article",
-                    "article_key": candidate.article_key,
-                    "source": str(row["source"]),
-                    "published": str(row["published_at_raw"] or "").strip()
-                    or _epoch_as_iso(row["published_at"]),
-                    "title": str(row["title"]),
-                    "url": str(row["url"] or "").strip(),
-                    "section": str(row["section"] or "").strip(),
-                    "evidence_kind": evidence_kind,
-                    "routing_class": ROUTING_SELECTED_ARTICLE,
-                    "article_candidate_class": "collected_sqlite_article",
-                    "evidence": evidence_text,
-                }
+                _article_evidence(
+                    candidate,
+                    row,
+                    routing_class=ROUTING_SELECTED_ARTICLE,
+                    max_content_chars=max_content_chars,
+                )
             )
         else:
             evidence.append(
                 _event_evidence(candidate, routing_class=ROUTING_SELECTED_ARTICLE)
+            )
+    return evidence
+
+
+def query_automatic_evidence(
+    db_path: Path,
+    routed_events: Sequence[RoutedEvent],
+    *,
+    max_content_chars: int = MAX_ARTICLE_CONTENT_CHARS,
+) -> list[dict[str, Any]]:
+    """Load SQLite evidence for persisted automatic articles when available."""
+    article_keys = [
+        item.candidate.article_key
+        for item in routed_events
+        if item.candidate.kind == "article"
+        and item.candidate.article_key is not None
+    ]
+    article_rows = _query_article_evidence(db_path, article_keys)
+    evidence: list[dict[str, Any]] = []
+    for item in routed_events:
+        candidate = item.candidate
+        if candidate.kind == "article":
+            row = article_rows.get(candidate.article_key or "")
+            if row is None:
+                raise SynthesisError(
+                    f"automatically routed article disappeared from SQLite: {candidate.id}"
+                )
+            evidence.append(
+                _article_evidence(
+                    candidate,
+                    row,
+                    routing_class=item.routing_class,
+                    max_content_chars=max_content_chars,
+                )
+            )
+        else:
+            evidence.append(
+                _event_evidence(candidate, routing_class=item.routing_class)
             )
     return evidence
 
@@ -559,12 +735,16 @@ def build_final_prompt(
         "Every evidence record has an explicit routing_class. Apply this hierarchy exactly:\n"
         "- selected_article: editorially rank the strongest items as concise bullets in *Worth "
         "Knowing Today*. Semantically deduplicate overlapping stories and do not repeat one "
-        "development from multiple outlets. Collected SQLite articles are richer than "
-        "secondary_prepared_market_news records; the latter retain only their supplied prepared "
-        "summary and URL and must not be treated as equally complete reporting.\n"
+        "development from multiple outlets. Only collected_sqlite_article records represent richer "
+        "crawler-collected reporting. secondary_finnhub_summary_only, "
+        "secondary_prepared_market_news, and secondary_prepared_company_news records retain only "
+        "a provider/prepared summary and URL; do not treat any as full-text reporting merely "
+        "because one is stored in SQLite.\n"
         "- auto_portfolio_watchlist: represent EVERY record in *Portfolio / Watchlist Events*. "
-        "Consolidate overlapping records by ticker into one coherent bullet rather than producing "
-        "one bullet per record. Do not drop a record merely because it seems less newsworthy. Emit "
+        "When one persisted article has multiple prepared_event_contexts, represent every listed "
+        "security association while consolidating the article into one coherent bullet. Consolidate "
+        "overlapping records by ticker rather than producing one bullet per record. Do not drop a "
+        "record merely because it seems less newsworthy. Emit "
         "this section if and only if auto_portfolio_watchlist evidence exists.\n"
         "- auto_market_move: represent ALL such records in exactly ONE compact bullet/line under "
         "*Market Snapshot*. Never emit multiple market-move bullets. Emit this section if and only "
@@ -688,10 +868,9 @@ def synthesize_morning_brief(
         stage="pass 1 shortlist",
     )
     selected_evidence = query_shortlisted_evidence(db_path, candidates, shortlist_ids)
-    automatic_evidence = [
-        _event_evidence(item.candidate, routing_class=item.routing_class)
-        for item in routing_plan.automatic_events
-    ]
+    automatic_evidence = query_automatic_evidence(
+        db_path, routing_plan.automatic_events
+    )
     evidence = [*selected_evidence, *automatic_evidence]
     pass_2_prompt = build_final_prompt(
         evidence,
@@ -886,6 +1065,54 @@ def _query_article_evidence(
     return rows
 
 
+def _article_evidence(
+    candidate: CandidateTitle,
+    row: sqlite3.Row,
+    *,
+    routing_class: str,
+    max_content_chars: int,
+) -> dict[str, Any]:
+    """Build evidence from the durable SQLite row for one article candidate."""
+    summary = str(row["summary"] or "").strip()
+    content = str(row["content"] or "").strip()
+    summary_only = is_finnhub_summary_only_section(row["section"])
+    if summary_only:
+        evidence_text = _bounded_text(summary or content, max_content_chars)
+        evidence_kind = "summary_only"
+    elif summary:
+        evidence_text = summary
+        evidence_kind = "summary"
+    else:
+        evidence_text = _bounded_text(content, max_content_chars)
+        evidence_kind = "bounded_content_fallback"
+    published_raw = str(row["published_at_raw"] or "").strip()
+    published_iso = _epoch_as_iso(row["published_at"])
+    record: dict[str, Any] = {
+        "id": candidate.id,
+        "kind": "article",
+        "article_key": candidate.article_key,
+        "source": str(row["source"]),
+        "published": _publication_display(published_raw, published_iso),
+        "published_at_raw": published_raw,
+        "title": str(row["title"]),
+        "url": str(row["url"] or "").strip(),
+        "section": str(row["section"] or "").strip(),
+        "evidence_kind": evidence_kind,
+        "routing_class": routing_class,
+        "article_candidate_class": (
+            "secondary_finnhub_summary_only"
+            if summary_only
+            else "collected_sqlite_article"
+        ),
+        "evidence_depth": "summary_only" if summary_only else "collected_article",
+        "evidence": evidence_text,
+    }
+    details = _compact_event_details(candidate.metadata)
+    if details:
+        record["details"] = details
+    return record
+
+
 def _event_evidence(candidate: CandidateTitle, *, routing_class: str) -> dict[str, Any]:
     """Preserve one prepared event's own bounded summary and supplied URL."""
     event = candidate.metadata
@@ -896,7 +1123,31 @@ def _event_evidence(candidate: CandidateTitle, *, routing_class: str) -> dict[st
         _nested_value(event, "metadata", "summary"),
         _nested_value(event, "metadata", "description"),
     )
-    compact_details: dict[str, Any] = {}
+    event_type = str(event.get("event_type") or "").strip().casefold()
+    evidence_record = {
+        "id": candidate.id,
+        "kind": "event",
+        "source": candidate.source,
+        "published": candidate.published,
+        "title": candidate.title,
+        "url": url,
+        "details": _compact_event_details(event),
+        "evidence_kind": "prepared_event",
+        "routing_class": routing_class,
+        "evidence": _bounded_text(summary, MAX_EVENT_DETAIL_CHARS),
+    }
+    if event_type in ARTICLE_EVENT_TYPES:
+        evidence_record["article_candidate_class"] = (
+            "secondary_prepared_company_news"
+            if event_type == "company-news"
+            else "secondary_prepared_market_news"
+        )
+        evidence_record["evidence_depth"] = "summary_only"
+    return evidence_record
+
+
+def _compact_event_details(event: dict[str, Any]) -> dict[str, Any]:
+    details: dict[str, Any] = {}
     for key in (
         "event_type",
         "security_id",
@@ -915,7 +1166,12 @@ def _event_evidence(candidate: CandidateTitle, *, routing_class: str) -> dict[st
     ):
         value = event.get(key)
         if value not in (None, "", [], {}):
-            compact_details[key] = value
+            details[key] = value
+    contexts = event.get("prepared_event_contexts")
+    if isinstance(contexts, list) and contexts:
+        details["prepared_event_contexts"] = [
+            dict(context) for context in contexts if isinstance(context, dict)
+        ]
     metadata = event.get("metadata")
     if isinstance(metadata, dict):
         for key in (
@@ -927,24 +1183,9 @@ def _event_evidence(candidate: CandidateTitle, *, routing_class: str) -> dict[st
             "fiscal_year",
         ):
             value = metadata.get(key)
-            if value not in (None, "", [], {}) and key not in compact_details:
-                compact_details[key] = value
-
-    evidence_record = {
-        "id": candidate.id,
-        "kind": "event",
-        "source": candidate.source,
-        "published": candidate.published,
-        "title": candidate.title,
-        "url": url,
-        "details": compact_details,
-        "evidence_kind": "prepared_event",
-        "routing_class": routing_class,
-        "evidence": _bounded_text(summary, MAX_EVENT_DETAIL_CHARS),
-    }
-    if str(event.get("event_type") or "").strip().casefold() == "market-news":
-        evidence_record["article_candidate_class"] = "secondary_prepared_market_news"
-    return evidence_record
+            if value not in (None, "", [], {}) and key not in details:
+                details[key] = value
+    return details
 
 
 def _universe_role_map(raw_universe: Any) -> dict[str, str]:
@@ -1031,24 +1272,7 @@ def _candidate_article_url(candidate: CandidateTitle) -> str:
             candidate.metadata.get("source_url"),
             _nested_value(candidate.metadata, "metadata", "url"),
         )
-    url = str(raw_url or "").strip()
-    if not url:
-        return ""
-    try:
-        parts = urlsplit(url)
-        query = urlencode(
-            sorted(
-                (key, value)
-                for key, value in parse_qsl(parts.query, keep_blank_values=True)
-                if not key.casefold().startswith("utm_")
-                and key.casefold()
-                not in {"fbclid", "gclid", "mc_cid", "mc_eid"}
-            )
-        )
-        host = parts.netloc.casefold().removeprefix("www.")
-        return urlunsplit(("", host, parts.path.rstrip("/"), query, ""))
-    except ValueError:
-        return url.partition("#")[0].rstrip("/")
+    return canonical_news_url(raw_url)
 
 
 def _article_record_key(
@@ -1058,15 +1282,9 @@ def _article_record_key(
     url = _candidate_article_url(candidate)
     if url:
         return ("url", url)
-    security_id = str(
-        candidate.metadata.get("security_id")
-        or candidate.metadata.get("ticker")
-        or ""
-    ).strip().casefold()
     return (
         "fallback",
         _source_identity(candidate, source_label),
-        security_id,
         title,
         _candidate_publication_day(candidate),
     )
@@ -1136,11 +1354,18 @@ def _ordered_source_labels(
     return labels
 
 
+def _publication_display(published_raw: str, published_iso: str) -> str:
+    """Prefer readable source dates while retaining numeric raw values elsewhere."""
+    if published_raw and not re.fullmatch(r"\d+(?:\.\d+)?", published_raw):
+        return published_raw
+    return published_iso or published_raw
+
+
 def _epoch_as_iso(raw_epoch: Any) -> str:
     try:
         epoch = int(raw_epoch)
         return (
-            datetime.fromtimestamp(epoch, timezone.utc)
+            datetime.fromtimestamp(epoch, UTC)
             .isoformat()
             .replace("+00:00", "Z")
         )
@@ -1235,7 +1460,7 @@ def _with_retries(operation: Callable[[], Any], *, attempts: int, stage: str) ->
     for attempt in range(1, attempts + 1):
         try:
             return operation()
-        except Exception as exc:  # OpenClaw and output-validation errors retry once
+        except Exception as exc:  # noqa: BLE001 - retry model and validation failures
             last_error = exc
             if attempt < attempts:
                 print(
@@ -1312,7 +1537,7 @@ def main(argv: list[str] | None = None, *, model_call: ModelCall | None = None) 
             session_key=args.session_key,
             output_path=output_path,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - CLI boundary reports all failures
         print(f"morning-brief synthesis failed: {exc}", file=sys.stderr)
         return 1
 

--- a/src/harness/news.py
+++ b/src/harness/news.py
@@ -1,3 +1,4 @@
+# ruff: noqa: DTZ001, FURB162
 """News ingestion, stable article identity, and read-only existence lookup.
 
 Raw morning-brief markdown is joined to same-name summaries and inserted into
@@ -12,11 +13,15 @@ import hashlib
 import json
 import re
 import sqlite3
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable, Literal, Mapping, Sequence, TypedDict
+from typing import Literal, TypedDict
 from zoneinfo import ZoneInfo
+
+from harness.news_store import NEWS_COLUMNS as _NEWS_COLUMNS
+from harness.news_store import create_news_schema, ensure_canonical_news_schema
 
 # Header keys we care about (case-insensitive on the label).
 META_KEYS = {"source", "url", "published", "collected", "section", "status"}
@@ -113,7 +118,7 @@ def resolve_source_id(filename: str, known_ids: list[str]) -> str | None:
 
     Falls back to a regex for ir-* files when the registry is missing.
     """
-    stem = filename[:-3] if filename.endswith(".md") else filename
+    stem = filename.removesuffix(".md")
     for sid in known_ids:
         if stem == sid or stem.startswith(sid + "-"):
             return sid
@@ -225,7 +230,7 @@ def _month(token: str) -> int | None:
 
 
 def _midnight_utc(value: date) -> ParsedPublished:
-    dt = datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    dt = datetime(value.year, value.month, value.day, tzinfo=UTC)
     return ParsedPublished(epoch=int(dt.timestamp()), date_only=value.isoformat())
 
 
@@ -269,7 +274,7 @@ def _with_time(
     if not zone:
         return _midnight_utc(value)
     if zone in {"UTC", "GMT", "Z"}:
-        tz = timezone.utc
+        tz = UTC
     elif zone in _GENERIC_US_ZONES:
         tz = ZoneInfo(_GENERIC_US_ZONES[zone])
     else:
@@ -486,7 +491,7 @@ def is_excluded_filename(name: str) -> str | None:
     """Return an exclusion reason for filenames we never ingest."""
     if name.endswith("-error.md"):
         return "error"
-    stem = name[:-3] if name.endswith(".md") else name
+    stem = name.removesuffix(".md")
     if stem.upper().startswith("INDEX"):
         return "index"
     if stem == "ad-hoc-saas-market-signal":
@@ -726,45 +731,9 @@ def check_candidates(
 # ---------------------------------------------------------------------------
 # Schema management
 # ---------------------------------------------------------------------------
-NEWS_TABLE_SQL = """
-CREATE TABLE IF NOT EXISTS news (
-    article_key       TEXT PRIMARY KEY,
-    published_at      INTEGER NOT NULL,
-    published_at_raw  TEXT NOT NULL,
-    title             TEXT NOT NULL,
-    content           TEXT NOT NULL,
-    summary           TEXT,
-    source            TEXT NOT NULL,
-    url               TEXT NOT NULL,
-    section           TEXT,
-    collected_at      TEXT NOT NULL
-)
-"""
-
-NEWS_INDEX_SQL = (
-    "CREATE INDEX IF NOT EXISTS idx_news_published ON news(published_at)",
-    "CREATE INDEX IF NOT EXISTS idx_news_collected ON news(collected_at)",
-    "CREATE INDEX IF NOT EXISTS idx_news_url ON news(url)",
-)
-
-_NEWS_COLUMNS = (
-    "article_key",
-    "published_at",
-    "published_at_raw",
-    "title",
-    "content",
-    "summary",
-    "source",
-    "url",
-    "section",
-    "collected_at",
-)
-
-
 def _create_news_schema(conn: sqlite3.Connection) -> None:
-    conn.execute(NEWS_TABLE_SQL)
-    for statement in NEWS_INDEX_SQL:
-        conn.execute(statement)
+    """Compatibility wrapper around the shared canonical schema helper."""
+    create_news_schema(conn)
 
 
 def _legacy_publication_epoch(raw: str, collected_at: str) -> int:
@@ -862,6 +831,10 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         _migrate_legacy_news(conn, set(columns))
     else:
         _create_news_schema(conn)
+    try:
+        ensure_canonical_news_schema(conn)
+    except RuntimeError as exc:
+        raise NewsSchemaError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -1098,7 +1071,7 @@ def _ingest_one(
 
     collected = parsed.meta.get("collected", "").strip()
     if not collected:
-        collected = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        collected = datetime.now(UTC).isoformat(timespec="seconds").replace(
             "+00:00", "Z"
         )
     else:

--- a/src/harness/news_store.py
+++ b/src/harness/news_store.py
@@ -1,0 +1,124 @@
+"""Shared schema and identity helpers for the canonical SQLite news store."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+NEWS_DB_RELATIVE_PATH = Path("data") / "04-database" / "invest.db"
+FINNHUB_SUMMARY_ONLY_SECTION = "finnhub-summary-only"
+
+NEWS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS news (
+    article_key       TEXT PRIMARY KEY,
+    published_at      INTEGER NOT NULL,
+    published_at_raw  TEXT NOT NULL,
+    title             TEXT NOT NULL,
+    content           TEXT NOT NULL,
+    summary           TEXT,
+    source            TEXT NOT NULL,
+    url               TEXT NOT NULL,
+    section           TEXT,
+    collected_at      TEXT NOT NULL
+)
+"""
+
+NEWS_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_news_published ON news(published_at)",
+    "CREATE INDEX IF NOT EXISTS idx_news_collected ON news(collected_at)",
+    "CREATE INDEX IF NOT EXISTS idx_news_url ON news(url)",
+)
+
+NEWS_COLUMNS = (
+    "article_key",
+    "published_at",
+    "published_at_raw",
+    "title",
+    "content",
+    "summary",
+    "source",
+    "url",
+    "section",
+    "collected_at",
+)
+
+
+def create_news_schema(connection: sqlite3.Connection) -> None:
+    """Create the canonical news table and indexes if they are absent."""
+    connection.execute(NEWS_TABLE_SQL)
+    for statement in NEWS_INDEX_SQL:
+        connection.execute(statement)
+
+
+def ensure_canonical_news_schema(connection: sqlite3.Connection) -> None:
+    """Create or validate the canonical news schema without committing.
+
+    Legacy schema migration remains the responsibility of ``harness.news``,
+    which has the historical date parser needed to migrate old rows safely.
+    """
+    table_exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'news'"
+    ).fetchone()
+    if table_exists is None:
+        create_news_schema(connection)
+        return
+
+    columns = {
+        str(row[1]): row for row in connection.execute("PRAGMA table_info(news)")
+    }
+    missing = set(NEWS_COLUMNS) - set(columns)
+    published_type = str(columns.get("published_at", (None, None, ""))[2]).upper()
+    article_key_is_primary = bool(
+        columns.get("article_key") and int(columns["article_key"][5]) == 1
+    )
+    if missing or published_type != "INTEGER" or not article_key_is_primary:
+        if missing:
+            detail = f"missing columns: {', '.join(sorted(missing))}"
+        elif published_type != "INTEGER":
+            detail = (
+                f"published_at has type {published_type or 'UNKNOWN'}, expected INTEGER"
+            )
+        else:
+            detail = "article_key is not the primary key"
+        raise RuntimeError(
+            "news table has an unsupported schema "
+            f"({detail}); repair or recreate the database before preparing evidence"
+        )
+    create_news_schema(connection)
+
+
+def resolve_news_db_path(workspace_root: Path, db_path: Path | None = None) -> Path:
+    """Resolve an explicit news DB path or the workspace-local default."""
+    if db_path is not None:
+        return db_path.expanduser().resolve()
+    return workspace_root.resolve() / NEWS_DB_RELATIVE_PATH
+
+
+def is_finnhub_summary_only_section(raw_section: object) -> bool:
+    """Return whether a row contains only Finnhub's provider summary."""
+    return str(raw_section or "").strip().casefold() == FINNHUB_SUMMARY_ONLY_SECTION
+
+
+def canonical_news_url(raw_url: object) -> str:
+    """Return a stable URL identity while leaving the stored URL untouched."""
+    url = str(raw_url or "").strip()
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+        query = urlencode(
+            sorted(
+                (key, value)
+                for key, value in parse_qsl(parts.query, keep_blank_values=True)
+                if not key.casefold().startswith("utm_")
+                and key.casefold()
+                not in {"fbclid", "gclid", "mc_cid", "mc_eid"}
+            )
+        )
+        host = parts.netloc.casefold().removeprefix("www.")
+        path = re.sub(r"/{2,}", "/", parts.path).rstrip("/")
+        return urlunsplit(("", host, path, query, ""))
+    except ValueError:
+        return url.partition("#")[0].rstrip("/")

--- a/tests/test_harness/test_finnhub_news_persistence.py
+++ b/tests/test_harness/test_finnhub_news_persistence.py
@@ -1,0 +1,606 @@
+"""Regression coverage for post-crawler Finnhub news persistence."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, date, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from harness import news as news_domain
+from harness.commands.brief import prep_command
+from harness.config import HarnessSettings, get_settings
+from harness.morning_brief import (
+    MAX_FINNHUB_SUMMARY_CHARS,
+    collect_market,
+    ensure_daily_run_layout,
+    prepare_evidence,
+)
+from harness.morning_brief_synthesis import (
+    ROUTING_AUTO_PORTFOLIO,
+    build_source_collection_line,
+    build_title_universe,
+    partition_candidates,
+    query_automatic_evidence,
+    synthesize_morning_brief,
+)
+from harness.news_store import (
+    FINNHUB_SUMMARY_ONLY_SECTION,
+    ensure_canonical_news_schema,
+)
+from harness.portfolio_state import ensure_portfolio_layout, portfolio_paths
+
+RUN_DATE = date(2026, 8, 12)
+COLLECTED_AT = "2026-08-12T10:15:00Z"
+
+
+def _timestamp(hour: int) -> int:
+    return int(
+        datetime(
+            RUN_DATE.year,
+            RUN_DATE.month,
+            RUN_DATE.day,
+            hour,
+            tzinfo=UTC,
+        ).timestamp()
+    )
+
+
+def _write_payload(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_duplicate_payload(path: Path, *, long_summary: bool = False) -> None:
+    market_summary = (
+        "m" * (MAX_FINNHUB_SUMMARY_CHARS + 500)
+        if long_summary
+        else "Rates moved after the inflation release."
+    )
+    _write_payload(
+        path,
+        {
+            "indexes": [
+                {
+                    "symbol": "SPY",
+                    "change_pct": 1.2,
+                    "headline": "SPY moved 1.20%",
+                }
+            ],
+            "news": [
+                {
+                    "headline": "Markets digest inflation data",
+                    "datetime": _timestamp(8),
+                    "source": "Reuters",
+                    "url": "https://www.example.com/markets/story",
+                    "summary": market_summary,
+                },
+                {
+                    "headline": "Markets digest inflation data",
+                    "datetime": _timestamp(8),
+                    "source": "Reuters",
+                    "url": "https://example.com/markets/story/?utm_medium=api",
+                    "summary": market_summary,
+                },
+            ],
+            "company_news": [
+                {
+                    "headline": "Shared product update",
+                    "datetime": _timestamp(9),
+                    "source": "CNBC",
+                    "url": "https://example.com/company/update",
+                    "summary": "The company described the product update.",
+                    "_security_id": "NVDA",
+                },
+                {
+                    "headline": "Shared product update",
+                    "datetime": _timestamp(9),
+                    "source": "CNBC",
+                    "url": "https://example.com/company/update?utm_source=finnhub",
+                    "summary": "The company described the product update.",
+                    "_security_id": "MSFT",
+                },
+            ],
+        },
+    )
+
+
+def _collect(
+    workspace: Path, payload_path: Path, *, collected_at: str = COLLECTED_AT
+) -> dict:
+    with patch("harness.morning_brief.now_utc_iso", return_value=collected_at):
+        return collect_market(
+            workspace,
+            run_date=RUN_DATE,
+            source=str(payload_path),
+            provider="file",
+        )
+
+
+def _set_universe(workspace: Path) -> None:
+    ensure_portfolio_layout(workspace)
+    portfolio_paths(workspace).universe.write_text(
+        json.dumps(
+            [
+                {
+                    "security_id": "NVDA",
+                    "ticker": "NVDA",
+                    "source_kind": "holding",
+                },
+                {
+                    "security_id": "MSFT",
+                    "ticker": "MSFT",
+                    "source_kind": "watchlist",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _prepared_path(workspace: Path) -> Path:
+    return (
+        ensure_daily_run_layout(workspace, RUN_DATE).structured_dir
+        / "prepared-evidence.json"
+    )
+
+
+def test_collect_defers_persistence_until_prep_and_prep_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "finnhub-market.json"
+    _write_duplicate_payload(payload_path, long_summary=True)
+    db_path = tmp_path / "custom" / "invest.db"
+
+    collected = _collect(tmp_path, payload_path)
+
+    assert collected["event_count"] == 5
+    assert not db_path.exists()
+    assert not (tmp_path / "data" / "04-database" / "invest.db").exists()
+    raw_payload = json.loads(Path(collected["raw_path"]).read_text(encoding="utf-8"))
+    assert "news_persistence" not in raw_payload
+    assert all(
+        "persisted_article_key" not in event for event in raw_payload["events"]
+    )
+
+    first = prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+
+    connection = sqlite3.connect(db_path)
+    rows = connection.execute(
+        "SELECT article_key, published_at, published_at_raw, title, content, "
+        "summary, source, section, collected_at FROM news ORDER BY source"
+    ).fetchall()
+    connection.close()
+    assert first["news_inserted_count"] == 2
+    assert first["news_duplicate_count"] == 2
+    assert len(rows) == 2
+    assert {row[6] for row in rows} == {"Reuters", "CNBC"}
+    assert {row[7] for row in rows} == {FINNHUB_SUMMARY_ONLY_SECTION}
+    assert all(row[4] == row[5] for row in rows)
+    assert all(len(row[4]) <= MAX_FINNHUB_SUMMARY_CHARS for row in rows)
+    assert {row[8] for row in rows} == {COLLECTED_AT}
+    assert all(row[1] in {_timestamp(8), _timestamp(9)} for row in rows)
+    assert all(row[2] in {str(_timestamp(8)), str(_timestamp(9))} for row in rows)
+
+    rewritten_raw = json.loads(
+        Path(collected["raw_path"]).read_text(encoding="utf-8")
+    )
+    persisted_events = [
+        event
+        for event in rewritten_raw["events"]
+        if event["event_type"] in {"market-news", "company-news"}
+    ]
+    assert all(event.get("persisted_article_key") for event in persisted_events)
+    assert len({event["persisted_article_key"] for event in persisted_events}) == 2
+    assert rewritten_raw["news_persistence"]["inserted"] == 2
+
+    second = prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+    connection = sqlite3.connect(db_path)
+    rerun_count = connection.execute("SELECT count(*) FROM news").fetchone()[0]
+    connection.close()
+
+    assert second["news_inserted_count"] == 0
+    assert second["news_duplicate_count"] == 4
+    assert rerun_count == 2
+
+
+def test_collecting_prices_only_never_touches_the_database(tmp_path: Path) -> None:
+    payload_path = tmp_path / "prices-only.json"
+    _write_payload(
+        payload_path,
+        {
+            "indexes": [
+                {
+                    "symbol": "SPY",
+                    "change_pct": -0.4,
+                    "headline": "SPY moved -0.40%",
+                }
+            ]
+        },
+    )
+
+    result = _collect(tmp_path, payload_path)
+
+    assert result["event_count"] == 1
+    assert not (tmp_path / "data" / "04-database" / "invest.db").exists()
+
+
+def test_exact_url_security_associations_survive_collect_prep_and_synthesis(
+    tmp_path: Path,
+) -> None:
+    _set_universe(tmp_path)
+    article_url = "https://example.com/shared-story"
+    payload_path = tmp_path / "exact-duplicate-urls.json"
+    _write_payload(
+        payload_path,
+        {
+            "news": [
+                {
+                    "headline": "General version of shared story",
+                    "datetime": _timestamp(8),
+                    "source": "CNBC",
+                    "url": article_url,
+                    "summary": "A general provider summary.",
+                }
+            ],
+            "company_news": [
+                {
+                    "headline": "Shared story affects two companies",
+                    "datetime": _timestamp(8),
+                    "source": "CNBC",
+                    "url": article_url,
+                    "summary": "A company-linked provider summary.",
+                    "_security_id": "NVDA",
+                },
+                {
+                    "headline": "Shared story affects two companies",
+                    "datetime": _timestamp(8),
+                    "source": "CNBC",
+                    "url": article_url,
+                    "summary": "A company-linked provider summary.",
+                    "_security_id": "MSFT",
+                },
+            ],
+        },
+    )
+    db_path = tmp_path / "invest.db"
+
+    _collect(tmp_path, payload_path)
+    prep = prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+    prepared_path = _prepared_path(tmp_path)
+    prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
+    linked_events = [
+        event
+        for event in prepared["events"]
+        if event.get("reference_url") == article_url
+    ]
+
+    assert prep["news_inserted_count"] == 1
+    assert prep["news_duplicate_count"] == 2
+    assert {event["security_id"] for event in linked_events} == {"NVDA", "MSFT"}
+    assert {event["event_type"] for event in linked_events} == {"company-news"}
+    assert len({event["persisted_article_key"] for event in linked_events}) == 1
+    assert any(
+        item["reason"] == "duplicate-url-unlinked"
+        for item in prepared["suppressed"]
+    )
+
+    candidates = build_title_universe(db_path, prepared_path, RUN_DATE)
+    plan = partition_candidates(candidates)
+    assert len(candidates) == 1
+    source_line = build_source_collection_line(candidates)
+    assert source_line.startswith("*Source Collection:* 1 article record —")
+    assert "CNBC 1" in source_line
+    assert candidates[0].title_record()["article_candidate_class"] == (
+        "secondary_finnhub_summary_only"
+    )
+    assert candidates[0].title_record()["evidence_depth"] == "summary_only"
+    assert plan.article_candidates == ()
+    assert len(plan.automatic_events) == 1
+    assert plan.automatic_events[0].routing_class == ROUTING_AUTO_PORTFOLIO
+
+    prompts: list[str] = []
+
+    def model_call(**kwargs) -> str:
+        prompts.append(kwargs["prompt"])
+        if "PASS 1" in kwargs["prompt"]:
+            return '{"ids":[]}'
+        return (
+            "*Portfolio / Watchlist Events*\n"
+            "• Shared story affects NVDA and MSFT.\n\n"
+            "*Worth Knowing Today*\n"
+            "• No additional selected articles."
+        )
+
+    brief = synthesize_morning_brief(
+        db_path=db_path,
+        prepared_path=prepared_path,
+        run_date=RUN_DATE,
+        model_call=model_call,
+    )
+    evidence_payload = json.loads(
+        prompts[1].split("SHORTLISTED_EVIDENCE_JSON:\n", 1)[1]
+    )
+    evidence = evidence_payload["evidence"]
+
+    assert brief.count("Shared story affects NVDA and MSFT") == 1
+    assert "Finnhub summary-only rows contain only a provider summary" in prompts[0]
+    assert "do not treat any as full-text reporting" in prompts[1]
+    assert len(evidence) == 1
+    assert evidence[0]["evidence_kind"] == "summary_only"
+    assert evidence[0]["article_candidate_class"] == (
+        "secondary_finnhub_summary_only"
+    )
+    contexts = evidence[0]["details"]["prepared_event_contexts"]
+    assert {(item["security_id"], item["portfolio_role"]) for item in contexts} == {
+        ("NVDA", "holding"),
+        ("MSFT", "watchlist"),
+    }
+
+
+def test_prepare_prefers_matching_rich_crawler_row_without_inserting_summary(
+    tmp_path: Path,
+) -> None:
+    _set_universe(tmp_path)
+    article_url = "https://example.com/company/rich-story"
+    payload_path = tmp_path / "matching-finnhub.json"
+    _write_payload(
+        payload_path,
+        {
+            "company_news": [
+                {
+                    "headline": "Finnhub version of rich story",
+                    "datetime": _timestamp(9),
+                    "source": "Reuters",
+                    "url": article_url,
+                    "summary": "Thin Finnhub provider summary.",
+                    "_security_id": "NVDA",
+                }
+            ]
+        },
+    )
+    db_path = tmp_path / "invest.db"
+    connection = sqlite3.connect(db_path)
+    ensure_canonical_news_schema(connection)
+    connection.execute(
+        "INSERT INTO news VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "crawler-rich-key",
+            _timestamp(9),
+            "2026-08-12T09:00:00Z",
+            "Crawler full-text version of rich story",
+            "RICH CRAWLER FULL TEXT with reporting details.",
+            "Crawler-generated rich summary.",
+            "reuters-markets",
+            article_url,
+            "markets",
+            COLLECTED_AT,
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    _collect(tmp_path, payload_path)
+    prep = prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+    prepared = json.loads(_prepared_path(tmp_path).read_text(encoding="utf-8"))
+    event = next(
+        item for item in prepared["events"] if item.get("event_type") == "company-news"
+    )
+
+    connection = sqlite3.connect(db_path)
+    rows = connection.execute(
+        "SELECT article_key, content, summary, section FROM news"
+    ).fetchall()
+    connection.close()
+    assert prep["news_inserted_count"] == 0
+    assert prep["news_duplicate_count"] == 1
+    assert rows == [
+        (
+            "crawler-rich-key",
+            "RICH CRAWLER FULL TEXT with reporting details.",
+            "Crawler-generated rich summary.",
+            "markets",
+        )
+    ]
+    assert event["persisted_article_key"] == "crawler-rich-key"
+
+    candidates = build_title_universe(db_path, _prepared_path(tmp_path), RUN_DATE)
+    plan = partition_candidates(candidates)
+    evidence = query_automatic_evidence(db_path, plan.automatic_events)
+    assert len(candidates) == 1
+    assert candidates[0].metadata["summary_only"] is False
+    assert evidence[0]["article_candidate_class"] == "collected_sqlite_article"
+    assert evidence[0]["evidence_kind"] == "summary"
+    assert evidence[0]["evidence"] == "Crawler-generated rich summary."
+    assert "Thin Finnhub provider summary." not in json.dumps(evidence)
+
+
+def test_backdated_persistence_uses_run_date_for_fresh_queries(tmp_path: Path) -> None:
+    payload_path = tmp_path / "backdated.json"
+    _write_payload(
+        payload_path,
+        {
+            "news": [
+                {
+                    "headline": "Backdated run story",
+                    "datetime": _timestamp(7),
+                    "source": "Reuters",
+                    "url": "https://example.com/backdated",
+                    "summary": "Provider summary.",
+                }
+            ]
+        },
+    )
+    db_path = tmp_path / "invest.db"
+
+    _collect(tmp_path, payload_path, collected_at="2030-01-02T23:30:00-05:00")
+    prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+
+    connection = sqlite3.connect(db_path)
+    collected_at = connection.execute("SELECT collected_at FROM news").fetchone()[0]
+    connection.close()
+    assert collected_at == "2026-08-12T23:30:00-05:00"
+    candidates = build_title_universe(db_path, _prepared_path(tmp_path), RUN_DATE)
+    assert len(candidates) == 1
+    assert build_source_collection_line(candidates).startswith(
+        "*Source Collection:* 1 article record —"
+    )
+
+
+def test_invest_db_environment_override_flows_through_brief_prep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload_path = tmp_path / "override.json"
+    _write_payload(
+        payload_path,
+        {
+            "news": [
+                {
+                    "headline": "Override path story",
+                    "datetime": _timestamp(7),
+                    "source": "Reuters",
+                    "url": "https://example.com/override",
+                    "summary": "Provider summary.",
+                }
+            ]
+        },
+    )
+    override = tmp_path / "override-db" / "custom.db"
+    monkeypatch.setenv("MINERVA_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("INVEST_DB", str(override))
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        _collect(tmp_path, payload_path)
+
+        result = prep_command(run_date=RUN_DATE, settings=settings)
+
+        assert result.exit_code == 0
+        assert override.is_file()
+        assert not (tmp_path / "data" / "04-database" / "invest.db").exists()
+    finally:
+        get_settings.cache_clear()
+
+
+def test_collect_does_not_fail_before_supported_legacy_schema_migration(
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "legacy-order.json"
+    _write_payload(
+        payload_path,
+        {
+            "news": [
+                {
+                    "headline": "Legacy ordering story",
+                    "datetime": _timestamp(7),
+                    "source": "Reuters",
+                    "url": "https://example.com/legacy-order",
+                    "summary": "Provider summary.",
+                }
+            ]
+        },
+    )
+    db_path = tmp_path / "legacy.db"
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        CREATE TABLE news (
+            article_key TEXT PRIMARY KEY,
+            published_at TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            summary TEXT,
+            source TEXT NOT NULL,
+            url TEXT NOT NULL,
+            section TEXT,
+            collected_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    _collect(tmp_path, payload_path)
+    connection = sqlite3.connect(db_path)
+    assert "published_at_raw" not in {
+        row[1] for row in connection.execute("PRAGMA table_info(news)")
+    }
+    connection.close()
+
+    raw_dir = tmp_path / "empty-raw"
+    summaries_dir = tmp_path / "empty-summaries"
+    raw_dir.mkdir()
+    summaries_dir.mkdir()
+    migrated = news_domain.ingest(
+        db_path=db_path,
+        news_root=tmp_path,
+        news_sources_path=tmp_path / "missing-news-sources.json",
+        ir_registry_path=tmp_path / "missing-ir-registry.json",
+        explicit_raw=raw_dir,
+        explicit_summaries=summaries_dir,
+    )
+    assert migrated.stats["eligible"] == 0
+
+    prep = prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+    assert prep["news_inserted_count"] == 1
+
+
+def test_unsupported_schema_error_does_not_claim_ingest_can_fix_it(
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "malformed-schema.json"
+    _write_payload(
+        payload_path,
+        {
+            "news": [
+                {
+                    "headline": "Malformed schema story",
+                    "datetime": _timestamp(7),
+                    "source": "Reuters",
+                    "url": "https://example.com/malformed",
+                    "summary": "Provider summary.",
+                }
+            ]
+        },
+    )
+    db_path = tmp_path / "malformed.db"
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        CREATE TABLE news (
+            article_key TEXT,
+            published_at INTEGER NOT NULL,
+            published_at_raw TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            summary TEXT,
+            source TEXT NOT NULL,
+            url TEXT NOT NULL,
+            section TEXT,
+            collected_at TEXT NOT NULL
+        )
+        """
+    )
+
+    connection.commit()
+    connection.close()
+    _collect(tmp_path, payload_path)
+
+    with pytest.raises(RuntimeError, match="unsupported schema") as exc_info:
+        prepare_evidence(tmp_path, run_date=RUN_DATE, db_path=db_path)
+
+    message = str(exc_info.value)
+    assert "article_key is not the primary key" in message
+    assert "repair or recreate" in message
+    assert "ingest_news" not in message
+
+    result = prep_command(
+        run_date=RUN_DATE,
+        settings=HarnessSettings(workspace_root=tmp_path, invest_db=db_path),
+    )
+    command_message = result.stderr.decode("utf-8")
+    assert result.exit_code == 1
+    assert "repair or recreate the malformed news database" in command_message
+    assert "ingest_news" not in command_message

--- a/tests/test_harness/test_morning_brief.py
+++ b/tests/test_harness/test_morning_brief.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import tempfile
 import unittest
-from datetime import date
+from datetime import UTC, date
 from pathlib import Path
 from unittest.mock import patch
 
@@ -38,7 +38,6 @@ from harness.portfolio_state import (
     sync_portfolio,
     write_json,
 )
-
 
 FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "morning_brief"
 RUN_DATE = date(2026, 4, 8)
@@ -452,15 +451,29 @@ class MorningBriefTests(unittest.TestCase):
         self.assertIn("manifest:", result.stdout)
         report_dir = self.workspace / "workspace" / "reports" / "03-daily-news" / RUN_DATE.isoformat()
         self.assertTrue(report_dir.is_dir())
+        calls = call_log.read_text(encoding="utf-8").splitlines()
         self.assertEqual(
-            call_log.read_text(encoding="utf-8").splitlines(),
+            calls[:4],
             [
                 f"portfolio sync --date {RUN_DATE.isoformat()} --holdings-source {FIXTURE_DIR / 'holdings.csv'} --transactions-source {FIXTURE_DIR / 'transactions.csv'} --watchlist-source {FIXTURE_DIR / 'watchlist.json'}",
                 f"brief filings --date {RUN_DATE.isoformat()}",
                 f"brief earnings --date {RUN_DATE.isoformat()} --provider finnhub --source {FIXTURE_DIR / 'market-data.json'}",
                 f"brief market --date {RUN_DATE.isoformat()} --provider finnhub --source {FIXTURE_DIR / 'market-data.json'}",
-                f"brief prep --date {RUN_DATE.isoformat()}",
             ],
+        )
+        self.assertEqual(len(calls), 6)
+        self.assertTrue(calls[4].startswith("news ingest --raw-dir "))
+        self.assertIn(" --summaries-dir ", calls[4])
+        self.assertIn(
+            f" --db {self.workspace / 'workspace' / 'data' / '04-database' / 'invest.db'}",
+            calls[4],
+        )
+        self.assertIn(" --news-sources ", calls[4])
+        self.assertIn(" --ir-registry ", calls[4])
+        self.assertIn(" --report ", calls[4])
+        self.assertEqual(
+            calls[5],
+            f"brief prep --date {RUN_DATE.isoformat()} --db {self.workspace / 'workspace' / 'data' / '04-database' / 'invest.db'}",
         )
 
     def test_wrapper_skips_news_collection_when_env_set(self) -> None:
@@ -507,7 +520,12 @@ class MorningBriefTests(unittest.TestCase):
         self.assertIn("News collection (skipped)", result.stdout)
         # No openclaw agent or news-related minerva calls in the log.
         logged_commands = call_log.read_text(encoding="utf-8")
-        self.assertNotIn("openclaw", logged_commands)
+        self.assertFalse(
+            any(
+                line.startswith("openclaw ")
+                for line in logged_commands.splitlines()
+            )
+        )
         self.assertNotIn("extract-files", logged_commands)
 
 
@@ -607,9 +625,9 @@ class MorningBriefTests(unittest.TestCase):
         self.assertIn("XLK", symbols)
 
     def test_normalize_news_events_filters_by_time(self) -> None:
-        from datetime import datetime as _dt, timezone as _tz
+        from datetime import datetime as _dt
         # Use timestamps relative to RUN_DATE so the 18h window works
-        run_date_midnight = int(_dt.combine(RUN_DATE, _dt.min.time(), tzinfo=_tz.utc).timestamp())
+        run_date_midnight = int(_dt.combine(RUN_DATE, _dt.min.time(), tzinfo=UTC).timestamp())
         recent_ts = run_date_midnight + 6 * 3600  # 6 AM on run date
         old_ts = run_date_midnight - 24 * 3600  # 24 hours before run date (outside 18h window)
 
@@ -625,8 +643,8 @@ class MorningBriefTests(unittest.TestCase):
         self.assertEqual(events[0]["news_source"], "Reuters")
 
     def test_normalize_company_news_events(self) -> None:
-        from datetime import datetime as _dt, timezone as _tz
-        run_date_midnight = int(_dt.combine(RUN_DATE, _dt.min.time(), tzinfo=_tz.utc).timestamp())
+        from datetime import datetime as _dt
+        run_date_midnight = int(_dt.combine(RUN_DATE, _dt.min.time(), tzinfo=UTC).timestamp())
         recent_ts = run_date_midnight + 6 * 3600
         news_items = [
             {
@@ -689,7 +707,7 @@ class MorningBriefTests(unittest.TestCase):
         (self.workspace / "empty-ir.json").write_text("[]", encoding="utf-8")
         collect_market(self.workspace, run_date=RUN_DATE, source=str(market_file))
 
-        summary = prepare_evidence(self.workspace, run_date=RUN_DATE)
+        prepare_evidence(self.workspace, run_date=RUN_DATE)
         run_paths = ensure_daily_run_layout(self.workspace, RUN_DATE)
         prepared = load_json(run_paths.structured_dir / "prepared-evidence.json", default={})
 

--- a/tests/test_harness/test_morning_brief_synthesis.py
+++ b/tests/test_harness/test_morning_brief_synthesis.py
@@ -502,6 +502,12 @@ def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
     assert auto_by_title["WATCH schedules an investor day"]["routing_class"] == (
         "auto_portfolio_watchlist"
     )
+    assert auto_by_title["WATCH schedules an investor day"][
+        "article_candidate_class"
+    ] == "secondary_prepared_company_news"
+    assert auto_by_title["WATCH schedules an investor day"]["evidence_depth"] == (
+        "summary_only"
+    )
     assert auto_by_title["SPY moved 1.25%"]["routing_class"] == "auto_market_move"
     assert auto_by_title["Employment report due at 08:30 ET"]["routing_class"] == (
         "other_auto_event"
@@ -613,12 +619,16 @@ def test_model_cannot_put_a_preamble_between_collection_and_market() -> None:
             "omitted required Portfolio / Watchlist Events section",
         ),
         (
-            "*Portfolio / Watchlist Events*\n• Event\n\n"
-            "*Worth Knowing Today*\n• Article",
+            (
+                "*Portfolio / Watchlist Events*\n• Event\n\n"
+                "*Worth Knowing Today*\n• Article"
+            ),
             False,
             False,
-            "included Portfolio / Watchlist Events section without "
-            "auto_portfolio_watchlist evidence",
+            (
+                "included Portfolio / Watchlist Events section without "
+                "auto_portfolio_watchlist evidence"
+            ),
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- persist Finnhub `market-news` and `company-news` summaries into the canonical `news` table after crawler ingestion
- deduplicate provider records by canonical URL and reconcile them to richer crawler rows when available
- preserve all portfolio/watchlist security associations when one article is returned for multiple companies
- merge persisted rows with prepared-event routing metadata so synthesis and source accounting count each article once
- label Finnhub rows as summary-only evidence rather than full-text reporting
- honor `INVEST_DB`, migrate the news schema before persistence, and keep backdated runs attached to their brief date

## Pipeline ordering

Finnhub persistence intentionally runs during evidence preparation, after crawler ingestion. Persisting during market collection would put thin provider summaries in the crawler dedup list and could suppress richer full-text collection later in the same run.

## Stack

1. Post-ingest synthesis foundation (#70)
2. Evidence routing and section ordering (#71)
3. Deterministic source accounting (#72)
4. **This PR:** Finnhub persistence

This PR is based on `feat/morning-brief-source-accounting`; merge the stack from the bottom up.

## Verification

- `uv run pytest -q` — 450 passed
- changed-file Ruff checks — passed
- Python `compileall` — passed
- `bash -n` on both morning-brief scripts — passed
- `git diff --check` — passed
- replayed the July 24 market payload against a copy of `invest.db`:
  - 53 Finnhub rows inserted; 7 duplicate URLs reconciled
  - source line: 97 article records — Reuters 35, Yahoo 19, CNBC 14, Economist 4, WSJ 19, Company IR 5, BLS/BEA/Fed 1; plus 13 market-price observations
