### PR TITLE
feat(brief): route evidence and order Slack sections

### DIFF
--- a/src/harness/morning_brief_synthesis.py
+++ b/src/harness/morning_brief_synthesis.py
@@ -1,10 +1,12 @@
 """Post-ingest, two-pass OpenClaw synthesis for the daily morning brief.
 
 The collection pipeline owns all network/tool work and SQLite ingestion. This
-module starts at the resulting SQLite database and prepared evidence file. It
-runs two OpenClaw main-agent turns in one dedicated session: a title-only broad
-shortlist, followed by final synthesis from evidence fetched only for validated
-shortlist IDs.
+module starts at the resulting SQLite database and prepared evidence file,
+then deterministically separates article choices from automatic events. It
+runs two OpenClaw main-agent turns in one dedicated session: pass 1 chooses
+only among collected articles and secondary ``market-news`` records; pass 2
+receives evidence for those choices plus every automatically routed prepared
+event.
 """
 
 from __future__ import annotations
@@ -27,6 +29,12 @@ DEFAULT_MODEL = "gpt-5.6-sol"
 DEFAULT_REASONING = "high"
 MAX_ARTICLE_CONTENT_CHARS = 4_000
 MAX_EVENT_DETAIL_CHARS = 2_000
+MAX_SHORTLIST_IDS = 30
+ROUTING_SELECTED_ARTICLE = "selected_article"
+ROUTING_AUTO_PORTFOLIO = "auto_portfolio_watchlist"
+ROUTING_AUTO_MARKET = "auto_market_move"
+ROUTING_OTHER_AUTO = "other_auto_event"
+PORTFOLIO_ROLES = frozenset({"holding", "watchlist"})
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 ModelCall = Callable[..., str]
@@ -38,7 +46,7 @@ class SynthesisError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class CandidateTitle:
-    """One stable title/headline candidate shown to the first model pass."""
+    """One stable collected-article or prepared-event candidate."""
 
     id: str
     kind: str
@@ -49,13 +57,18 @@ class CandidateTitle:
     metadata: dict[str, Any] = field(default_factory=dict, compare=False, repr=False)
 
     def title_record(self) -> dict[str, Any]:
-        """Return the compact, summary-free representation for pass 1."""
+        """Return the compact, summary-free article-choice record for pass 1."""
         record: dict[str, Any] = {
             "id": self.id,
             "kind": self.kind,
             "source": self.source,
             "published": self.published,
             "title": self.title,
+            "article_candidate_class": (
+                "collected_sqlite_article"
+                if self.kind == "article"
+                else "secondary_prepared_market_news"
+            ),
         }
         if self.article_key is not None:
             record["article_key"] = self.article_key
@@ -71,6 +84,22 @@ class CandidateTitle:
             if value not in (None, ""):
                 record[key] = value
         return record
+
+
+@dataclass(frozen=True, slots=True)
+class RoutedEvent:
+    """A prepared event that bypasses pass 1 with an editorial routing class."""
+
+    candidate: CandidateTitle
+    routing_class: str
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingPlan:
+    """Deterministic pass-1 candidates and pass-2 automatic events."""
+
+    article_candidates: tuple[CandidateTitle, ...]
+    automatic_events: tuple[RoutedEvent, ...]
 
 
 def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateTitle]:
@@ -128,7 +157,9 @@ def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateT
     return candidates
 
 
-def load_prepared_event_titles(prepared_path: Path, run_date: date) -> list[CandidateTitle]:
+def load_prepared_event_titles(
+    prepared_path: Path, run_date: date
+) -> list[CandidateTitle]:
     """Load compact prepared-evidence headlines and assign deterministic IDs."""
     if not prepared_path.is_file():
         raise SynthesisError(f"prepared evidence does not exist: {prepared_path}")
@@ -153,8 +184,14 @@ def load_prepared_event_titles(prepared_path: Path, run_date: date) -> list[Cand
         event_date = str(raw_event.get("event_date") or run_date.isoformat()).strip()
         if not title or event_date not in {"", run_date.isoformat()}:
             continue
-        source = str(raw_event.get("source_name") or raw_event.get("source") or "prepared-evidence").strip()
-        security_id = str(raw_event.get("security_id") or raw_event.get("ticker") or "").strip()
+        source = str(
+            raw_event.get("source_name")
+            or raw_event.get("source")
+            or "prepared-evidence"
+        ).strip()
+        security_id = str(
+            raw_event.get("security_id") or raw_event.get("ticker") or ""
+        ).strip()
         stable_key = "|".join((source, security_id, title, event_date))
         candidate_id = f"event:{hashlib.sha256(stable_key.encode('utf-8')).hexdigest()}"
         if candidate_id in seen_ids:
@@ -189,14 +226,48 @@ def load_prepared_event_titles(prepared_path: Path, run_date: date) -> list[Cand
 def build_title_universe(
     db_path: Path, prepared_path: Path, run_date: date
 ) -> list[CandidateTitle]:
-    """Build the complete, stable pass-1 universe (articles first, then events)."""
+    """Build all fresh collected articles and current prepared events."""
     return query_fresh_article_titles(db_path, run_date) + load_prepared_event_titles(
         prepared_path, run_date
     )
 
 
+def partition_candidates(candidates: Sequence[CandidateTitle]) -> RoutingPlan:
+    """Partition candidates before pass 1 using the approved routing hierarchy.
+
+    Collected SQLite articles always compete in pass 1. A prepared event linked
+    to a holding/watchlist security bypasses pass 1 even when it is article-like;
+    otherwise market moves bypass, unlinked ``market-news`` records compete as
+    secondary article candidates, and every remaining prepared event advances as
+    an ``other_auto_event``.
+    """
+    article_candidates: list[CandidateTitle] = []
+    automatic_events: list[RoutedEvent] = []
+    for candidate in candidates:
+        if candidate.kind == "article":
+            article_candidates.append(candidate)
+            continue
+
+        event_type = str(candidate.metadata.get("event_type") or "").strip().casefold()
+        portfolio_role = (
+            str(candidate.metadata.get("portfolio_role") or "").strip().casefold()
+        )
+        if portfolio_role in PORTFOLIO_ROLES:
+            routing_class = ROUTING_AUTO_PORTFOLIO
+        elif event_type == "market":
+            routing_class = ROUTING_AUTO_MARKET
+        elif event_type == "market-news":
+            article_candidates.append(candidate)
+            continue
+        else:
+            routing_class = ROUTING_OTHER_AUTO
+        automatic_events.append(RoutedEvent(candidate, routing_class))
+
+    return RoutingPlan(tuple(article_candidates), tuple(automatic_events))
+
+
 def build_shortlist_prompt(candidates: Sequence[CandidateTitle], run_date: date) -> str:
-    """Render the first-pass prompt containing every title and no article body."""
+    """Render pass 1 with only article-choice titles and no evidence bodies."""
     payload = {
         "run_date": run_date.isoformat(),
         "candidate_count": len(candidates),
@@ -206,15 +277,22 @@ def build_shortlist_prompt(candidates: Sequence[CandidateTitle], run_date: date)
         "You are Sol performing PASS 1 of a deterministic morning-brief workflow.\n"
         "For this turn, DO NOT use or call any tools. DO NOT browse, search, or fetch anything. "
         "DO NOT read, create, edit, or write any files. Work only from this message and reply "
-        "directly. The JSON below is the complete title/headline universe for this run.\n\n"
-        "Select a BROAD shortlist for a long-only investor. Cast a wide net: retain anything plausibly "
-        "market-moving, company-specific, portfolio-relevant, useful as a read-through, materially "
-        "economic/political/geopolitical, or a significant scheduled event. Include relevant IR and "
-        "prepared-evidence events. Prefer false positives over false negatives at this stage. Source "
-        "balance must follow merit, not quotas. Do not draft, summarize, filter to a tiny final list, "
-        "or invent IDs.\n\n"
-        "Return exactly one strict JSON object and no markdown or commentary:\n"
-        '{"ids":["exact-stable-id", "..."]}\n\n'
+        "directly. The JSON below is the complete ARTICLE-CHOICE title/headline universe for this "
+        "run. Portfolio/watchlist events, market moves, and other non-article events have already "
+        "been routed automatically and must not compete in this pass.\n\n"
+        "Select a focused but broad shortlist for a long-only investor, targeting 15-25 choices "
+        "when the candidate quality supports it. HARD MAXIMUM: select no more than 30 IDs. Retain "
+        "stories that are plausibly market-moving, company-specific, useful as an investor "
+        "read-through, or materially economic, political, or geopolitical. Reject lifestyle, "
+        "sports, celebrity, and other non-investor fluff. Semantically deduplicate overlapping "
+        "headlines: select one representative of the same development, preferring a "
+        "collected_sqlite_article over a secondary_prepared_market_news record because the former "
+        "has richer collected evidence. A secondary market-news record may be selected when it is "
+        "the only coverage or is materially distinct. Rank and balance sources on merit, not quotas. "
+        "Do not draft the brief, summarize unsupported details, or invent IDs.\n\n"
+        "Return exactly one strict JSON object and no markdown or commentary. Include exactly one "
+        "concise editorial reason with every selected ID:\n"
+        '{"selections":[{"id":"exact-stable-id","reason":"concise reason"}]}\n\n'
         "TITLE_UNIVERSE_JSON:\n"
         f"{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}"
     )
@@ -261,18 +339,25 @@ def parse_shortlist_output(raw: str) -> list[str]:
                 unique.append(identifier)
         return unique
 
-    raise SynthesisError("pass 1 did not return a JSON shortlist with an `ids` array")
+    raise SynthesisError(
+        "pass 1 did not return a JSON shortlist with a `selections` or `ids` array"
+    )
 
 
 def validate_shortlist_ids(
     requested_ids: Sequence[str], candidates: Sequence[CandidateTitle]
 ) -> list[str]:
-    """Drop unknown/duplicate IDs and return valid IDs in stable universe order."""
+    """Return valid IDs in stable universe order and reject an oversized shortlist."""
     requested = set(requested_ids)
     valid = [candidate.id for candidate in candidates if candidate.id in requested]
     if candidates and not valid:
         raise SynthesisError(
             "pass 1 returned no valid IDs from the non-empty title universe"
+        )
+    if len(valid) > MAX_SHORTLIST_IDS:
+        raise SynthesisError(
+            f"pass 1 returned {len(valid)} valid IDs; hard maximum is "
+            f"{MAX_SHORTLIST_IDS}"
         )
     return valid
 
@@ -284,7 +369,7 @@ def query_shortlisted_evidence(
     *,
     max_content_chars: int = MAX_ARTICLE_CONTENT_CHARS,
 ) -> list[dict[str, Any]]:
-    """Fetch summaries/bounded content only for validated shortlist candidates."""
+    """Fetch evidence only for validated pass-1 article choices."""
     candidate_by_id = {candidate.id: candidate for candidate in candidates}
     selected = [candidate_by_id[item_id] for item_id in shortlist_ids]
     selected_article_keys = [
@@ -299,7 +384,9 @@ def query_shortlisted_evidence(
         if candidate.kind == "article":
             row = article_rows.get(candidate.article_key or "")
             if row is None:
-                raise SynthesisError(f"shortlisted article disappeared from SQLite: {candidate.id}")
+                raise SynthesisError(
+                    f"shortlisted article disappeared from SQLite: {candidate.id}"
+                )
             summary = str(row["summary"] or "").strip()
             content = str(row["content"] or "").strip()
             if summary:
@@ -320,38 +407,76 @@ def query_shortlisted_evidence(
                     "url": str(row["url"] or "").strip(),
                     "section": str(row["section"] or "").strip(),
                     "evidence_kind": evidence_kind,
+                    "routing_class": ROUTING_SELECTED_ARTICLE,
+                    "article_candidate_class": "collected_sqlite_article",
                     "evidence": evidence_text,
                 }
             )
         else:
-            evidence.append(_event_evidence(candidate))
+            evidence.append(
+                _event_evidence(candidate, routing_class=ROUTING_SELECTED_ARTICLE)
+            )
     return evidence
 
 
-def build_final_prompt(evidence: Sequence[dict[str, Any]], run_date: date) -> str:
-    """Render the second-pass prompt with all and only shortlisted evidence."""
+def build_final_prompt(
+    evidence: Sequence[dict[str, Any]],
+    run_date: date,
+    *,
+    shortlisted_count: int | None = None,
+    automatic_event_count: int | None = None,
+) -> str:
+    """Render pass 2 with selected-article and automatic-event evidence."""
+    selected_count = (
+        shortlisted_count
+        if shortlisted_count is not None
+        else sum(
+            item.get("routing_class") == ROUTING_SELECTED_ARTICLE for item in evidence
+        )
+    )
+    automatic_count = (
+        automatic_event_count
+        if automatic_event_count is not None
+        else len(evidence) - selected_count
+    )
     payload = {
         "run_date": run_date.isoformat(),
-        "shortlisted_count": len(evidence),
+        "shortlisted_count": selected_count,
+        "automatic_event_count": automatic_count,
+        "evidence_count": len(evidence),
         "evidence": list(evidence),
     }
     return (
         "You are Sol performing PASS 2 of a deterministic morning-brief workflow.\n"
         "For this turn, DO NOT use or call any tools. DO NOT browse, search, or fetch anything. "
         "DO NOT read, create, edit, or write any files. Work only from this message and reply "
-        "directly. Even though the prior pass is visible in this session, all available shortlisted "
-        "evidence is included below. Filter and rank it now; do not rely on outside facts or prior-pass "
-        "titles that are absent from this evidence.\n\n"
+        "directly. Even though the prior pass is visible in this session, the JSON below is the "
+        "complete closed evidence set. Use no outside facts, tools, files, or prior-pass titles that "
+        "are absent from this evidence. Never fabricate a fact, link, date, portfolio relationship, "
+        "or event.\n\n"
+        "Every evidence record has an explicit routing_class. Apply this hierarchy exactly:\n"
+        "- selected_article: editorially rank the strongest items as concise bullets in *Worth "
+        "Knowing Today*. Semantically deduplicate overlapping stories and do not repeat one "
+        "development from multiple outlets. Collected SQLite articles are richer than "
+        "secondary_prepared_market_news records; the latter retain only their supplied prepared "
+        "summary and URL and must not be treated as equally complete reporting.\n"
+        "- auto_portfolio_watchlist: represent EVERY record in *Portfolio / Watchlist Events*. "
+        "Consolidate overlapping records by ticker into one coherent bullet rather than producing "
+        "one bullet per record. Do not drop a record merely because it seems less newsworthy.\n"
+        "- auto_market_move: represent ALL such records in exactly ONE compact bullet/line under "
+        "*Market Snapshot*. Never emit multiple market-move bullets. Omit the section only when no "
+        "auto_market_move evidence exists.\n"
+        "- other_auto_event: include EVERY record appropriately and concisely, consolidating true "
+        "duplicates; use *Other Events* after Market Snapshot when a separate section is clearest.\n\n"
         "Return ONLY the final Slack-formatted daily-news brief as plain text (Slack mrkdwn), with no "
-        "JSON, code fence, preamble, postscript, or file instructions. Use this section order:\n"
-        "1. *Worth Knowing Today* — required; ranked, concise news bullets.\n"
-        "2. *Portfolio / Watchlist Events* — optional; include only direct, material portfolio or "
-        "watchlist developments. Omit it entirely when none are supported.\n\n"
-        "Preserve source links using Slack links such as <https://example.com|Source> wherever a supplied "
-        "URL supports a claim. Use concise labels such as Reuters, WSJ, Economist, or TICKER IR rather "
-        "than internal source IDs. Rank and balance sources on merit; do not enforce quotas and do not repeat "
-        "the same development from multiple outlets. Never fabricate a fact, link, date, portfolio "
-        "relationship, or event. If evidence is thin, say so briefly rather than padding the brief.\n\n"
+        "JSON, code fence, preamble, postscript, or file instructions. Use section order: *Worth "
+        "Knowing Today* (required), then *Portfolio / Watchlist Events*, *Market Snapshot*, and "
+        "*Other Events* when their routed evidence exists. Preserve supplied URLs when representing "
+        "their evidence, using Slack links such as <https://example.com|Source>; never replace or "
+        "invent a link. Use concise source labels such as Reuters, WSJ, Economist, or TICKER IR rather "
+        "than internal IDs. Rank and balance selected articles on merit, not quotas. If selected-article "
+        "evidence is thin, say so briefly rather than padding Worth Knowing Today, while still "
+        "representing every automatic event as directed.\n\n"
         "SHORTLISTED_EVIDENCE_JSON:\n"
         f"{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}"
     )
@@ -372,11 +497,15 @@ def normalize_final_brief(raw: str) -> str:
         raise SynthesisError("pass 2 returned JSON instead of a text-only Slack brief")
 
     worth_position = _section_heading_position(brief, "Worth Knowing Today")
-    portfolio_position = _section_heading_position(brief, "Portfolio / Watchlist Events")
+    portfolio_position = _section_heading_position(
+        brief, "Portfolio / Watchlist Events"
+    )
     if worth_position is None:
         raise SynthesisError("pass 2 omitted required Worth Knowing Today section")
     if portfolio_position is not None and worth_position >= portfolio_position:
-        raise SynthesisError("pass 2 returned the optional portfolio/watchlist section out of order")
+        raise SynthesisError(
+            "pass 2 returned the optional portfolio/watchlist section out of order"
+        )
     return brief
 
 
@@ -392,8 +521,10 @@ def synthesize_morning_brief(
     output_path: Path | None = None,
     retry_count: int = 1,
 ) -> str:
-    """Run both OpenClaw turns and optionally persist the final text artifact."""
-    candidates = build_title_universe(db_path, prepared_path, run_date)
+    """Run both OpenClaw turns in one session and persist the final artifact."""
+    all_candidates = build_title_universe(db_path, prepared_path, run_date)
+    routing_plan = partition_candidates(all_candidates)
+    candidates = routing_plan.article_candidates
     call_model = model_call or _default_model_call
     active_session_key = _resolve_session_key(session_key, run_date)
     pass_1_prompt = build_shortlist_prompt(candidates, run_date)
@@ -413,8 +544,18 @@ def synthesize_morning_brief(
         attempts=retry_count + 1,
         stage="pass 1 shortlist",
     )
-    evidence = query_shortlisted_evidence(db_path, candidates, shortlist_ids)
-    pass_2_prompt = build_final_prompt(evidence, run_date)
+    selected_evidence = query_shortlisted_evidence(db_path, candidates, shortlist_ids)
+    automatic_evidence = [
+        _event_evidence(item.candidate, routing_class=item.routing_class)
+        for item in routing_plan.automatic_events
+    ]
+    evidence = [*selected_evidence, *automatic_evidence]
+    pass_2_prompt = build_final_prompt(
+        evidence,
+        run_date,
+        shortlisted_count=len(selected_evidence),
+        automatic_event_count=len(automatic_evidence),
+    )
     brief = _with_retries(
         lambda: normalize_final_brief(
             call_model(
@@ -583,13 +724,16 @@ def _query_article_evidence(
             for row in connection.execute(query, tuple(chunk)):
                 rows[str(row["article_key"])] = row
     except sqlite3.Error as exc:
-        raise SynthesisError(f"could not query shortlisted news evidence: {exc}") from exc
+        raise SynthesisError(
+            f"could not query shortlisted news evidence: {exc}"
+        ) from exc
     finally:
         connection.close()
     return rows
 
 
-def _event_evidence(candidate: CandidateTitle) -> dict[str, Any]:
+def _event_evidence(candidate: CandidateTitle, *, routing_class: str) -> dict[str, Any]:
+    """Preserve one prepared event's own bounded summary and supplied URL."""
     event = candidate.metadata
     url = str(event.get("reference_url") or event.get("source_url") or "").strip()
     summary = _first_nonempty_text(
@@ -632,7 +776,7 @@ def _event_evidence(candidate: CandidateTitle) -> dict[str, Any]:
             if value not in (None, "", [], {}) and key not in compact_details:
                 compact_details[key] = value
 
-    return {
+    evidence_record = {
         "id": candidate.id,
         "kind": "event",
         "source": candidate.source,
@@ -641,8 +785,12 @@ def _event_evidence(candidate: CandidateTitle) -> dict[str, Any]:
         "url": url,
         "details": compact_details,
         "evidence_kind": "prepared_event",
+        "routing_class": routing_class,
         "evidence": _bounded_text(summary, MAX_EVENT_DETAIL_CHARS),
     }
+    if str(event.get("event_type") or "").strip().casefold() == "market-news":
+        evidence_record["article_candidate_class"] = "secondary_prepared_market_news"
+    return evidence_record
 
 
 def _universe_role_map(raw_universe: Any) -> dict[str, str]:
@@ -652,7 +800,9 @@ def _universe_role_map(raw_universe: Any) -> dict[str, str]:
     for item in raw_universe:
         if not isinstance(item, dict):
             continue
-        security_id = str(item.get("security_id") or item.get("ticker") or "").strip().upper()
+        security_id = (
+            str(item.get("security_id") or item.get("ticker") or "").strip().upper()
+        )
         role = str(item.get("source_kind") or item.get("relationship") or "").strip()
         if security_id and role:
             roles[security_id] = role
@@ -662,8 +812,10 @@ def _universe_role_map(raw_universe: Any) -> dict[str, str]:
 def _epoch_as_iso(raw_epoch: Any) -> str:
     try:
         epoch = int(raw_epoch)
-        return datetime.fromtimestamp(epoch, timezone.utc).isoformat().replace(
-            "+00:00", "Z"
+        return (
+            datetime.fromtimestamp(epoch, timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
         )
     except (TypeError, ValueError, OSError, OverflowError):
         return ""
@@ -696,7 +848,7 @@ def _extract_id_list(value: Any) -> list[Any] | None:
     normalized = {
         str(key).casefold().replace("-", "_"): item for key, item in value.items()
     }
-    for key in ("ids", "shortlist_ids", "selected_ids"):
+    for key in ("selections", "ids", "shortlist_ids", "selected_ids"):
         selected = normalized.get(key)
         if isinstance(selected, list):
             return selected
@@ -729,9 +881,7 @@ def _section_heading_position(text: str, heading: str) -> int | None:
     return match.start() if match else None
 
 
-def _with_retries(
-    operation: Callable[[], Any], *, attempts: int, stage: str
-) -> Any:
+def _with_retries(operation: Callable[[], Any], *, attempts: int, stage: str) -> Any:
     if attempts < 1:
         raise ValueError("attempts must be at least one")
     last_error: Exception | None = None
@@ -753,14 +903,20 @@ def _with_retries(
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--date", required=True, help="Morning-brief run date (YYYY-MM-DD).")
+    parser.add_argument(
+        "--date", required=True, help="Morning-brief run date (YYYY-MM-DD)."
+    )
     parser.add_argument("--db", type=Path, help="Path to invest.db.")
     parser.add_argument(
         "--prepared-evidence", type=Path, help="Path to prepared-evidence.json."
     )
     parser.add_argument("--output", type=Path, help="Final Slack brief output path.")
-    parser.add_argument("--workspace-root", type=Path, help="Minerva hard-disk workspace root.")
-    parser.add_argument("--model", default=DEFAULT_MODEL, help="OpenClaw model override.")
+    parser.add_argument(
+        "--workspace-root", type=Path, help="Minerva hard-disk workspace root."
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help="OpenClaw model override."
+    )
     parser.add_argument(
         "--session-key",
         help=(

--- a/src/harness/morning_brief_synthesis.py
+++ b/src/harness/morning_brief_synthesis.py
@@ -462,16 +462,18 @@ def build_final_prompt(
         "summary and URL and must not be treated as equally complete reporting.\n"
         "- auto_portfolio_watchlist: represent EVERY record in *Portfolio / Watchlist Events*. "
         "Consolidate overlapping records by ticker into one coherent bullet rather than producing "
-        "one bullet per record. Do not drop a record merely because it seems less newsworthy.\n"
+        "one bullet per record. Do not drop a record merely because it seems less newsworthy. Emit "
+        "this section if and only if auto_portfolio_watchlist evidence exists.\n"
         "- auto_market_move: represent ALL such records in exactly ONE compact bullet/line under "
-        "*Market Snapshot*. Never emit multiple market-move bullets. Omit the section only when no "
-        "auto_market_move evidence exists.\n"
+        "*Market Snapshot*. Never emit multiple market-move bullets. Emit this section if and only "
+        "if auto_market_move evidence exists.\n"
         "- other_auto_event: include EVERY record appropriately and concisely, consolidating true "
-        "duplicates; use *Other Events* after Market Snapshot when a separate section is clearest.\n\n"
+        "duplicates; use *Other Events* when a separate section is clearest.\n\n"
         "Return ONLY the final Slack-formatted daily-news brief as plain text (Slack mrkdwn), with no "
-        "JSON, code fence, preamble, postscript, or file instructions. Use section order: *Worth "
-        "Knowing Today* (required), then *Portfolio / Watchlist Events*, *Market Snapshot*, and "
-        "*Other Events* when their routed evidence exists. Preserve supplied URLs when representing "
+        "JSON, code fence, preamble, postscript, or file instructions. Use section order: *Market "
+        "Snapshot* first when its routed evidence exists, then *Portfolio / Watchlist Events* when "
+        "its routed evidence exists, then *Worth Knowing Today* (required), and finally *Other "
+        "Events* when its routed evidence exists. Preserve supplied URLs when representing "
         "their evidence, using Slack links such as <https://example.com|Source>; never replace or "
         "invent a link. Use concise source labels such as Reuters, WSJ, Economist, or TICKER IR rather "
         "than internal IDs. Rank and balance selected articles on merit, not quotas. If selected-article "
@@ -482,8 +484,17 @@ def build_final_prompt(
     )
 
 
-def normalize_final_brief(raw: str) -> str:
-    """Normalize harmless outer fencing and validate required plain-text sections."""
+def normalize_final_brief(
+    raw: str,
+    *,
+    has_market_move_evidence: bool | None = None,
+    has_portfolio_watchlist_evidence: bool | None = None,
+) -> str:
+    """Normalize pass 2 and validate its evidence-aware Slack section order.
+
+    Evidence-presence checks are optional for standalone callers; the synthesis
+    workflow always supplies them from the deterministic automatic routes.
+    """
     brief = _strip_outer_code_fence(raw.strip()).strip()
     if not brief:
         raise SynthesisError("pass 2 returned an empty brief")
@@ -496,15 +507,36 @@ def normalize_final_brief(raw: str) -> str:
     if isinstance(decoded, (dict, list)):
         raise SynthesisError("pass 2 returned JSON instead of a text-only Slack brief")
 
-    worth_position = _section_heading_position(brief, "Worth Knowing Today")
-    portfolio_position = _section_heading_position(
-        brief, "Portfolio / Watchlist Events"
-    )
-    if worth_position is None:
+    section_positions = {
+        "Market Snapshot": _section_heading_position(brief, "Market Snapshot"),
+        "Portfolio / Watchlist Events": _section_heading_position(
+            brief, "Portfolio / Watchlist Events"
+        ),
+        "Worth Knowing Today": _section_heading_position(brief, "Worth Knowing Today"),
+    }
+    if section_positions["Worth Knowing Today"] is None:
         raise SynthesisError("pass 2 omitted required Worth Knowing Today section")
-    if portfolio_position is not None and worth_position >= portfolio_position:
+
+    _validate_evidence_section_presence(
+        section_positions,
+        "Market Snapshot",
+        has_evidence=has_market_move_evidence,
+        routing_class=ROUTING_AUTO_MARKET,
+    )
+    _validate_evidence_section_presence(
+        section_positions,
+        "Portfolio / Watchlist Events",
+        has_evidence=has_portfolio_watchlist_evidence,
+        routing_class=ROUTING_AUTO_PORTFOLIO,
+    )
+
+    present_positions = [
+        position for position in section_positions.values() if position is not None
+    ]
+    if present_positions != sorted(present_positions):
         raise SynthesisError(
-            "pass 2 returned the optional portfolio/watchlist section out of order"
+            "pass 2 returned sections out of order; expected Market Snapshot, "
+            "Portfolio / Watchlist Events, then Worth Knowing Today"
         )
     return brief
 
@@ -556,6 +588,14 @@ def synthesize_morning_brief(
         shortlisted_count=len(selected_evidence),
         automatic_event_count=len(automatic_evidence),
     )
+    has_market_move_evidence = any(
+        item.get("routing_class") == ROUTING_AUTO_MARKET
+        for item in automatic_evidence
+    )
+    has_portfolio_watchlist_evidence = any(
+        item.get("routing_class") == ROUTING_AUTO_PORTFOLIO
+        for item in automatic_evidence
+    )
     brief = _with_retries(
         lambda: normalize_final_brief(
             call_model(
@@ -563,7 +603,9 @@ def synthesize_morning_brief(
                 model=model,
                 reasoning=reasoning,
                 session_key=active_session_key,
-            )
+            ),
+            has_market_move_evidence=has_market_move_evidence,
+            has_portfolio_watchlist_evidence=has_portfolio_watchlist_evidence,
         ),
         attempts=retry_count + 1,
         stage="pass 2 synthesis",
@@ -879,6 +921,26 @@ def _section_heading_position(text: str, heading: str) -> int | None:
     )
     match = pattern.search(text)
     return match.start() if match else None
+
+
+def _validate_evidence_section_presence(
+    section_positions: dict[str, int | None],
+    heading: str,
+    *,
+    has_evidence: bool | None,
+    routing_class: str,
+) -> None:
+    if has_evidence is None:
+        return
+    section_is_present = section_positions[heading] is not None
+    if has_evidence and not section_is_present:
+        raise SynthesisError(
+            f"pass 2 omitted required {heading} section for {routing_class} evidence"
+        )
+    if not has_evidence and section_is_present:
+        raise SynthesisError(
+            f"pass 2 included {heading} section without {routing_class} evidence"
+        )
 
 
 def _with_retries(operation: Callable[[], Any], *, attempts: int, stage: str) -> Any:

--- a/tests/test_harness/test_morning_brief_synthesis.py
+++ b/tests/test_harness/test_morning_brief_synthesis.py
@@ -13,11 +13,14 @@ import pytest
 
 from harness.morning_brief_synthesis import (
     MAX_ARTICLE_CONTENT_CHARS,
+    MAX_SHORTLIST_IDS,
+    CandidateTitle,
     SynthesisError,
     main,
     parse_openclaw_json_output,
     parse_shortlist_output,
     synthesize_morning_brief,
+    validate_shortlist_ids,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -125,7 +128,12 @@ def _make_inputs(tmp_path: Path) -> tuple[Path, Path]:
                         "security_id": "PORT",
                         "ticker": "PORT",
                         "source_kind": "holding",
-                    }
+                    },
+                    {
+                        "security_id": "WATCH",
+                        "ticker": "WATCH",
+                        "source_kind": "watchlist",
+                    },
                 ],
                 "events": [
                     {
@@ -140,7 +148,55 @@ def _make_inputs(tmp_path: Path) -> tuple[Path, Path]:
                         "timing": "bmo",
                         "reference_url": "https://example.com/calendar",
                         "summary": "Consensus expects revenue growth.",
-                    }
+                    },
+                    {
+                        "source": "ir",
+                        "source_name": "ir",
+                        "event_type": "company-news",
+                        "event_date": RUN_DATE.isoformat(),
+                        "security_id": "WATCH",
+                        "relationship": "monitored",
+                        "group": "company-specific",
+                        "headline": "WATCH schedules an investor day",
+                        "reference_url": "https://example.com/watch-ir",
+                        "summary": "The prepared event gives the scheduled time.",
+                    },
+                    {
+                        "source": "market",
+                        "source_name": "market",
+                        "event_type": "market",
+                        "event_date": RUN_DATE.isoformat(),
+                        "security_id": "SPY",
+                        "relationship": "market",
+                        "group": "market-context",
+                        "headline": "SPY moved 1.25%",
+                        "change_pct": 1.25,
+                        "reference_url": "https://example.com/spy",
+                    },
+                    {
+                        "source": "macro",
+                        "source_name": "macro",
+                        "event_type": "macro-release",
+                        "event_date": RUN_DATE.isoformat(),
+                        "security_id": "",
+                        "relationship": "market",
+                        "group": "macro-policy",
+                        "headline": "Employment report due at 08:30 ET",
+                        "reference_url": "https://example.com/macro",
+                        "summary": "The release is scheduled for 08:30 ET.",
+                    },
+                    {
+                        "source": "market",
+                        "source_name": "market",
+                        "event_type": "market-news",
+                        "event_date": RUN_DATE.isoformat(),
+                        "security_id": "",
+                        "relationship": "market",
+                        "group": "market-context",
+                        "headline": "Thin wire record covers a bank merger",
+                        "reference_url": "https://example.com/market-news",
+                        "summary": "A short prepared summary of the merger report.",
+                    },
                 ],
             }
         ),
@@ -153,7 +209,7 @@ def _payload_from_prompt(prompt: str, marker: str) -> dict:
     return json.loads(prompt.split(marker, 1)[1].strip())
 
 
-def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
+def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
     tmp_path: Path,
 ) -> None:
     db_path, prepared_path = _make_inputs(tmp_path)
@@ -167,22 +223,38 @@ def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
         if "PASS 1" in prompt:
             universe = _payload_from_prompt(prompt, "TITLE_UNIVERSE_JSON:")
             article_ids = [
-                item["id"] for item in universe["candidates"] if item["kind"] == "article"
+                item["id"]
+                for item in universe["candidates"]
+                if item["kind"] == "article"
             ]
-            event_id = next(
-                item["id"] for item in universe["candidates"] if item["kind"] == "event"
+            market_news_id = next(
+                item["id"]
+                for item in universe["candidates"]
+                if item.get("event_type") == "market-news"
             )
-            # Fenced JSON, duplicate IDs, and an invented ID are tolerated, but
-            # deterministic validation must keep only supplied universe IDs.
+            # Fenced JSON, reasons, duplicate IDs, and an invented ID are
+            # tolerated; validation keeps only supplied IDs.
             return (
                 "shortlist follows\n```json\n"
                 + json.dumps(
                     {
-                        "shortlist_ids": [
-                            article_ids[1],
-                            event_id,
-                            "article:not-in-universe",
-                            article_ids[1],
+                        "selections": [
+                            {
+                                "id": article_ids[1],
+                                "reason": "Richer IR evidence; punctuation: [] {}.",
+                            },
+                            {
+                                "id": market_news_id,
+                                "reason": "Distinct merger story.",
+                            },
+                            {
+                                "id": "article:not-in-universe",
+                                "reason": "Invented and rejected.",
+                            },
+                            {
+                                "id": article_ids[1],
+                                "reason": "Duplicate and rejected.",
+                            },
                         ]
                     }
                 )
@@ -207,8 +279,13 @@ def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
         f"daily-news-sol-{RUN_DATE.isoformat()}-"
     )
     assert all("DO NOT use or call any tools" in prompt for prompt in prompts)
-    assert all("DO NOT browse, search, or fetch anything" in prompt for prompt in prompts)
-    assert all("DO NOT read, create, edit, or write any files" in prompt for prompt in prompts)
+    assert all(
+        "DO NOT browse, search, or fetch anything" in prompt for prompt in prompts
+    )
+    assert all(
+        "DO NOT read, create, edit, or write any files" in prompt for prompt in prompts
+    )
+
     title_universe = _payload_from_prompt(prompts[0], "TITLE_UNIVERSE_JSON:")
     article_records = [
         item for item in title_universe["candidates"] if item["kind"] == "article"
@@ -224,25 +301,70 @@ def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
         {"id", "article_key", "source", "published", "title"} <= item.keys()
         for item in article_records
     )
+    market_news_records = [
+        item
+        for item in title_universe["candidates"]
+        if item.get("event_type") == "market-news"
+    ]
+    assert len(market_news_records) == 1
+    assert market_news_records[0]["article_candidate_class"] == (
+        "secondary_prepared_market_news"
+    )
+    assert title_universe["candidate_count"] == 4
+    assert "PORT reports before the open" not in prompts[0]
+    assert "WATCH schedules an investor day" not in prompts[0]
+    assert "SPY moved 1.25%" not in prompts[0]
+    assert "Employment report due at 08:30 ET" not in prompts[0]
     assert "UNSELECTED-SUMMARY" not in prompts[0]
     assert "UNSELECTED-CONTENT" not in prompts[0]
+    assert "targeting 15-25" in prompts[0]
+    assert "HARD MAXIMUM: select no more than 30 IDs" in prompts[0]
+    assert "Semantically deduplicate" in prompts[0]
+    assert "Reject lifestyle" in prompts[0]
 
     shortlisted = _payload_from_prompt(prompts[1], "SHORTLISTED_EVIDENCE_JSON:")
     assert shortlisted["shortlisted_count"] == 2
-    assert [item["kind"] for item in shortlisted["evidence"]] == ["article", "event"]
-    assert {item["id"] for item in shortlisted["evidence"]} == {
-        "article:key-ir",
-        next(
-            item["id"]
-            for item in title_universe["candidates"]
-            if item["kind"] == "event"
-        ),
+    assert shortlisted["automatic_event_count"] == 4
+    assert shortlisted["evidence_count"] == 6
+    evidence = shortlisted["evidence"]
+    assert [item["routing_class"] for item in evidence[:2]] == [
+        "selected_article",
+        "selected_article",
+    ]
+    auto_by_title = {item["title"]: item for item in evidence[2:]}
+    assert set(auto_by_title) == {
+        "PORT reports before the open",
+        "WATCH schedules an investor day",
+        "SPY moved 1.25%",
+        "Employment report due at 08:30 ET",
     }
+    assert auto_by_title["PORT reports before the open"]["routing_class"] == (
+        "auto_portfolio_watchlist"
+    )
+    assert auto_by_title["WATCH schedules an investor day"]["routing_class"] == (
+        "auto_portfolio_watchlist"
+    )
+    assert auto_by_title["SPY moved 1.25%"]["routing_class"] == "auto_market_move"
+    assert auto_by_title["Employment report due at 08:30 ET"]["routing_class"] == (
+        "other_auto_event"
+    )
+    selected_market_news = next(
+        item
+        for item in evidence
+        if item.get("article_candidate_class") == "secondary_prepared_market_news"
+    )
+    assert selected_market_news["url"] == "https://example.com/market-news"
+    assert selected_market_news["evidence"] == (
+        "A short prepared summary of the merger report."
+    )
+    assert selected_market_news["evidence_kind"] == "prepared_event"
     assert "article:not-in-universe" not in prompts[1]
     assert "UNSELECTED-SUMMARY" not in prompts[1]
-    fallback = shortlisted["evidence"][0]
+    fallback = evidence[0]
     assert fallback["evidence_kind"] == "bounded_content_fallback"
     assert len(fallback["evidence"]) <= MAX_ARTICLE_CONTENT_CHARS + 50
+    assert "represent EVERY record" in prompts[1]
+    assert "exactly ONE compact bullet/line" in prompts[1]
 
 
 @pytest.mark.parametrize(
@@ -262,10 +384,46 @@ def test_all_fresh_titles_reach_pass_1_and_only_valid_shortlist_reaches_pass_2(
             '{"article_ids":["article:a"],"event_ids":["event:b"]}',
             ["article:a", "event:b"],
         ),
+        (
+            json.dumps(
+                {
+                    "selections": [
+                        {
+                            "id": "article:a",
+                            "reason": 'JSON-safe reason with quotes: "important".',
+                        },
+                        {"id": "event:b", "reason": "Distinct read-through."},
+                    ]
+                }
+            ),
+            ["article:a", "event:b"],
+        ),
     ],
 )
 def test_broad_shortlist_parsing_is_robust(raw: str, expected: list[str]) -> None:
     assert parse_shortlist_output(raw) == expected
+
+
+def test_shortlist_validation_rejects_more_than_hard_maximum() -> None:
+    candidates = [
+        CandidateTitle(
+            id=f"article:{index}",
+            kind="article",
+            title=f"Article {index}",
+            source="wire",
+            published=RUN_DATE.isoformat(),
+            article_key=str(index),
+        )
+        for index in range(MAX_SHORTLIST_IDS + 5)
+    ]
+
+    with pytest.raises(
+        SynthesisError,
+        match=rf"returned {MAX_SHORTLIST_IDS + 5} valid IDs; hard maximum is {MAX_SHORTLIST_IDS}",
+    ):
+        validate_shortlist_ids(
+            [candidate.id for candidate in reversed(candidates)], candidates
+        )
 
 
 def test_invalid_pass_1_output_is_retried_once(tmp_path: Path) -> None:
@@ -278,9 +436,7 @@ def test_invalid_pass_1_output_is_retried_once(tmp_path: Path) -> None:
             pass_1_attempts += 1
             if pass_1_attempts == 1:
                 return "not JSON"
-            universe = _payload_from_prompt(
-                kwargs["prompt"], "TITLE_UNIVERSE_JSON:"
-            )
+            universe = _payload_from_prompt(kwargs["prompt"], "TITLE_UNIVERSE_JSON:")
             return json.dumps({"ids": [universe["candidates"][0]["id"]]})
         return FINAL_BRIEF
 
@@ -295,7 +451,9 @@ def test_invalid_pass_1_output_is_retried_once(tmp_path: Path) -> None:
     assert pass_1_attempts == 2
 
 
-def test_empty_shortlist_for_nonempty_universe_fails_after_retry(tmp_path: Path) -> None:
+def test_empty_shortlist_for_nonempty_universe_fails_after_retry(
+    tmp_path: Path,
+) -> None:
     db_path, prepared_path = _make_inputs(tmp_path)
     calls = 0
 
@@ -326,8 +484,7 @@ def test_empty_universe_preserves_explicit_evidence_thin_brief(tmp_path: Path) -
     prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
     prompts: list[str] = []
     thin_brief = (
-        "*Worth Knowing Today*\n"
-        "• Evidence is thin; no supported material items."
+        "*Worth Knowing Today*\n• Evidence is thin; no supported material items."
     )
 
     def model_call(**kwargs) -> str:
@@ -348,6 +505,8 @@ def test_empty_universe_preserves_explicit_evidence_thin_brief(tmp_path: Path) -
     assert shortlisted == {
         "run_date": RUN_DATE.isoformat(),
         "shortlisted_count": 0,
+        "automatic_event_count": 0,
+        "evidence_count": 0,
         "evidence": [],
     }
 
@@ -458,7 +617,9 @@ def test_default_workflow_uses_two_main_agent_turns_in_one_session(
             stdout = json.dumps(
                 {"status": "ok", "result": {"payloads": [{"text": FINAL_BRIEF}]}}
             )
-        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="diagnostic")
+        return subprocess.CompletedProcess(
+            command, 0, stdout=stdout, stderr="diagnostic"
+        )
 
     monkeypatch.setattr("harness.morning_brief_synthesis.subprocess.run", fake_run)
 
@@ -495,9 +656,7 @@ def test_openclaw_subprocess_failure_surfaces_stderr(
 
     monkeypatch.setattr("harness.morning_brief_synthesis.subprocess.run", fake_run)
 
-    with pytest.raises(
-        SynthesisError, match="status 17: gateway connection failed"
-    ):
+    with pytest.raises(SynthesisError, match="status 17: gateway connection failed"):
         synthesize_morning_brief(
             db_path=db_path,
             prepared_path=prepared_path,
@@ -506,17 +665,19 @@ def test_openclaw_subprocess_failure_surfaces_stderr(
         )
 
 
-def _write_fake_wrapper_commands(tmp_path: Path, *, pipeline_status: int) -> tuple[Path, Path]:
+def _write_fake_wrapper_commands(
+    tmp_path: Path, *, pipeline_status: int
+) -> tuple[Path, Path]:
     pipeline = tmp_path / "fake-pipeline.sh"
     pipeline.write_text(
         "#!/usr/bin/env bash\n"
-        "echo pipeline >> \"$ORDER_LOG\"\n"
+        'echo pipeline >> "$ORDER_LOG"\n'
         "echo collection-log-line\n"
         + (
-            "mkdir -p \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
-            f"{RUN_DATE.isoformat()}/data/rendered\"\n"
-            "echo evidence > \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
-            f"{RUN_DATE.isoformat()}/data/rendered/test.md\"\n"
+            'mkdir -p "$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/'
+            f'{RUN_DATE.isoformat()}/data/rendered"\n'
+            'echo evidence > "$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/'
+            f'{RUN_DATE.isoformat()}/data/rendered/test.md"\n'
             if pipeline_status == 0
             else ""
         )
@@ -528,7 +689,7 @@ def _write_fake_wrapper_commands(tmp_path: Path, *, pipeline_status: int) -> tup
     synthesis = tmp_path / "fake-synthesis.sh"
     synthesis.write_text(
         "#!/usr/bin/env bash\n"
-        "echo sol >> \"$ORDER_LOG\"\n"
+        'echo sol >> "$ORDER_LOG"\n'
         "printf '%s\\n' '*Worth Knowing Today*' '• item'\n",
         encoding="utf-8",
     )
@@ -590,15 +751,15 @@ def test_wrapper_retries_pipeline_once_before_invoking_sol(tmp_path: Path) -> No
     pipeline = tmp_path / "flaky-pipeline.sh"
     pipeline.write_text(
         "#!/usr/bin/env bash\n"
-        "echo pipeline >> \"$ORDER_LOG\"\n"
+        'echo pipeline >> "$ORDER_LOG"\n'
         "attempt=1\n"
-        "[[ -f \"$ATTEMPT_FILE\" ]] && attempt=2\n"
-        "touch \"$ATTEMPT_FILE\"\n"
-        "if [[ \"$attempt\" -eq 1 ]]; then exit 17; fi\n"
-        "mkdir -p \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
-        f"{RUN_DATE.isoformat()}/data/rendered\"\n"
-        "echo evidence > \"$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/"
-        f"{RUN_DATE.isoformat()}/data/rendered/test.md\"\n",
+        '[[ -f "$ATTEMPT_FILE" ]] && attempt=2\n'
+        'touch "$ATTEMPT_FILE"\n'
+        'if [[ "$attempt" -eq 1 ]]; then exit 17; fi\n'
+        'mkdir -p "$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/'
+        f'{RUN_DATE.isoformat()}/data/rendered"\n'
+        'echo evidence > "$MINERVA_WORKSPACE_ROOT/reports/03-daily-news/'
+        f'{RUN_DATE.isoformat()}/data/rendered/test.md"\n',
         encoding="utf-8",
     )
     pipeline.chmod(0o755)

--- a/tests/test_harness/test_morning_brief_synthesis.py
+++ b/tests/test_harness/test_morning_brief_synthesis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import subprocess
 from datetime import date, datetime
@@ -17,6 +18,7 @@ from harness.morning_brief_synthesis import (
     CandidateTitle,
     SynthesisError,
     main,
+    normalize_final_brief,
     parse_openclaw_json_output,
     parse_shortlist_output,
     synthesize_morning_brief,
@@ -26,10 +28,12 @@ from harness.morning_brief_synthesis import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_DATE = date(2026, 7, 19)
 FINAL_BRIEF = (
-    "*Worth Knowing Today*\n"
-    "• Material development <https://example.com/story|Reuters>\n\n"
+    "*Market Snapshot*\n"
+    "• SPY moved 1.25% <https://example.com/spy|Market>\n\n"
     "*Portfolio / Watchlist Events*\n"
-    "• Portfolio item <https://example.com/ir|PORT IR>"
+    "• Portfolio item <https://example.com/ir|PORT IR>\n\n"
+    "*Worth Knowing Today*\n"
+    "• Material development <https://example.com/story|Reuters>"
 )
 
 
@@ -365,6 +369,98 @@ def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
     assert len(fallback["evidence"]) <= MAX_ARTICLE_CONTENT_CHARS + 50
     assert "represent EVERY record" in prompts[1]
     assert "exactly ONE compact bullet/line" in prompts[1]
+    assert (
+        "Use section order: *Market Snapshot* first when its routed evidence exists, "
+        "then *Portfolio / Watchlist Events* when its routed evidence exists, then "
+        "*Worth Knowing Today* (required)"
+    ) in prompts[1]
+    assert (
+        "Emit this section if and only if auto_portfolio_watchlist evidence exists."
+        in prompts[1]
+    )
+    assert (
+        "Emit this section if and only if auto_market_move evidence exists."
+        in prompts[1]
+    )
+
+
+def test_final_brief_validation_enforces_market_portfolio_worth_order() -> None:
+    assert (
+        normalize_final_brief(
+            FINAL_BRIEF,
+            has_market_move_evidence=True,
+            has_portfolio_watchlist_evidence=True,
+        )
+        == FINAL_BRIEF
+    )
+    prior_order = (
+        "*Worth Knowing Today*\n• Article\n\n"
+        "*Portfolio / Watchlist Events*\n• Portfolio event\n\n"
+        "*Market Snapshot*\n• Market move"
+    )
+
+    with pytest.raises(
+        SynthesisError,
+        match=(
+            "expected Market Snapshot, Portfolio / Watchlist Events, then Worth "
+            "Knowing Today"
+        ),
+    ):
+        normalize_final_brief(
+            prior_order,
+            has_market_move_evidence=True,
+            has_portfolio_watchlist_evidence=True,
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        "brief",
+        "has_market_move_evidence",
+        "has_portfolio_watchlist_evidence",
+        "message",
+    ),
+    [
+        (
+            "*Worth Knowing Today*\n• Article",
+            True,
+            False,
+            "omitted required Market Snapshot section",
+        ),
+        (
+            "*Market Snapshot*\n• Move\n\n*Worth Knowing Today*\n• Article",
+            False,
+            False,
+            "included Market Snapshot section without auto_market_move evidence",
+        ),
+        (
+            "*Worth Knowing Today*\n• Article",
+            False,
+            True,
+            "omitted required Portfolio / Watchlist Events section",
+        ),
+        (
+            "*Portfolio / Watchlist Events*\n• Event\n\n"
+            "*Worth Knowing Today*\n• Article",
+            False,
+            False,
+            "included Portfolio / Watchlist Events section without "
+            "auto_portfolio_watchlist evidence",
+        ),
+    ],
+)
+def test_final_brief_sections_follow_automatic_evidence(
+    brief: str,
+    has_market_move_evidence: bool,
+    has_portfolio_watchlist_evidence: bool,
+    message: str,
+) -> None:
+    with pytest.raises(SynthesisError, match=re.escape(message)):
+        normalize_final_brief(
+            brief,
+            has_market_move_evidence=has_market_move_evidence,
+            has_portfolio_watchlist_evidence=has_portfolio_watchlist_evidence,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- partition article candidates from automatically routed events
- route portfolio/watchlist events and market moves deterministically
- prefer richer collected articles over secondary provider summaries
- enforce Slack section presence and ordering: Market Snapshot, Portfolio / Watchlist Events, Worth Knowing Today, Other Events

## Stack

1. Post-ingest synthesis foundation (#70)
2. **This PR:** evidence routing and section ordering
3. Deterministic source accounting
4. Finnhub persistence (#69)

This PR is based on `feat/morning-brief-post-ingest-synthesis`; merge #70 first.
