### PR TITLE
feat(brief): add post-ingest Sol synthesis

### DIFF
--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 RUN_DATE="${1:-$(date +%F)}"
+WORKSPACE_ROOT="${MINERVA_WORKSPACE_ROOT:-${ROOT_DIR}/hard-disk}"
 MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-900}"
 MINERVA_WEBFETCH_TIMEOUT="${MINERVA_WEBFETCH_TIMEOUT:-300}"
 MINERVA_MAX_COLLECTORS="${MINERVA_MAX_COLLECTORS:-8}"
@@ -28,8 +29,8 @@ done
 # raw directory for summarization and the single SQLite writer.
 NEWS_RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/morning-brief-${RUN_DATE}-XXXXXX")"
 NEWS_SOURCE_ROOTS_DIR="${NEWS_RUN_DIR}/sources"
-REPORT_DIR="${ROOT_DIR}/hard-disk/reports/03-daily-news/${RUN_DATE}"
-INVEST_DB="${INVEST_DB:-${ROOT_DIR}/hard-disk/data/04-database/invest.db}"
+REPORT_DIR="${WORKSPACE_ROOT}/reports/03-daily-news/${RUN_DATE}"
+INVEST_DB="${INVEST_DB:-${WORKSPACE_ROOT}/data/04-database/invest.db}"
 INGEST_OK=0
 cleanup_run_dir() {
   # Remove the temp run dir only when ingest into invest.db succeeded.
@@ -41,7 +42,7 @@ cleanup_run_dir() {
 trap cleanup_run_dir EXIT
 
 export UV_CACHE_DIR="${UV_CACHE_DIR:-${ROOT_DIR}/.uv-cache}"
-export MINERVA_WORKSPACE_ROOT="${MINERVA_WORKSPACE_ROOT:-${ROOT_DIR}/hard-disk}"
+export MINERVA_WORKSPACE_ROOT="${WORKSPACE_ROOT}"
 
 MINERVA_RUNNER="${MINERVA_RUNNER:-uv run minerva}"
 MINERVA_BRIEF_EARNINGS_PROVIDER="${MINERVA_BRIEF_EARNINGS_PROVIDER:-finnhub}"

--- a/scripts/run_morning_brief_with_synthesis.sh
+++ b/scripts/run_morning_brief_with_synthesis.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Load API keys for both child processes before strict mode.  The existing
-# collection script does this too, but exports made in a child do not propagate
-# back to this wrapper.
+# Load the shell environment needed by the collection pipeline and OpenClaw
+# before strict mode. The collection script does this too, but exports made in
+# a child do not propagate back to this wrapper.
 source ~/.zshrc >/dev/null 2>&1 || true
 
 set -euo pipefail
@@ -26,7 +26,7 @@ export MINERVA_WORKSPACE_ROOT="${WORKSPACE_ROOT}"
 export INVEST_DB
 
 # Collection, extraction, SQLite ingestion, and evidence preparation must all
-# finish successfully before the first Sol call. Retry the complete wrapper
+# finish successfully before the first OpenClaw Sol turn. Retry the complete wrapper
 # once on a non-zero exit or a missing/empty rendered evidence directory.
 # Noisy output stays out of cron stdout, which is reserved for the final brief.
 pipeline_status=1

--- a/scripts/run_morning_brief_with_synthesis.sh
+++ b/scripts/run_morning_brief_with_synthesis.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Load API keys for both child processes before strict mode.  The existing
+# collection script does this too, but exports made in a child do not propagate
+# back to this wrapper.
+source ~/.zshrc >/dev/null 2>&1 || true
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+RUN_DATE="${1:-$(date +%F)}"
+WORKSPACE_ROOT="${MINERVA_WORKSPACE_ROOT:-${ROOT_DIR}/hard-disk}"
+REPORT_DIR="${WORKSPACE_ROOT}/reports/03-daily-news/${RUN_DATE}"
+INVEST_DB="${INVEST_DB:-${WORKSPACE_ROOT}/data/04-database/invest.db}"
+PREPARED_PATH="${REPORT_DIR}/data/structured/prepared-evidence.json"
+RENDERED_DIR="${REPORT_DIR}/data/rendered"
+OUTPUT_PATH="${REPORT_DIR}/notes/slack-brief.md"
+PIPELINE_LOG="${MINERVA_MORNING_BRIEF_LOG:-${TMPDIR:-/tmp}/minerva-morning-brief-pipeline-${RUN_DATE}.log}"
+SYNTHESIS_LOG="${MINERVA_MORNING_BRIEF_SYNTHESIS_LOG:-${TMPDIR:-/tmp}/minerva-morning-brief-synthesis-${RUN_DATE}.log}"
+PIPELINE_SCRIPT="${MINERVA_MORNING_BRIEF_PIPELINE_SCRIPT:-${ROOT_DIR}/scripts/run_morning_brief.sh}"
+SYNTHESIS_RUNNER="${MINERVA_SYNTHESIS_RUNNER:-uv run python -m harness.morning_brief_synthesis}"
+SYNTHESIS_MODEL="${MINERVA_BRIEF_SYNTHESIS_MODEL:-gpt-5.6-sol}"
+
+mkdir -p "$(dirname "${PIPELINE_LOG}")" "$(dirname "${SYNTHESIS_LOG}")"
+export MINERVA_WORKSPACE_ROOT="${WORKSPACE_ROOT}"
+export INVEST_DB
+
+# Collection, extraction, SQLite ingestion, and evidence preparation must all
+# finish successfully before the first Sol call. Retry the complete wrapper
+# once on a non-zero exit or a missing/empty rendered evidence directory.
+# Noisy output stays out of cron stdout, which is reserved for the final brief.
+pipeline_status=1
+for attempt in 1 2; do
+  printf '\n=== pipeline attempt %s ===\n' "${attempt}" >>"${PIPELINE_LOG}"
+  set +e
+  bash "${PIPELINE_SCRIPT}" "${RUN_DATE}" >>"${PIPELINE_LOG}" 2>&1
+  pipeline_status=$?
+  set -e
+  if [[ "${pipeline_status}" -eq 0 ]] && [[ -d "${RENDERED_DIR}" ]] && find "${RENDERED_DIR}" -maxdepth 1 -type f -print -quit | grep -q .; then
+    break
+  fi
+  pipeline_status=1
+done
+if [[ "${pipeline_status}" -ne 0 ]]; then
+  echo "morning-brief collection pipeline failed twice or produced no rendered evidence; Sol was not invoked" >&2
+  echo "pipeline log: ${PIPELINE_LOG}" >&2
+  tail -n 40 "${PIPELINE_LOG}" >&2 || true
+  exit 1
+fi
+
+IFS=' ' read -r -a SYNTHESIS_RUNNER_ARR <<< "${SYNTHESIS_RUNNER}"
+set +e
+"${SYNTHESIS_RUNNER_ARR[@]}" \
+  --date "${RUN_DATE}" \
+  --workspace-root "${WORKSPACE_ROOT}" \
+  --db "${INVEST_DB}" \
+  --prepared-evidence "${PREPARED_PATH}" \
+  --output "${OUTPUT_PATH}" \
+  --model "${SYNTHESIS_MODEL}" 2>"${SYNTHESIS_LOG}"
+synthesis_status=$?
+set -e
+if [[ "${synthesis_status}" -ne 0 ]]; then
+  echo "morning-brief synthesis failed with status ${synthesis_status}" >&2
+  echo "synthesis log: ${SYNTHESIS_LOG}" >&2
+  tail -n 40 "${SYNTHESIS_LOG}" >&2 || true
+  exit "${synthesis_status}"
+fi
+
+rm -f "${PIPELINE_LOG}" "${SYNTHESIS_LOG}"

--- a/src/harness/morning_brief_synthesis.py
+++ b/src/harness/morning_brief_synthesis.py
@@ -1,0 +1,699 @@
+"""Post-ingest, two-pass model synthesis for the daily morning brief.
+
+The collection pipeline owns all network/tool work and SQLite ingestion.  This
+module starts at the resulting SQLite database and prepared evidence file.  It
+makes two plain model calls: a title-only broad shortlist, followed by final
+synthesis from evidence fetched only for validated shortlist IDs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from harness.commands.extract import _generate_answer
+from harness.config import get_settings
+
+DEFAULT_MODEL = "gpt-5.6-sol"
+DEFAULT_REASONING = "high"
+DEFAULT_PASS_1_TOKENS = 16_384
+DEFAULT_PASS_2_TOKENS = 12_000
+MAX_ARTICLE_CONTENT_CHARS = 4_000
+MAX_EVENT_DETAIL_CHARS = 2_000
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ModelCall = Callable[..., str]
+
+
+class SynthesisError(RuntimeError):
+    """Raised when deterministic synthesis prerequisites or outputs are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateTitle:
+    """One stable title/headline candidate shown to the first model pass."""
+
+    id: str
+    kind: str
+    title: str
+    source: str
+    published: str
+    article_key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict, compare=False, repr=False)
+
+    def title_record(self) -> dict[str, Any]:
+        """Return the compact, summary-free representation for pass 1."""
+        record: dict[str, Any] = {
+            "id": self.id,
+            "kind": self.kind,
+            "source": self.source,
+            "published": self.published,
+            "title": self.title,
+        }
+        if self.article_key is not None:
+            record["article_key"] = self.article_key
+        for key in (
+            "event_type",
+            "security_id",
+            "relationship",
+            "portfolio_role",
+            "group",
+            "release_time",
+        ):
+            value = self.metadata.get(key)
+            if value not in (None, ""):
+                record[key] = value
+        return record
+
+
+def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateTitle]:
+    """Read every article first collected on ``run_date`` without reading its body.
+
+    ``collected_at`` is canonical ISO text written by ``ingest_news.py``.  Its
+    leading calendar date is the collection run's date even when the timestamp
+    includes an offset, so a prefix comparison avoids silently shifting a local
+    collection into another UTC date.
+    """
+    if not db_path.is_file():
+        raise SynthesisError(f"news database does not exist: {db_path}")
+
+    uri = f"file:{db_path.resolve()}?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+    except sqlite3.Error as exc:
+        raise SynthesisError(f"could not open news database read-only: {exc}") from exc
+
+    connection.row_factory = sqlite3.Row
+    try:
+        rows = connection.execute(
+            """
+            SELECT article_key, source, published_at, published_at_raw, title
+            FROM news
+            WHERE substr(collected_at, 1, 10) = ?
+            ORDER BY source COLLATE NOCASE,
+                     published_at,
+                     title COLLATE NOCASE,
+                     article_key
+            """,
+            (run_date.isoformat(),),
+        ).fetchall()
+    except sqlite3.Error as exc:
+        raise SynthesisError(f"could not query fresh news titles: {exc}") from exc
+    finally:
+        connection.close()
+
+    candidates: list[CandidateTitle] = []
+    for row in rows:
+        article_key = str(row["article_key"])
+        published_iso = _epoch_as_iso(row["published_at"])
+        published_raw = str(row["published_at_raw"] or "").strip()
+        candidates.append(
+            CandidateTitle(
+                id=f"article:{article_key}",
+                kind="article",
+                article_key=article_key,
+                source=str(row["source"]),
+                published=published_raw or published_iso,
+                title=str(row["title"]),
+                metadata={"published_at": published_iso},
+            )
+        )
+    return candidates
+
+
+def load_prepared_event_titles(prepared_path: Path, run_date: date) -> list[CandidateTitle]:
+    """Load compact prepared-evidence headlines and assign deterministic IDs."""
+    if not prepared_path.is_file():
+        raise SynthesisError(f"prepared evidence does not exist: {prepared_path}")
+    try:
+        payload = json.loads(prepared_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SynthesisError(f"could not read prepared evidence: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SynthesisError("prepared evidence must be a JSON object")
+
+    universe_roles = _universe_role_map(payload.get("universe"))
+    events = payload.get("events", [])
+    if not isinstance(events, list):
+        raise SynthesisError("prepared evidence `events` must be a list")
+
+    candidates: list[CandidateTitle] = []
+    seen_ids: set[str] = set()
+    for raw_event in events:
+        if not isinstance(raw_event, dict):
+            continue
+        title = str(raw_event.get("headline") or raw_event.get("title") or "").strip()
+        event_date = str(raw_event.get("event_date") or run_date.isoformat()).strip()
+        if not title or event_date not in {"", run_date.isoformat()}:
+            continue
+        source = str(raw_event.get("source_name") or raw_event.get("source") or "prepared-evidence").strip()
+        security_id = str(raw_event.get("security_id") or raw_event.get("ticker") or "").strip()
+        stable_key = "|".join((source, security_id, title, event_date))
+        candidate_id = f"event:{hashlib.sha256(stable_key.encode('utf-8')).hexdigest()}"
+        if candidate_id in seen_ids:
+            continue
+        seen_ids.add(candidate_id)
+        metadata = dict(raw_event)
+        role = universe_roles.get(security_id.upper())
+        if role:
+            metadata["portfolio_role"] = role
+        candidates.append(
+            CandidateTitle(
+                id=candidate_id,
+                kind="event",
+                source=source,
+                published=event_date or run_date.isoformat(),
+                title=title,
+                metadata=metadata,
+            )
+        )
+
+    return sorted(
+        candidates,
+        key=lambda item: (
+            item.source.casefold(),
+            item.published,
+            item.title.casefold(),
+            item.id,
+        ),
+    )
+
+
+def build_title_universe(
+    db_path: Path, prepared_path: Path, run_date: date
+) -> list[CandidateTitle]:
+    """Build the complete, stable pass-1 universe (articles first, then events)."""
+    return query_fresh_article_titles(db_path, run_date) + load_prepared_event_titles(
+        prepared_path, run_date
+    )
+
+
+def build_shortlist_prompt(candidates: Sequence[CandidateTitle], run_date: date) -> str:
+    """Render the first-pass prompt containing every title and no article body."""
+    payload = {
+        "run_date": run_date.isoformat(),
+        "candidate_count": len(candidates),
+        "candidates": [candidate.title_record() for candidate in candidates],
+    }
+    return (
+        "You are Sol performing PASS 1 of a deterministic morning-brief workflow.\n"
+        "You have no tools and must not request tools, browse, or write files. The JSON below is the "
+        "complete title/headline universe for this run.\n\n"
+        "Select a BROAD shortlist for a long-only investor. Cast a wide net: retain anything plausibly "
+        "market-moving, company-specific, portfolio-relevant, useful as a read-through, materially "
+        "economic/political/geopolitical, or a significant scheduled event. Include relevant IR and "
+        "prepared-evidence events. Prefer false positives over false negatives at this stage. Source "
+        "balance must follow merit, not quotas. Do not draft, summarize, filter to a tiny final list, "
+        "or invent IDs.\n\n"
+        "Return exactly one strict JSON object and no markdown or commentary:\n"
+        '{"ids":["exact-stable-id", "..."]}\n\n'
+        "TITLE_UNIVERSE_JSON:\n"
+        f"{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}"
+    )
+
+
+def parse_shortlist_output(raw: str) -> list[str]:
+    """Parse common harmless wrappers around the required strict shortlist JSON."""
+    text = raw.strip()
+    if not text:
+        raise SynthesisError("pass 1 returned an empty response")
+
+    decoded_values: list[Any] = []
+    unwrapped = _strip_outer_code_fence(text)
+    for candidate_text in (unwrapped, text):
+        try:
+            decoded_values.append(json.loads(candidate_text))
+        except json.JSONDecodeError:
+            pass
+
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(text):
+        if character not in "[{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        decoded_values.append(value)
+
+    for value in decoded_values:
+        extracted = _extract_id_list(value)
+        if extracted is None:
+            continue
+        unique: list[str] = []
+        seen: set[str] = set()
+        for item in extracted:
+            identifier = ""
+            if isinstance(item, str):
+                identifier = item.strip()
+            elif isinstance(item, dict) and isinstance(item.get("id"), str):
+                identifier = item["id"].strip()
+            if identifier and identifier not in seen:
+                seen.add(identifier)
+                unique.append(identifier)
+        return unique
+
+    raise SynthesisError("pass 1 did not return a JSON shortlist with an `ids` array")
+
+
+def validate_shortlist_ids(
+    requested_ids: Sequence[str], candidates: Sequence[CandidateTitle]
+) -> list[str]:
+    """Drop unknown/duplicate IDs and return valid IDs in stable universe order."""
+    requested = set(requested_ids)
+    valid = [candidate.id for candidate in candidates if candidate.id in requested]
+    if candidates and not valid:
+        raise SynthesisError(
+            "pass 1 returned no valid IDs from the non-empty title universe"
+        )
+    return valid
+
+
+def query_shortlisted_evidence(
+    db_path: Path,
+    candidates: Sequence[CandidateTitle],
+    shortlist_ids: Sequence[str],
+    *,
+    max_content_chars: int = MAX_ARTICLE_CONTENT_CHARS,
+) -> list[dict[str, Any]]:
+    """Fetch summaries/bounded content only for validated shortlist candidates."""
+    candidate_by_id = {candidate.id: candidate for candidate in candidates}
+    selected = [candidate_by_id[item_id] for item_id in shortlist_ids]
+    selected_article_keys = [
+        candidate.article_key
+        for candidate in selected
+        if candidate.kind == "article" and candidate.article_key is not None
+    ]
+    article_rows = _query_article_evidence(db_path, selected_article_keys)
+
+    evidence: list[dict[str, Any]] = []
+    for candidate in selected:
+        if candidate.kind == "article":
+            row = article_rows.get(candidate.article_key or "")
+            if row is None:
+                raise SynthesisError(f"shortlisted article disappeared from SQLite: {candidate.id}")
+            summary = str(row["summary"] or "").strip()
+            content = str(row["content"] or "").strip()
+            if summary:
+                evidence_text = summary
+                evidence_kind = "summary"
+            else:
+                evidence_text = _bounded_text(content, max_content_chars)
+                evidence_kind = "bounded_content_fallback"
+            evidence.append(
+                {
+                    "id": candidate.id,
+                    "kind": "article",
+                    "article_key": candidate.article_key,
+                    "source": str(row["source"]),
+                    "published": str(row["published_at_raw"] or "").strip()
+                    or _epoch_as_iso(row["published_at"]),
+                    "title": str(row["title"]),
+                    "url": str(row["url"] or "").strip(),
+                    "section": str(row["section"] or "").strip(),
+                    "evidence_kind": evidence_kind,
+                    "evidence": evidence_text,
+                }
+            )
+        else:
+            evidence.append(_event_evidence(candidate))
+    return evidence
+
+
+def build_final_prompt(evidence: Sequence[dict[str, Any]], run_date: date) -> str:
+    """Render the second-pass prompt with all and only shortlisted evidence."""
+    payload = {
+        "run_date": run_date.isoformat(),
+        "shortlisted_count": len(evidence),
+        "evidence": list(evidence),
+    }
+    return (
+        "You are Sol performing PASS 2 of a deterministic morning-brief workflow.\n"
+        "You have no tools and must not request tools, browse, or write files. All available shortlisted "
+        "evidence is included below. Filter and rank it now; do not rely on outside facts.\n\n"
+        "Return ONLY the final Slack-formatted daily-news brief as plain text (Slack mrkdwn), with no "
+        "JSON, code fence, preamble, postscript, or file instructions. Use this section order:\n"
+        "1. *Worth Knowing Today* — required; ranked, concise news bullets.\n"
+        "2. *Portfolio / Watchlist Events* — optional; include only direct, material portfolio or "
+        "watchlist developments. Omit it entirely when none are supported.\n\n"
+        "Preserve source links using Slack links such as <https://example.com|Source> wherever a supplied "
+        "URL supports a claim. Use concise labels such as Reuters, WSJ, Economist, or TICKER IR rather "
+        "than internal source IDs. Rank and balance sources on merit; do not enforce quotas and do not repeat "
+        "the same development from multiple outlets. Never fabricate a fact, link, date, portfolio "
+        "relationship, or event. If evidence is thin, say so briefly rather than padding the brief.\n\n"
+        "SHORTLISTED_EVIDENCE_JSON:\n"
+        f"{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}"
+    )
+
+
+def normalize_final_brief(raw: str) -> str:
+    """Normalize harmless outer fencing and validate required plain-text sections."""
+    brief = _strip_outer_code_fence(raw.strip()).strip()
+    if not brief:
+        raise SynthesisError("pass 2 returned an empty brief")
+    if "```" in brief:
+        raise SynthesisError("pass 2 returned a code fence instead of plain Slack text")
+    try:
+        decoded = json.loads(brief)
+    except json.JSONDecodeError:
+        decoded = None
+    if isinstance(decoded, (dict, list)):
+        raise SynthesisError("pass 2 returned JSON instead of a text-only Slack brief")
+
+    worth_position = _section_heading_position(brief, "Worth Knowing Today")
+    portfolio_position = _section_heading_position(brief, "Portfolio / Watchlist Events")
+    if worth_position is None:
+        raise SynthesisError("pass 2 omitted required Worth Knowing Today section")
+    if portfolio_position is not None and worth_position >= portfolio_position:
+        raise SynthesisError("pass 2 returned the optional portfolio/watchlist section out of order")
+    return brief
+
+
+def synthesize_morning_brief(
+    *,
+    db_path: Path,
+    prepared_path: Path,
+    run_date: date,
+    model_call: ModelCall | None = None,
+    model: str = DEFAULT_MODEL,
+    reasoning: str = DEFAULT_REASONING,
+    output_path: Path | None = None,
+    retry_count: int = 1,
+) -> str:
+    """Run both in-memory model passes and optionally persist the final text artifact."""
+    candidates = build_title_universe(db_path, prepared_path, run_date)
+    call_model = model_call or _default_model_call
+    pass_1_prompt = build_shortlist_prompt(candidates, run_date)
+
+    shortlist_ids = _with_retries(
+        lambda: validate_shortlist_ids(
+            parse_shortlist_output(
+                call_model(
+                    prompt=pass_1_prompt,
+                    model=model,
+                    reasoning=reasoning,
+                    max_tokens=DEFAULT_PASS_1_TOKENS,
+                )
+            ),
+            candidates,
+        ),
+        attempts=retry_count + 1,
+        stage="pass 1 shortlist",
+    )
+    evidence = query_shortlisted_evidence(db_path, candidates, shortlist_ids)
+    pass_2_prompt = build_final_prompt(evidence, run_date)
+    brief = _with_retries(
+        lambda: normalize_final_brief(
+            call_model(
+                prompt=pass_2_prompt,
+                model=model,
+                reasoning=reasoning,
+                max_tokens=DEFAULT_PASS_2_TOKENS,
+            )
+        ),
+        attempts=retry_count + 1,
+        stage="pass 2 synthesis",
+    )
+
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(f"{brief}\n", encoding="utf-8")
+    return brief
+
+
+def _default_model_call(
+    *, prompt: str, model: str, reasoning: str, max_tokens: int
+) -> str:
+    settings = get_settings()
+    if not settings.openai_api_key:
+        raise SynthesisError("OPENAI_API_KEY is not set for morning-brief synthesis")
+    return _generate_answer(
+        prompt=prompt,
+        document_text="",
+        model=model,
+        max_tokens=max_tokens,
+        thinking=reasoning,
+        api_key=settings.openai_api_key,
+    )
+
+
+def _query_article_evidence(
+    db_path: Path, article_keys: Sequence[str]
+) -> dict[str, sqlite3.Row]:
+    if not article_keys:
+        return {}
+    uri = f"file:{db_path.resolve()}?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+    except sqlite3.Error as exc:
+        raise SynthesisError(f"could not open news database read-only: {exc}") from exc
+    connection.row_factory = sqlite3.Row
+    rows: dict[str, sqlite3.Row] = {}
+    try:
+        for start in range(0, len(article_keys), 500):
+            chunk = article_keys[start : start + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            query = (
+                "SELECT article_key, published_at, published_at_raw, title, content, summary, "
+                f"source, url, section FROM news WHERE article_key IN ({placeholders})"
+            )
+            for row in connection.execute(query, tuple(chunk)):
+                rows[str(row["article_key"])] = row
+    except sqlite3.Error as exc:
+        raise SynthesisError(f"could not query shortlisted news evidence: {exc}") from exc
+    finally:
+        connection.close()
+    return rows
+
+
+def _event_evidence(candidate: CandidateTitle) -> dict[str, Any]:
+    event = candidate.metadata
+    url = str(event.get("reference_url") or event.get("source_url") or "").strip()
+    summary = _first_nonempty_text(
+        event.get("summary"),
+        event.get("description"),
+        _nested_value(event, "metadata", "summary"),
+        _nested_value(event, "metadata", "description"),
+    )
+    compact_details: dict[str, Any] = {}
+    for key in (
+        "event_type",
+        "security_id",
+        "ticker",
+        "relationship",
+        "portfolio_role",
+        "group",
+        "status",
+        "timing",
+        "release_time",
+        "category",
+        "importance",
+        "form",
+        "change_pct",
+        "material",
+    ):
+        value = event.get(key)
+        if value not in (None, "", [], {}):
+            compact_details[key] = value
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        for key in (
+            "actual",
+            "estimate",
+            "previous",
+            "period",
+            "fiscal_period",
+            "fiscal_year",
+        ):
+            value = metadata.get(key)
+            if value not in (None, "", [], {}) and key not in compact_details:
+                compact_details[key] = value
+
+    return {
+        "id": candidate.id,
+        "kind": "event",
+        "source": candidate.source,
+        "published": candidate.published,
+        "title": candidate.title,
+        "url": url,
+        "details": compact_details,
+        "evidence_kind": "prepared_event",
+        "evidence": _bounded_text(summary, MAX_EVENT_DETAIL_CHARS),
+    }
+
+
+def _universe_role_map(raw_universe: Any) -> dict[str, str]:
+    if not isinstance(raw_universe, list):
+        return {}
+    roles: dict[str, str] = {}
+    for item in raw_universe:
+        if not isinstance(item, dict):
+            continue
+        security_id = str(item.get("security_id") or item.get("ticker") or "").strip().upper()
+        role = str(item.get("source_kind") or item.get("relationship") or "").strip()
+        if security_id and role:
+            roles[security_id] = role
+    return roles
+
+
+def _epoch_as_iso(raw_epoch: Any) -> str:
+    try:
+        epoch = int(raw_epoch)
+        return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+    except (TypeError, ValueError, OSError, OverflowError):
+        return ""
+
+
+def _bounded_text(text: str, limit: int) -> str:
+    normalized = text.strip()
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[:limit].rstrip()}\n[content truncated deterministically]"
+
+
+def _first_nonempty_text(*values: Any) -> str:
+    for value in values:
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _nested_value(payload: dict[str, Any], parent: str, child: str) -> Any:
+    nested = payload.get(parent)
+    return nested.get(child) if isinstance(nested, dict) else None
+
+
+def _extract_id_list(value: Any) -> list[Any] | None:
+    if isinstance(value, list):
+        return value
+    if not isinstance(value, dict):
+        return None
+    normalized = {
+        str(key).casefold().replace("-", "_"): item for key, item in value.items()
+    }
+    for key in ("ids", "shortlist_ids", "selected_ids"):
+        selected = normalized.get(key)
+        if isinstance(selected, list):
+            return selected
+
+    split_ids: list[Any] = []
+    found_split_list = False
+    for key in ("article_ids", "event_ids"):
+        selected = normalized.get(key)
+        if isinstance(selected, list):
+            found_split_list = True
+            split_ids.extend(selected)
+    return split_ids if found_split_list else None
+
+
+def _strip_outer_code_fence(text: str) -> str:
+    match = re.fullmatch(
+        r"\s*```[^\n`]*\n(.*?)\n?```\s*",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    return match.group(1).strip() if match else text
+
+
+def _section_heading_position(text: str, heading: str) -> int | None:
+    pattern = re.compile(
+        rf"(?im)^\s*(?:#{{1,3}}\s*)?(?:\*{{1,2}})?{re.escape(heading)}"
+        rf"(?:\*{{1,2}})?\s*:?\s*$"
+    )
+    match = pattern.search(text)
+    return match.start() if match else None
+
+
+def _with_retries(
+    operation: Callable[[], Any], *, attempts: int, stage: str
+) -> Any:
+    if attempts < 1:
+        raise ValueError("attempts must be at least one")
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except Exception as exc:  # model/API and output-validation errors retry once
+            last_error = exc
+            if attempt < attempts:
+                print(
+                    f"morning-brief synthesis: {stage} attempt {attempt} failed; retrying once: {exc}",
+                    file=sys.stderr,
+                )
+    assert last_error is not None
+    raise SynthesisError(
+        f"{stage} failed after {attempts} attempt{'s' if attempts != 1 else ''}: {last_error}"
+    ) from last_error
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", required=True, help="Morning-brief run date (YYYY-MM-DD).")
+    parser.add_argument("--db", type=Path, help="Path to invest.db.")
+    parser.add_argument(
+        "--prepared-evidence", type=Path, help="Path to prepared-evidence.json."
+    )
+    parser.add_argument("--output", type=Path, help="Final Slack brief output path.")
+    parser.add_argument("--workspace-root", type=Path, help="Minerva hard-disk workspace root.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Pure model-call model name.")
+    return parser
+
+
+def main(argv: list[str] | None = None, *, model_call: ModelCall | None = None) -> int:
+    """CLI entry point; stdout is reserved exclusively for the final Slack brief."""
+    args = _build_parser().parse_args(argv)
+    try:
+        run_date = date.fromisoformat(args.date)
+    except ValueError:
+        print(f"invalid --date value: {args.date!r}", file=sys.stderr)
+        return 2
+
+    workspace_root = (
+        args.workspace_root
+        or Path(os.getenv("MINERVA_WORKSPACE_ROOT", REPO_ROOT / "hard-disk"))
+    ).resolve()
+    db_path = (
+        args.db
+        or Path(
+            os.getenv(
+                "INVEST_DB", workspace_root / "data" / "04-database" / "invest.db"
+            )
+        )
+    ).resolve()
+    report_root = workspace_root / "reports" / "03-daily-news" / run_date.isoformat()
+    prepared_path = (
+        args.prepared_evidence
+        or report_root / "data" / "structured" / "prepared-evidence.json"
+    ).resolve()
+    output_path = (args.output or report_root / "notes" / "slack-brief.md").resolve()
+
+    try:
+        brief = synthesize_morning_brief(
+            db_path=db_path,
+            prepared_path=prepared_path,
+            run_date=run_date,
+            model_call=model_call,
+            model=args.model,
+            output_path=output_path,
+        )
+    except Exception as exc:
+        print(f"morning-brief synthesis failed: {exc}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(f"{brief}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/harness/morning_brief_synthesis.py
+++ b/src/harness/morning_brief_synthesis.py
@@ -1,9 +1,10 @@
-"""Post-ingest, two-pass model synthesis for the daily morning brief.
+"""Post-ingest, two-pass OpenClaw synthesis for the daily morning brief.
 
-The collection pipeline owns all network/tool work and SQLite ingestion.  This
-module starts at the resulting SQLite database and prepared evidence file.  It
-makes two plain model calls: a title-only broad shortlist, followed by final
-synthesis from evidence fetched only for validated shortlist IDs.
+The collection pipeline owns all network/tool work and SQLite ingestion. This
+module starts at the resulting SQLite database and prepared evidence file. It
+runs two OpenClaw main-agent turns in one dedicated session: a title-only broad
+shortlist, followed by final synthesis from evidence fetched only for validated
+shortlist IDs.
 """
 
 from __future__ import annotations
@@ -14,19 +15,16 @@ import json
 import os
 import re
 import sqlite3
+import subprocess
 import sys
+import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
-from harness.commands.extract import _generate_answer
-from harness.config import get_settings
-
 DEFAULT_MODEL = "gpt-5.6-sol"
 DEFAULT_REASONING = "high"
-DEFAULT_PASS_1_TOKENS = 16_384
-DEFAULT_PASS_2_TOKENS = 12_000
 MAX_ARTICLE_CONTENT_CHARS = 4_000
 MAX_EVENT_DETAIL_CHARS = 2_000
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -206,8 +204,9 @@ def build_shortlist_prompt(candidates: Sequence[CandidateTitle], run_date: date)
     }
     return (
         "You are Sol performing PASS 1 of a deterministic morning-brief workflow.\n"
-        "You have no tools and must not request tools, browse, or write files. The JSON below is the "
-        "complete title/headline universe for this run.\n\n"
+        "For this turn, DO NOT use or call any tools. DO NOT browse, search, or fetch anything. "
+        "DO NOT read, create, edit, or write any files. Work only from this message and reply "
+        "directly. The JSON below is the complete title/headline universe for this run.\n\n"
         "Select a BROAD shortlist for a long-only investor. Cast a wide net: retain anything plausibly "
         "market-moving, company-specific, portfolio-relevant, useful as a read-through, materially "
         "economic/political/geopolitical, or a significant scheduled event. Include relevant IR and "
@@ -338,8 +337,11 @@ def build_final_prompt(evidence: Sequence[dict[str, Any]], run_date: date) -> st
     }
     return (
         "You are Sol performing PASS 2 of a deterministic morning-brief workflow.\n"
-        "You have no tools and must not request tools, browse, or write files. All available shortlisted "
-        "evidence is included below. Filter and rank it now; do not rely on outside facts.\n\n"
+        "For this turn, DO NOT use or call any tools. DO NOT browse, search, or fetch anything. "
+        "DO NOT read, create, edit, or write any files. Work only from this message and reply "
+        "directly. Even though the prior pass is visible in this session, all available shortlisted "
+        "evidence is included below. Filter and rank it now; do not rely on outside facts or prior-pass "
+        "titles that are absent from this evidence.\n\n"
         "Return ONLY the final Slack-formatted daily-news brief as plain text (Slack mrkdwn), with no "
         "JSON, code fence, preamble, postscript, or file instructions. Use this section order:\n"
         "1. *Worth Knowing Today* — required; ranked, concise news bullets.\n"
@@ -386,12 +388,14 @@ def synthesize_morning_brief(
     model_call: ModelCall | None = None,
     model: str = DEFAULT_MODEL,
     reasoning: str = DEFAULT_REASONING,
+    session_key: str | None = None,
     output_path: Path | None = None,
     retry_count: int = 1,
 ) -> str:
-    """Run both in-memory model passes and optionally persist the final text artifact."""
+    """Run both OpenClaw turns and optionally persist the final text artifact."""
     candidates = build_title_universe(db_path, prepared_path, run_date)
     call_model = model_call or _default_model_call
+    active_session_key = _resolve_session_key(session_key, run_date)
     pass_1_prompt = build_shortlist_prompt(candidates, run_date)
 
     shortlist_ids = _with_retries(
@@ -401,7 +405,7 @@ def synthesize_morning_brief(
                     prompt=pass_1_prompt,
                     model=model,
                     reasoning=reasoning,
-                    max_tokens=DEFAULT_PASS_1_TOKENS,
+                    session_key=active_session_key,
                 )
             ),
             candidates,
@@ -417,7 +421,7 @@ def synthesize_morning_brief(
                 prompt=pass_2_prompt,
                 model=model,
                 reasoning=reasoning,
-                max_tokens=DEFAULT_PASS_2_TOKENS,
+                session_key=active_session_key,
             )
         ),
         attempts=retry_count + 1,
@@ -430,20 +434,130 @@ def synthesize_morning_brief(
     return brief
 
 
+def _resolve_session_key(session_key: str | None, run_date: date) -> str:
+    if session_key is None:
+        return f"daily-news-sol-{run_date.isoformat()}-{uuid.uuid4().hex[:12]}"
+    resolved = session_key.strip()
+    if not resolved:
+        raise SynthesisError("--session-key must not be empty")
+    return resolved
+
+
 def _default_model_call(
-    *, prompt: str, model: str, reasoning: str, max_tokens: int
+    *, prompt: str, model: str, reasoning: str, session_key: str
 ) -> str:
-    settings = get_settings()
-    if not settings.openai_api_key:
-        raise SynthesisError("OPENAI_API_KEY is not set for morning-brief synthesis")
-    return _generate_answer(
-        prompt=prompt,
-        document_text="",
-        model=model,
-        max_tokens=max_tokens,
-        thinking=reasoning,
-        api_key=settings.openai_api_key,
-    )
+    command = [
+        "openclaw",
+        "agent",
+        "--agent",
+        "main",
+        "--model",
+        model,
+        "--thinking",
+        reasoning,
+        "--json",
+        "--session-key",
+        session_key,
+        "--message",
+        prompt,
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise SynthesisError(f"could not start OpenClaw agent command: {exc}") from exc
+
+    if completed.returncode != 0:
+        diagnostic = completed.stderr.strip() or completed.stdout.strip()
+        if diagnostic:
+            diagnostic = _bounded_text(diagnostic, 2_000)
+            detail = f": {diagnostic}"
+        else:
+            detail = " (no diagnostic output)"
+        raise SynthesisError(
+            f"OpenClaw agent command exited with status {completed.returncode}{detail}"
+        )
+    return parse_openclaw_json_output(completed.stdout)
+
+
+def parse_openclaw_json_output(raw: str) -> str:
+    """Extract visible assistant text from top-level or Gateway-nested payloads."""
+    if not raw.strip():
+        raise SynthesisError("OpenClaw agent returned empty JSON stdout")
+    try:
+        response = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SynthesisError(
+            f"OpenClaw agent returned invalid JSON stdout at line {exc.lineno}, "
+            f"column {exc.colno}: {exc.msg}"
+        ) from exc
+    if not isinstance(response, dict):
+        raise SynthesisError("OpenClaw agent JSON stdout must be an object")
+
+    result = response.get("result")
+    result_object = result if isinstance(result, dict) else None
+    for container in (response, result_object):
+        if container is None:
+            continue
+        status = container.get("status")
+        if isinstance(status, str) and status.casefold() not in {
+            "ok",
+            "success",
+            "completed",
+        }:
+            detail = _openclaw_error_detail(response, result_object)
+            suffix = f": {detail}" if detail else ""
+            raise SynthesisError(f"OpenClaw agent returned status {status!r}{suffix}")
+
+    if "payloads" in response:
+        payloads = response["payloads"]
+    elif result_object is not None and "payloads" in result_object:
+        payloads = result_object["payloads"]
+    else:
+        detail = _openclaw_error_detail(response, result_object)
+        suffix = f": {detail}" if detail else ""
+        raise SynthesisError(f"OpenClaw agent JSON contained no payloads{suffix}")
+    if not isinstance(payloads, list):
+        raise SynthesisError("OpenClaw agent `payloads` must be a list")
+
+    texts: list[str] = []
+    for index, payload in enumerate(payloads):
+        if not isinstance(payload, dict):
+            raise SynthesisError(
+                f"OpenClaw agent payload {index} must be a JSON object"
+            )
+        text = payload.get("text")
+        if payload.get("isError") is True:
+            detail = text.strip() if isinstance(text, str) else "unknown agent error"
+            raise SynthesisError(f"OpenClaw agent returned an error payload: {detail}")
+        if payload.get("isReasoning") is True:
+            continue
+        if isinstance(text, str) and text.strip():
+            texts.append(text.strip())
+    if not texts:
+        raise SynthesisError("OpenClaw agent returned no visible text payload")
+    return "\n\n".join(texts)
+
+
+def _openclaw_error_detail(
+    response: dict[str, Any], result: dict[str, Any] | None
+) -> str:
+    for container in (result, response):
+        if container is None:
+            continue
+        for key in ("errorMessage", "error", "summary", "message"):
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return _bounded_text(value.strip(), 2_000)
+            if isinstance(value, dict) and value:
+                return _bounded_text(
+                    json.dumps(value, ensure_ascii=False, sort_keys=True), 2_000
+                )
+    return ""
 
 
 def _query_article_evidence(
@@ -624,7 +738,7 @@ def _with_retries(
     for attempt in range(1, attempts + 1):
         try:
             return operation()
-        except Exception as exc:  # model/API and output-validation errors retry once
+        except Exception as exc:  # OpenClaw and output-validation errors retry once
             last_error = exc
             if attempt < attempts:
                 print(
@@ -646,7 +760,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--output", type=Path, help="Final Slack brief output path.")
     parser.add_argument("--workspace-root", type=Path, help="Minerva hard-disk workspace root.")
-    parser.add_argument("--model", default=DEFAULT_MODEL, help="Pure model-call model name.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="OpenClaw model override.")
+    parser.add_argument(
+        "--session-key",
+        help=(
+            "OpenClaw session key shared by both passes. By default, generate a unique "
+            "daily-news-sol-<date>-... key."
+        ),
+    )
     return parser
 
 
@@ -685,6 +806,7 @@ def main(argv: list[str] | None = None, *, model_call: ModelCall | None = None) 
             run_date=run_date,
             model_call=model_call,
             model=args.model,
+            session_key=args.session_key,
             output_path=output_path,
         )
     except Exception as exc:

--- a/tests/test_harness/test_morning_brief.py
+++ b/tests/test_harness/test_morning_brief.py
@@ -448,11 +448,9 @@ class MorningBriefTests(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        # V2 prints output paths relative to ROOT_DIR/hard-disk, not MINERVA_WORKSPACE_ROOT.
         self.assertIn("prepared_evidence:", result.stdout)
         self.assertIn("manifest:", result.stdout)
-        # V2 creates dirs under ROOT_DIR/hard-disk.
-        report_dir = REPO_ROOT / "hard-disk" / "reports" / "03-daily-news" / RUN_DATE.isoformat()
+        report_dir = self.workspace / "workspace" / "reports" / "03-daily-news" / RUN_DATE.isoformat()
         self.assertTrue(report_dir.is_dir())
         self.assertEqual(
             call_log.read_text(encoding="utf-8").splitlines(),

--- a/tests/test_harness/test_morning_brief_synthesis.py
+++ b/tests/test_harness/test_morning_brief_synthesis.py
@@ -15,6 +15,7 @@ from harness.morning_brief_synthesis import (
     MAX_ARTICLE_CONTENT_CHARS,
     SynthesisError,
     main,
+    parse_openclaw_json_output,
     parse_shortlist_output,
     synthesize_morning_brief,
 )
@@ -200,6 +201,14 @@ def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
     assert len(prompts) == 2
     assert {call["model"] for call in model_calls} == {"gpt-5.6-sol"}
     assert {call["reasoning"] for call in model_calls} == {"high"}
+    session_keys = {call["session_key"] for call in model_calls}
+    assert len(session_keys) == 1
+    assert next(iter(session_keys)).startswith(
+        f"daily-news-sol-{RUN_DATE.isoformat()}-"
+    )
+    assert all("DO NOT use or call any tools" in prompt for prompt in prompts)
+    assert all("DO NOT browse, search, or fetch anything" in prompt for prompt in prompts)
+    assert all("DO NOT read, create, edit, or write any files" in prompt for prompt in prompts)
     title_universe = _payload_from_prompt(prompts[0], "TITLE_UNIVERSE_JSON:")
     article_records = [
         item for item in title_universe["candidates"] if item["kind"] == "article"
@@ -352,7 +361,10 @@ def test_cli_stdout_and_artifact_are_final_text_only_and_no_temp_json(
     system_tmp.mkdir()
     monkeypatch.setenv("TMPDIR", str(system_tmp))
 
+    model_calls: list[dict] = []
+
     def model_call(**kwargs) -> str:
+        model_calls.append(kwargs)
         if "PASS 1" in kwargs["prompt"]:
             universe = _payload_from_prompt(kwargs["prompt"], "TITLE_UNIVERSE_JSON:")
             return json.dumps({"ids": [universe["candidates"][0]["id"]]})
@@ -368,6 +380,8 @@ def test_cli_stdout_and_artifact_are_final_text_only_and_no_temp_json(
             str(prepared_path),
             "--output",
             str(output_path),
+            "--session-key",
+            "daily-news-sol-manual-test",
         ],
         model_call=model_call,
     )
@@ -376,9 +390,120 @@ def test_cli_stdout_and_artifact_are_final_text_only_and_no_temp_json(
     assert status == 0
     assert captured.out == f"{FINAL_BRIEF}\n"
     assert captured.err == ""
+    assert {call["session_key"] for call in model_calls} == {
+        "daily-news-sol-manual-test"
+    }
     assert output_path.read_text(encoding="utf-8") == f"{FINAL_BRIEF}\n"
     assert not list(system_tmp.rglob("*.json"))
     assert not any(system_tmp.iterdir())
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"payloads":[{"text":"top-level reply"}]}', "top-level reply"),
+        (
+            '{"status":"ok","result":{"payloads":[{"text":"first"},{"text":"second"}]}}',
+            "first\n\nsecond",
+        ),
+        (
+            '{"payloads":[{"isReasoning":true,"text":"hidden"},{"text":"visible"}]}',
+            "visible",
+        ),
+    ],
+)
+def test_openclaw_json_payload_parsing(raw: str, expected: str) -> None:
+    assert parse_openclaw_json_output(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        ("", "empty JSON stdout"),
+        ("not-json", "invalid JSON stdout"),
+        ('{"status":"error","summary":"gateway exploded"}', "gateway exploded"),
+        ('{"result":{}}', "contained no payloads"),
+        ('{"payloads":{}}', "payloads` must be a list"),
+        ('{"payloads":[{"text":""}]}', "no visible text payload"),
+        (
+            '{"payloads":[{"isError":true,"text":"model unavailable"}]}',
+            "model unavailable",
+        ),
+    ],
+)
+def test_openclaw_json_payload_errors_are_clear(raw: str, message: str) -> None:
+    with pytest.raises(SynthesisError, match=message):
+        parse_openclaw_json_output(raw)
+
+
+def test_default_workflow_uses_two_main_agent_turns_in_one_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+    commands: list[list[str]] = []
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        assert capture_output is True
+        assert text is True
+        assert check is False
+        commands.append(command)
+        prompt = command[command.index("--message") + 1]
+        if "PASS 1" in prompt:
+            universe = _payload_from_prompt(prompt, "TITLE_UNIVERSE_JSON:")
+            reply = json.dumps({"ids": [universe["candidates"][0]["id"]]})
+            stdout = json.dumps({"payloads": [{"text": reply}]})
+        else:
+            stdout = json.dumps(
+                {"status": "ok", "result": {"payloads": [{"text": FINAL_BRIEF}]}}
+            )
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="diagnostic")
+
+    monkeypatch.setattr("harness.morning_brief_synthesis.subprocess.run", fake_run)
+
+    brief = synthesize_morning_brief(
+        db_path=db_path,
+        prepared_path=prepared_path,
+        run_date=RUN_DATE,
+        session_key="daily-news-sol-known-audit-key",
+    )
+
+    assert brief == FINAL_BRIEF
+    assert len(commands) == 2
+    for command in commands:
+        assert command[:2] == ["openclaw", "agent"]
+        assert command[command.index("--agent") + 1] == "main"
+        assert command[command.index("--model") + 1] == "gpt-5.6-sol"
+        assert command[command.index("--thinking") + 1] == "high"
+        assert command[command.index("--session-key") + 1] == (
+            "daily-news-sol-known-audit-key"
+        )
+        assert "--json" in command
+        assert "--deliver" not in command
+
+
+def test_openclaw_subprocess_failure_surfaces_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+
+    def fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args[0], 17, stdout="", stderr="gateway connection failed"
+        )
+
+    monkeypatch.setattr("harness.morning_brief_synthesis.subprocess.run", fake_run)
+
+    with pytest.raises(
+        SynthesisError, match="status 17: gateway connection failed"
+    ):
+        synthesize_morning_brief(
+            db_path=db_path,
+            prepared_path=prepared_path,
+            run_date=RUN_DATE,
+            retry_count=0,
+        )
 
 
 def _write_fake_wrapper_commands(tmp_path: Path, *, pipeline_status: int) -> tuple[Path, Path]:

--- a/tests/test_harness/test_morning_brief_synthesis.py
+++ b/tests/test_harness/test_morning_brief_synthesis.py
@@ -1,0 +1,528 @@
+"""Focused tests for isolated post-ingest morning-brief synthesis."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+from harness.morning_brief_synthesis import (
+    MAX_ARTICLE_CONTENT_CHARS,
+    SynthesisError,
+    main,
+    parse_shortlist_output,
+    synthesize_morning_brief,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_DATE = date(2026, 7, 19)
+FINAL_BRIEF = (
+    "*Worth Knowing Today*\n"
+    "• Material development <https://example.com/story|Reuters>\n\n"
+    "*Portfolio / Watchlist Events*\n"
+    "• Portfolio item <https://example.com/ir|PORT IR>"
+)
+
+
+def _epoch(day: str) -> int:
+    return int(datetime.fromisoformat(f"{day}T12:00:00+00:00").timestamp())
+
+
+def _make_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    db_path = tmp_path / "invest.db"
+    connection = sqlite3.connect(db_path)
+    connection.executescript(
+        """
+        CREATE TABLE news (
+            article_key TEXT PRIMARY KEY,
+            published_at INTEGER NOT NULL,
+            published_at_raw TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            summary TEXT,
+            source TEXT NOT NULL,
+            url TEXT NOT NULL,
+            section TEXT,
+            collected_at TEXT NOT NULL
+        );
+        """
+    )
+    rows = [
+        (
+            "key-reuters",
+            _epoch("2026-07-19"),
+            "2026-07-19T08:00:00Z",
+            "Rates move after inflation data",
+            "UNSELECTED-CONTENT",
+            "UNSELECTED-SUMMARY",
+            "reuters",
+            "https://example.com/story",
+            "markets",
+            "2026-07-19T09:00:00Z",
+        ),
+        (
+            "key-ir",
+            _epoch("2026-07-18"),
+            "July 18, 2026 4:05 PM ET",
+            "Portfolio company announces acquisition",
+            "IR full content " + ("x" * (MAX_ARTICLE_CONTENT_CHARS + 500)),
+            None,
+            "ir-PORT",
+            "https://example.com/ir",
+            "press release",
+            "2026-07-19T09:01:00-04:00",
+        ),
+        (
+            "key-ft",
+            _epoch("2026-07-19"),
+            "2026-07-19",
+            "Manufacturing survey improves",
+            "FT-CONTENT",
+            "FT-SUMMARY",
+            "ft",
+            "https://example.com/ft",
+            "economy",
+            "2026-07-19T09:02:00Z",
+        ),
+        (
+            "key-old-run",
+            _epoch("2026-07-19"),
+            "2026-07-19",
+            "Previously collected title",
+            "OLD-CONTENT",
+            "OLD-SUMMARY",
+            "wsj",
+            "https://example.com/old",
+            "markets",
+            "2026-07-18T23:59:00Z",
+        ),
+    ]
+    connection.executemany(
+        """
+        INSERT INTO news (
+            article_key, published_at, published_at_raw, title, content, summary,
+            source, url, section, collected_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+    connection.commit()
+    connection.close()
+
+    prepared_path = tmp_path / "prepared-evidence.json"
+    prepared_path.write_text(
+        json.dumps(
+            {
+                "date": RUN_DATE.isoformat(),
+                "universe": [
+                    {
+                        "security_id": "PORT",
+                        "ticker": "PORT",
+                        "source_kind": "holding",
+                    }
+                ],
+                "events": [
+                    {
+                        "source": "earnings",
+                        "source_name": "earnings",
+                        "event_type": "earnings",
+                        "event_date": RUN_DATE.isoformat(),
+                        "security_id": "PORT",
+                        "relationship": "monitored",
+                        "group": "company-specific",
+                        "headline": "PORT reports before the open",
+                        "timing": "bmo",
+                        "reference_url": "https://example.com/calendar",
+                        "summary": "Consensus expects revenue growth.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return db_path, prepared_path
+
+
+def _payload_from_prompt(prompt: str, marker: str) -> dict:
+    return json.loads(prompt.split(marker, 1)[1].strip())
+
+
+def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
+    tmp_path: Path,
+) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+    prompts: list[str] = []
+    model_calls: list[dict] = []
+
+    def model_call(**kwargs) -> str:
+        model_calls.append(kwargs)
+        prompt = kwargs["prompt"]
+        prompts.append(prompt)
+        if "PASS 1" in prompt:
+            universe = _payload_from_prompt(prompt, "TITLE_UNIVERSE_JSON:")
+            article_ids = [
+                item["id"] for item in universe["candidates"] if item["kind"] == "article"
+            ]
+            event_id = next(
+                item["id"] for item in universe["candidates"] if item["kind"] == "event"
+            )
+            # Fenced JSON, duplicate IDs, and an invented ID are tolerated, but
+            # deterministic validation must keep only supplied universe IDs.
+            return (
+                "shortlist follows\n```json\n"
+                + json.dumps(
+                    {
+                        "shortlist_ids": [
+                            article_ids[1],
+                            event_id,
+                            "article:not-in-universe",
+                            article_ids[1],
+                        ]
+                    }
+                )
+                + "\n```"
+            )
+        return FINAL_BRIEF
+
+    brief = synthesize_morning_brief(
+        db_path=db_path,
+        prepared_path=prepared_path,
+        run_date=RUN_DATE,
+        model_call=model_call,
+    )
+
+    assert brief == FINAL_BRIEF
+    assert len(prompts) == 2
+    assert {call["model"] for call in model_calls} == {"gpt-5.6-sol"}
+    assert {call["reasoning"] for call in model_calls} == {"high"}
+    title_universe = _payload_from_prompt(prompts[0], "TITLE_UNIVERSE_JSON:")
+    article_records = [
+        item for item in title_universe["candidates"] if item["kind"] == "article"
+    ]
+    assert {item["title"] for item in article_records} == {
+        "Rates move after inflation data",
+        "Portfolio company announces acquisition",
+        "Manufacturing survey improves",
+    }
+    assert "Previously collected title" not in prompts[0]
+    assert any(item["source"] == "ir-PORT" for item in article_records)
+    assert all(
+        {"id", "article_key", "source", "published", "title"} <= item.keys()
+        for item in article_records
+    )
+    assert "UNSELECTED-SUMMARY" not in prompts[0]
+    assert "UNSELECTED-CONTENT" not in prompts[0]
+
+    shortlisted = _payload_from_prompt(prompts[1], "SHORTLISTED_EVIDENCE_JSON:")
+    assert shortlisted["shortlisted_count"] == 2
+    assert [item["kind"] for item in shortlisted["evidence"]] == ["article", "event"]
+    assert {item["id"] for item in shortlisted["evidence"]} == {
+        "article:key-ir",
+        next(
+            item["id"]
+            for item in title_universe["candidates"]
+            if item["kind"] == "event"
+        ),
+    }
+    assert "article:not-in-universe" not in prompts[1]
+    assert "UNSELECTED-SUMMARY" not in prompts[1]
+    fallback = shortlisted["evidence"][0]
+    assert fallback["evidence_kind"] == "bounded_content_fallback"
+    assert len(fallback["evidence"]) <= MAX_ARTICLE_CONTENT_CHARS + 50
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"ids":["article:a","event:b"]}', ["article:a", "event:b"]),
+        (
+            '```json\n{"selected_ids":["article:a","article:a"]}\n```',
+            ["article:a"],
+        ),
+        (
+            'Here is the broad list: {"shortlist_ids":["event:b"]} done.',
+            ["event:b"],
+        ),
+        ('[{"id":"article:a"},{"id":"event:b"}]', ["article:a", "event:b"]),
+        (
+            '{"article_ids":["article:a"],"event_ids":["event:b"]}',
+            ["article:a", "event:b"],
+        ),
+    ],
+)
+def test_broad_shortlist_parsing_is_robust(raw: str, expected: list[str]) -> None:
+    assert parse_shortlist_output(raw) == expected
+
+
+def test_invalid_pass_1_output_is_retried_once(tmp_path: Path) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+    pass_1_attempts = 0
+
+    def model_call(**kwargs) -> str:
+        nonlocal pass_1_attempts
+        if "PASS 1" in kwargs["prompt"]:
+            pass_1_attempts += 1
+            if pass_1_attempts == 1:
+                return "not JSON"
+            universe = _payload_from_prompt(
+                kwargs["prompt"], "TITLE_UNIVERSE_JSON:"
+            )
+            return json.dumps({"ids": [universe["candidates"][0]["id"]]})
+        return FINAL_BRIEF
+
+    result = synthesize_morning_brief(
+        db_path=db_path,
+        prepared_path=prepared_path,
+        run_date=RUN_DATE,
+        model_call=model_call,
+    )
+
+    assert result == FINAL_BRIEF
+    assert pass_1_attempts == 2
+
+
+def test_empty_shortlist_for_nonempty_universe_fails_after_retry(tmp_path: Path) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+    calls = 0
+
+    def model_call(**kwargs) -> str:
+        nonlocal calls
+        calls += 1
+        return '{"ids":[]}'
+
+    with pytest.raises(SynthesisError, match="no valid IDs"):
+        synthesize_morning_brief(
+            db_path=db_path,
+            prepared_path=prepared_path,
+            run_date=RUN_DATE,
+            model_call=model_call,
+        )
+
+    assert calls == 2
+
+
+def test_empty_universe_preserves_explicit_evidence_thin_brief(tmp_path: Path) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+    connection = sqlite3.connect(db_path)
+    connection.execute("DELETE FROM news")
+    connection.commit()
+    connection.close()
+    prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
+    prepared["events"] = []
+    prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
+    prompts: list[str] = []
+    thin_brief = (
+        "*Worth Knowing Today*\n"
+        "• Evidence is thin; no supported material items."
+    )
+
+    def model_call(**kwargs) -> str:
+        prompts.append(kwargs["prompt"])
+        if "PASS 1" in kwargs["prompt"]:
+            return '{"ids":[]}'
+        return thin_brief
+
+    result = synthesize_morning_brief(
+        db_path=db_path,
+        prepared_path=prepared_path,
+        run_date=RUN_DATE,
+        model_call=model_call,
+    )
+
+    assert result == thin_brief
+    shortlisted = _payload_from_prompt(prompts[1], "SHORTLISTED_EVIDENCE_JSON:")
+    assert shortlisted == {
+        "run_date": RUN_DATE.isoformat(),
+        "shortlisted_count": 0,
+        "evidence": [],
+    }
+
+
+def test_cli_stdout_and_artifact_are_final_text_only_and_no_temp_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    db_path, prepared_path = _make_inputs(tmp_path)
+    output_path = tmp_path / "report" / "notes" / "slack-brief.md"
+    system_tmp = tmp_path / "system-tmp"
+    system_tmp.mkdir()
+    monkeypatch.setenv("TMPDIR", str(system_tmp))
+
+    def model_call(**kwargs) -> str:
+        if "PASS 1" in kwargs["prompt"]:
+            universe = _payload_from_prompt(kwargs["prompt"], "TITLE_UNIVERSE_JSON:")
+            return json.dumps({"ids": [universe["candidates"][0]["id"]]})
+        return f"```mrkdwn\n{FINAL_BRIEF}\n```"
+
+    status = main(
+        [
+            "--date",
+            RUN_DATE.isoformat(),
+            "--db",
+            str(db_path),
+            "--prepared-evidence",
+            str(prepared_path),
+            "--output",
+            str(output_path),
+        ],
+        model_call=model_call,
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert captured.out == f"{FINAL_BRIEF}\n"
+    assert captured.err == ""
+    assert output_path.read_text(encoding="utf-8") == f"{FINAL_BRIEF}\n"
+    assert not list(system_tmp.rglob("*.json"))
+    assert not any(system_tmp.iterdir())
+
+
+def _write_fake_wrapper_commands(tmp_path: Path, *, pipeline_status: int) -> tuple[Path, Path]:
+    pipeline = tmp_path / "fake-pipeline.sh"
+    pipeline.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo pipeline >> \"$ORDER_LOG\"\n"
+        "echo collection-log-line\n"
+        + (
+            "mkdir -p \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
+            f"{RUN_DATE.isoformat()}/data/rendered\"\n"
+            "echo evidence > \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
+            f"{RUN_DATE.isoformat()}/data/rendered/test.md\"\n"
+            if pipeline_status == 0
+            else ""
+        )
+        + f"exit {pipeline_status}\n",
+        encoding="utf-8",
+    )
+    pipeline.chmod(0o755)
+
+    synthesis = tmp_path / "fake-synthesis.sh"
+    synthesis.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo sol >> \"$ORDER_LOG\"\n"
+        "printf '%s\\n' '*Worth Knowing Today*' '• item'\n",
+        encoding="utf-8",
+    )
+    synthesis.chmod(0o755)
+    return pipeline, synthesis
+
+
+def _wrapper_env(
+    tmp_path: Path, pipeline: Path, synthesis: Path, order_log: Path
+) -> dict[str, str]:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(fake_home),
+            "ORDER_LOG": str(order_log),
+            "MINERVA_MORNING_BRIEF_PIPELINE_SCRIPT": str(pipeline),
+            "MINERVA_SYNTHESIS_RUNNER": str(synthesis),
+            "MINERVA_WORKSPACE_ROOT": str(tmp_path / "workspace"),
+            "MINERVA_MORNING_BRIEF_LOG": str(tmp_path / "logs" / "pipeline.log"),
+            "MINERVA_MORNING_BRIEF_SYNTHESIS_LOG": str(
+                tmp_path / "logs" / "synthesis.log"
+            ),
+        }
+    )
+    return env
+
+
+def test_wrapper_invokes_sol_only_after_pipeline_success(tmp_path: Path) -> None:
+    order_log = tmp_path / "order.log"
+    pipeline, synthesis = _write_fake_wrapper_commands(tmp_path, pipeline_status=0)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "run_morning_brief_with_synthesis.sh"),
+            RUN_DATE.isoformat(),
+        ],
+        cwd=REPO_ROOT,
+        env=_wrapper_env(tmp_path, pipeline, synthesis, order_log),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert order_log.read_text(encoding="utf-8").splitlines() == ["pipeline", "sol"]
+    assert result.stdout == "*Worth Knowing Today*\n• item\n"
+    assert result.stderr == ""
+    assert not (tmp_path / "logs" / "pipeline.log").exists()
+    assert not (tmp_path / "logs" / "synthesis.log").exists()
+
+
+def test_wrapper_retries_pipeline_once_before_invoking_sol(tmp_path: Path) -> None:
+    order_log = tmp_path / "order.log"
+    attempt_file = tmp_path / "attempt"
+    _, synthesis = _write_fake_wrapper_commands(tmp_path, pipeline_status=0)
+    pipeline = tmp_path / "flaky-pipeline.sh"
+    pipeline.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo pipeline >> \"$ORDER_LOG\"\n"
+        "attempt=1\n"
+        "[[ -f \"$ATTEMPT_FILE\" ]] && attempt=2\n"
+        "touch \"$ATTEMPT_FILE\"\n"
+        "if [[ \"$attempt\" -eq 1 ]]; then exit 17; fi\n"
+        "mkdir -p \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
+        f"{RUN_DATE.isoformat()}/data/rendered\"\n"
+        "echo evidence > \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
+        f"{RUN_DATE.isoformat()}/data/rendered/test.md\"\n",
+        encoding="utf-8",
+    )
+    pipeline.chmod(0o755)
+    env = _wrapper_env(tmp_path, pipeline, synthesis, order_log)
+    env["ATTEMPT_FILE"] = str(attempt_file)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "run_morning_brief_with_synthesis.sh"),
+            RUN_DATE.isoformat(),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert order_log.read_text(encoding="utf-8").splitlines() == [
+        "pipeline",
+        "pipeline",
+        "sol",
+    ]
+
+
+def test_pipeline_failure_prevents_sol_invocation(tmp_path: Path) -> None:
+    order_log = tmp_path / "order.log"
+    pipeline, synthesis = _write_fake_wrapper_commands(tmp_path, pipeline_status=17)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "scripts" / "run_morning_brief_with_synthesis.sh"),
+            RUN_DATE.isoformat(),
+        ],
+        cwd=REPO_ROOT,
+        env=_wrapper_env(tmp_path, pipeline, synthesis, order_log),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert order_log.read_text(encoding="utf-8").splitlines() == [
+        "pipeline",
+        "pipeline",
+    ]
+    assert result.stdout == ""
+    assert "Sol was not invoked" in result.stderr
+    assert "pipeline log:" in result.stderr


### PR DESCRIPTION
## Summary

- run synthesis only after collection, extraction, SQLite ingestion, and evidence preparation succeed
- add a two-pass Sol workflow: title-only shortlist followed by evidence-grounded final synthesis
- run both passes through one dedicated OpenClaw main-agent session
- preserve retry/failure reporting and validate model output

## Stack

1. **This PR:** post-ingest synthesis foundation
2. Evidence routing and Slack section ordering
3. Deterministic source accounting
4. Finnhub persistence (#69)

Merge this stack from the bottom up.
