### PR TITLE
feat(brief): add deterministic source accounting

### DIFF
--- a/src/harness/morning_brief_synthesis.py
+++ b/src/harness/morning_brief_synthesis.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Sequence
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 DEFAULT_MODEL = "gpt-5.6-sol"
 DEFAULT_REASONING = "high"
@@ -35,6 +36,18 @@ ROUTING_AUTO_PORTFOLIO = "auto_portfolio_watchlist"
 ROUTING_AUTO_MARKET = "auto_market_move"
 ROUTING_OTHER_AUTO = "other_auto_event"
 PORTFOLIO_ROLES = frozenset({"holding", "watchlist"})
+ARTICLE_EVENT_TYPES = frozenset({"market-news", "company-news"})
+CORE_SOURCE_LABELS = (
+    "Reuters",
+    "Economist",
+    "WSJ",
+    "Company IR",
+    "BLS/BEA/Fed",
+)
+PREFERRED_NEWS_SOURCE_LABELS = ("Reuters", "Yahoo", "CNBC", "Bloomberg")
+SOURCE_COLLECTION_LINE_RE = re.compile(
+    r"(?im)^\s*(?:(?:[•●▪◦-]|\*)\s+)?\*{0,2}Source\s+Collection\s*:\*{0,2}"
+)
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 ModelCall = Callable[..., str]
@@ -123,7 +136,7 @@ def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateT
     try:
         rows = connection.execute(
             """
-            SELECT article_key, source, published_at, published_at_raw, title
+            SELECT article_key, source, published_at, published_at_raw, title, url
             FROM news
             WHERE substr(collected_at, 1, 10) = ?
             ORDER BY source COLLATE NOCASE,
@@ -151,7 +164,10 @@ def query_fresh_article_titles(db_path: Path, run_date: date) -> list[CandidateT
                 source=str(row["source"]),
                 published=published_raw or published_iso,
                 title=str(row["title"]),
-                metadata={"published_at": published_iso},
+                metadata={
+                    "published_at": published_iso,
+                    "url": str(row["url"] or "").strip(),
+                },
             )
         )
     return candidates
@@ -264,6 +280,92 @@ def partition_candidates(candidates: Sequence[CandidateTitle]) -> RoutingPlan:
         automatic_events.append(RoutedEvent(candidate, routing_class))
 
     return RoutingPlan(tuple(article_candidates), tuple(automatic_events))
+
+
+def build_source_collection_line(candidates: Sequence[CandidateTitle]) -> str:
+    """Count the run's article records and market observations deterministically.
+
+    Fresh SQLite rows and prepared ``market-news``/``company-news`` events are
+    article records. Prepared ``market`` events are observations instead. Exact
+    repeated records are counted once, with richer SQLite records taking
+    precedence over prepared news records.
+    """
+    counts = {label: 0 for label in CORE_SOURCE_LABELS}
+    prepared_labels: set[str] = set()
+    collected_labels: set[str] = set()
+    seen_candidate_ids: set[str] = set()
+    seen_article_records: set[tuple[str, ...]] = set()
+    seen_market_observations: set[tuple[str, str, str]] = set()
+    article_record_count = 0
+    market_price_observations = 0
+
+    # SQLite rows contain richer evidence and win when the same article also
+    # appears as a prepared Finnhub-style news event.
+    ordered_candidates = sorted(candidates, key=lambda item: item.kind != "article")
+    for candidate in ordered_candidates:
+        event_type = str(candidate.metadata.get("event_type") or "").strip().casefold()
+        if candidate.kind == "event" and event_type == "market":
+            observation_key = (
+                str(
+                    candidate.metadata.get("security_id")
+                    or candidate.metadata.get("ticker")
+                    or ""
+                )
+                .strip()
+                .casefold(),
+                candidate.published,
+                _normalized_title(candidate.title),
+            )
+            if observation_key not in seen_market_observations:
+                seen_market_observations.add(observation_key)
+                market_price_observations += 1
+            continue
+
+        if candidate.kind == "article":
+            source_label = _collected_source_label(candidate.source)
+            source_kind = "collected"
+        elif candidate.kind == "event" and event_type in ARTICLE_EVENT_TYPES:
+            source_label = _prepared_news_source_label(candidate.metadata)
+            source_kind = "prepared"
+        else:
+            continue
+
+        record_key = _article_record_key(candidate, source_label)
+        if candidate.id in seen_candidate_ids:
+            continue
+        # Every fresh SQLite row is an available article record. Prepared news
+        # is the secondary representation and is suppressed when that article
+        # was already counted from SQLite or an earlier prepared event.
+        if candidate.kind == "event" and record_key in seen_article_records:
+            continue
+
+        seen_candidate_ids.add(candidate.id)
+        seen_article_records.add(record_key)
+        counts[source_label] = counts.get(source_label, 0) + 1
+        article_record_count += 1
+        if source_kind == "prepared":
+            prepared_labels.add(source_label)
+        else:
+            collected_labels.add(source_label)
+
+    source_labels = _ordered_source_labels(
+        counts,
+        prepared_labels=prepared_labels,
+        collected_labels=collected_labels,
+    )
+    source_counts = " · ".join(
+        f"{label} {counts[label]}" for label in source_labels
+    )
+    article_noun = "article record" if article_record_count == 1 else "article records"
+    observation_noun = (
+        "market-price observation"
+        if market_price_observations == 1
+        else "market-price observations"
+    )
+    return (
+        f"*Source Collection:* {article_record_count} {article_noun} — {source_counts}; "
+        f"plus {market_price_observations} {observation_noun}."
+    )
 
 
 def build_shortlist_prompt(candidates: Sequence[CandidateTitle], run_date: date) -> str:
@@ -469,8 +571,10 @@ def build_final_prompt(
         "if auto_market_move evidence exists.\n"
         "- other_auto_event: include EVERY record appropriately and concisely, consolidating true "
         "duplicates; use *Other Events* when a separate section is clearest.\n\n"
-        "Return ONLY the final Slack-formatted daily-news brief as plain text (Slack mrkdwn), with no "
-        "JSON, code fence, preamble, postscript, or file instructions. Use section order: *Market "
+        "Return ONLY the final Slack-formatted daily-news brief body as plain text (Slack mrkdwn), "
+        "with no JSON, code fence, preamble, postscript, or file instructions. Do not write a Source "
+        "Collection line or any source counts; deterministic code will prepend that line after this "
+        "turn. Use section order: *Market "
         "Snapshot* first when its routed evidence exists, then *Portfolio / Watchlist Events* when "
         "its routed evidence exists, then *Worth Knowing Today* (required), and finally *Other "
         "Events* when its routed evidence exists. Preserve supplied URLs when representing "
@@ -506,6 +610,10 @@ def normalize_final_brief(
         decoded = None
     if isinstance(decoded, (dict, list)):
         raise SynthesisError("pass 2 returned JSON instead of a text-only Slack brief")
+    if SOURCE_COLLECTION_LINE_RE.search(brief):
+        raise SynthesisError(
+            "pass 2 returned a Source Collection line that deterministic code owns"
+        )
 
     section_positions = {
         "Market Snapshot": _section_heading_position(brief, "Market Snapshot"),
@@ -538,6 +646,8 @@ def normalize_final_brief(
             "pass 2 returned sections out of order; expected Market Snapshot, "
             "Portfolio / Watchlist Events, then Worth Knowing Today"
         )
+    if not present_positions or present_positions[0] != 0:
+        raise SynthesisError("pass 2 returned text before its first Slack section")
     return brief
 
 
@@ -555,6 +665,7 @@ def synthesize_morning_brief(
 ) -> str:
     """Run both OpenClaw turns in one session and persist the final artifact."""
     all_candidates = build_title_universe(db_path, prepared_path, run_date)
+    source_collection_line = build_source_collection_line(all_candidates)
     routing_plan = partition_candidates(all_candidates)
     candidates = routing_plan.article_candidates
     call_model = model_call or _default_model_call
@@ -596,7 +707,7 @@ def synthesize_morning_brief(
         item.get("routing_class") == ROUTING_AUTO_PORTFOLIO
         for item in automatic_evidence
     )
-    brief = _with_retries(
+    synthesized_body = _with_retries(
         lambda: normalize_final_brief(
             call_model(
                 prompt=pass_2_prompt,
@@ -610,6 +721,7 @@ def synthesize_morning_brief(
         attempts=retry_count + 1,
         stage="pass 2 synthesis",
     )
+    brief = f"{source_collection_line}\n{synthesized_body}"
 
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -849,6 +961,179 @@ def _universe_role_map(raw_universe: Any) -> dict[str, str]:
         if security_id and role:
             roles[security_id] = role
     return roles
+
+
+def _collected_source_label(raw_source: str) -> str:
+    normalized = re.sub(r"[\s_]+", "-", raw_source.strip().casefold())
+    if normalized.startswith("ir-") or normalized == "ir":
+        return "Company IR"
+    if normalized.startswith(("bls-", "bea-", "fed-")) or normalized in {
+        "bls",
+        "bea",
+        "fed",
+        "federal-reserve",
+    }:
+        return "BLS/BEA/Fed"
+    return _canonical_news_source_label(raw_source)
+
+
+def _prepared_news_source_label(event: dict[str, Any]) -> str:
+    raw_source = _first_nonempty_text(
+        event.get("news_source"),
+        _nested_value(event, "metadata", "news_source"),
+        _nested_value(event, "metadata", "source"),
+    )
+    return _canonical_news_source_label(raw_source)
+
+
+def _canonical_news_source_label(raw_source: Any) -> str:
+    display = re.sub(r"\s+", " ", str(raw_source or "").strip())
+    if not display:
+        return "Unknown"
+    key = re.sub(r"[\s_-]+", " ", display.casefold()).strip()
+    if key.startswith("reuters"):
+        return "Reuters"
+    if key in {"wsj", "wall street journal", "the wall street journal"} or key.startswith(
+        ("wsj ", "wall street journal ", "the wall street journal ")
+    ):
+        return "WSJ"
+    if key in {"economist", "the economist"} or key.startswith(
+        ("economist ", "the economist ")
+    ):
+        return "Economist"
+    if key.startswith("yahoo"):
+        return "Yahoo"
+    if key.startswith("cnbc"):
+        return "CNBC"
+    if key.startswith("bloomberg"):
+        return "Bloomberg"
+    if key in {"bls", "bea", "fed", "federal reserve"}:
+        return "BLS/BEA/Fed"
+    aliases = {
+        "ap": "AP",
+        "associated press": "AP",
+        "ft": "FT",
+        "financial times": "FT",
+        "seekingalpha": "Seeking Alpha",
+        "seeking alpha": "Seeking Alpha",
+    }
+    if key in aliases:
+        return aliases[key]
+    return display.title() if display.islower() else display
+
+
+def _candidate_article_url(candidate: CandidateTitle) -> str:
+    if candidate.kind == "article":
+        raw_url = candidate.metadata.get("url")
+    else:
+        raw_url = _first_nonempty_text(
+            candidate.metadata.get("reference_url"),
+            candidate.metadata.get("source_url"),
+            _nested_value(candidate.metadata, "metadata", "url"),
+        )
+    url = str(raw_url or "").strip()
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+        query = urlencode(
+            sorted(
+                (key, value)
+                for key, value in parse_qsl(parts.query, keep_blank_values=True)
+                if not key.casefold().startswith("utm_")
+                and key.casefold()
+                not in {"fbclid", "gclid", "mc_cid", "mc_eid"}
+            )
+        )
+        host = parts.netloc.casefold().removeprefix("www.")
+        return urlunsplit(("", host, parts.path.rstrip("/"), query, ""))
+    except ValueError:
+        return url.partition("#")[0].rstrip("/")
+
+
+def _article_record_key(
+    candidate: CandidateTitle, source_label: str
+) -> tuple[str, ...]:
+    title = _normalized_title(candidate.title)
+    url = _candidate_article_url(candidate)
+    if url:
+        return ("url", url)
+    security_id = str(
+        candidate.metadata.get("security_id")
+        or candidate.metadata.get("ticker")
+        or ""
+    ).strip().casefold()
+    return (
+        "fallback",
+        _source_identity(candidate, source_label),
+        security_id,
+        title,
+        _candidate_publication_day(candidate),
+    )
+
+
+def _candidate_publication_day(candidate: CandidateTitle) -> str:
+    for value in (
+        candidate.metadata.get("published_at"),
+        candidate.metadata.get("event_date"),
+        candidate.published,
+    ):
+        match = re.search(r"\b\d{4}-\d{2}-\d{2}\b", str(value or ""))
+        if match:
+            return match.group(0)
+    return candidate.published.strip().casefold()
+
+
+def _normalized_title(title: str) -> str:
+    return re.sub(r"[^\w]+", " ", title.casefold()).strip()
+
+
+def _source_identity(candidate: CandidateTitle, source_label: str) -> str:
+    if candidate.kind == "article" and source_label in {"Company IR", "BLS/BEA/Fed"}:
+        return f"{source_label}|{candidate.source}".casefold()
+    return source_label.casefold()
+
+
+def _ordered_source_labels(
+    counts: dict[str, int],
+    *,
+    prepared_labels: set[str],
+    collected_labels: set[str],
+) -> list[str]:
+    labels: list[str] = []
+
+    def append(label: str) -> None:
+        if label in counts and label not in labels:
+            labels.append(label)
+
+    # Prepared news feeds dominate volume, so show their familiar outlets
+    # first. Reuters is also a configured full-text source and remains visible
+    # at zero when neither collection path produced a record.
+    append("Reuters")
+    for label in PREFERRED_NEWS_SOURCE_LABELS[1:]:
+        if counts.get(label, 0):
+            append(label)
+    for label in sorted(
+        prepared_labels
+        - set(PREFERRED_NEWS_SOURCE_LABELS)
+        - set(CORE_SOURCE_LABELS),
+        key=str.casefold,
+    ):
+        append(label)
+
+    append("Economist")
+    append("WSJ")
+    for label in sorted(
+        collected_labels - set(CORE_SOURCE_LABELS) - set(PREFERRED_NEWS_SOURCE_LABELS),
+        key=str.casefold,
+    ):
+        append(label)
+    append("Company IR")
+    append("BLS/BEA/Fed")
+
+    for label in sorted(set(counts) - set(labels), key=str.casefold):
+        append(label)
+    return labels
 
 
 def _epoch_as_iso(raw_epoch: Any) -> str:

--- a/tests/test_harness/test_morning_brief_synthesis.py
+++ b/tests/test_harness/test_morning_brief_synthesis.py
@@ -17,6 +17,7 @@ from harness.morning_brief_synthesis import (
     MAX_SHORTLIST_IDS,
     CandidateTitle,
     SynthesisError,
+    build_source_collection_line,
     main,
     normalize_final_brief,
     parse_openclaw_json_output,
@@ -27,7 +28,7 @@ from harness.morning_brief_synthesis import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_DATE = date(2026, 7, 19)
-FINAL_BRIEF = (
+MODEL_BRIEF = (
     "*Market Snapshot*\n"
     "• SPY moved 1.25% <https://example.com/spy|Market>\n\n"
     "*Portfolio / Watchlist Events*\n"
@@ -35,6 +36,15 @@ FINAL_BRIEF = (
     "*Worth Knowing Today*\n"
     "• Material development <https://example.com/story|Reuters>"
 )
+SOURCE_COLLECTION_LINE = (
+    "*Source Collection:* 5 article records — Reuters 2 · CNBC 1 · Economist 0 · "
+    "WSJ 0 · FT 1 · Company IR 1 · BLS/BEA/Fed 0; plus 1 market-price observation."
+)
+EMPTY_SOURCE_COLLECTION_LINE = (
+    "*Source Collection:* 0 article records — Reuters 0 · Economist 0 · WSJ 0 · "
+    "Company IR 0 · BLS/BEA/Fed 0; plus 0 market-price observations."
+)
+FINAL_BRIEF = f"{SOURCE_COLLECTION_LINE}\n{MODEL_BRIEF}"
 
 
 def _epoch(day: str) -> int:
@@ -164,6 +174,7 @@ def _make_inputs(tmp_path: Path) -> tuple[Path, Path]:
                         "headline": "WATCH schedules an investor day",
                         "reference_url": "https://example.com/watch-ir",
                         "summary": "The prepared event gives the scheduled time.",
+                        "news_source": "CNBC",
                     },
                     {
                         "source": "market",
@@ -200,6 +211,7 @@ def _make_inputs(tmp_path: Path) -> tuple[Path, Path]:
                         "headline": "Thin wire record covers a bank merger",
                         "reference_url": "https://example.com/market-news",
                         "summary": "A short prepared summary of the merger report.",
+                        "news_source": "Reuters",
                     },
                 ],
             }
@@ -211,6 +223,145 @@ def _make_inputs(tmp_path: Path) -> tuple[Path, Path]:
 
 def _payload_from_prompt(prompt: str, marker: str) -> dict:
     return json.loads(prompt.split(marker, 1)[1].strip())
+
+
+def test_source_collection_counts_all_article_records_without_double_counting() -> None:
+    article_url = "https://example.com/reuters-exclusive"
+    candidates = [
+        CandidateTitle(
+            id="article:reuters",
+            kind="article",
+            title="Rates move after inflation data",
+            source="reuters-markets",
+            published=RUN_DATE.isoformat(),
+            article_key="reuters",
+            metadata={"url": article_url, "published_at": RUN_DATE.isoformat()},
+        ),
+        CandidateTitle(
+            id="article:reuters-update",
+            kind="article",
+            title="Rates move after inflation data — update",
+            source="reuters-markets",
+            published=RUN_DATE.isoformat(),
+            article_key="reuters-update",
+            metadata={"url": article_url, "published_at": RUN_DATE.isoformat()},
+        ),
+        CandidateTitle(
+            id="article:economist",
+            kind="article",
+            title="The productivity puzzle",
+            source="economist-business",
+            published=RUN_DATE.isoformat(),
+            article_key="economist",
+            metadata={"url": "https://example.com/economist"},
+        ),
+        CandidateTitle(
+            id="article:ir-port",
+            kind="article",
+            title="PORT announces an acquisition",
+            source="ir-PORT",
+            published=RUN_DATE.isoformat(),
+            article_key="ir-port",
+            metadata={"url": "https://example.com/port"},
+        ),
+        CandidateTitle(
+            id="article:ir-watch",
+            kind="article",
+            title="WATCH schedules an investor day",
+            source="ir-WATCH",
+            published=RUN_DATE.isoformat(),
+            article_key="ir-watch",
+            metadata={"url": "https://example.com/watch"},
+        ),
+        CandidateTitle(
+            id="article:bls",
+            kind="article",
+            title="Employment situation released",
+            source="bls-calendar",
+            published=RUN_DATE.isoformat(),
+            article_key="bls",
+            metadata={"url": "https://example.com/bls"},
+        ),
+        CandidateTitle(
+            id="event:duplicate-reuters",
+            kind="event",
+            title="Rates move after inflation data",
+            source="market",
+            published=RUN_DATE.isoformat(),
+            metadata={
+                "event_type": "market-news",
+                "news_source": "Reuters",
+                "reference_url": f"{article_url}/?utm_source=finnhub",
+            },
+        ),
+        CandidateTitle(
+            id="event:yahoo",
+            kind="event",
+            title="A distinct market story",
+            source="market",
+            published=RUN_DATE.isoformat(),
+            metadata={
+                "event_type": "market-news",
+                "news_source": "Yahoo Finance",
+                "reference_url": "https://example.com/yahoo",
+            },
+        ),
+        CandidateTitle(
+            id="event:bloomberg",
+            kind="event",
+            title="A distinct company story",
+            source="market",
+            published=RUN_DATE.isoformat(),
+            metadata={
+                "event_type": "company-news",
+                "news_source": "Bloomberg News",
+                "reference_url": "https://example.com/bloomberg",
+            },
+        ),
+        CandidateTitle(
+            id="event:spy-one",
+            kind="event",
+            title="SPY moved 1.25%",
+            source="market",
+            published=RUN_DATE.isoformat(),
+            metadata={"event_type": "market", "security_id": "SPY"},
+        ),
+        CandidateTitle(
+            id="event:spy-duplicate",
+            kind="event",
+            title="SPY moved 1.25%",
+            source="market",
+            published=RUN_DATE.isoformat(),
+            metadata={"event_type": "market", "security_id": "SPY"},
+        ),
+        CandidateTitle(
+            id="event:qqq",
+            kind="event",
+            title="QQQ moved 1.50%",
+            source="market",
+            published=RUN_DATE.isoformat(),
+            metadata={"event_type": "market", "security_id": "QQQ"},
+        ),
+        CandidateTitle(
+            id="event:earnings",
+            kind="event",
+            title="PORT reports before the open",
+            source="earnings",
+            published=RUN_DATE.isoformat(),
+            metadata={"event_type": "earnings", "security_id": "PORT"},
+        ),
+    ]
+
+    line = build_source_collection_line(candidates)
+
+    assert line == (
+        "*Source Collection:* 8 article records — Reuters 2 · Yahoo 1 · Bloomberg 1 · "
+        "Economist 1 · WSJ 0 · Company IR 2 · BLS/BEA/Fed 1; plus 2 "
+        "market-price observations."
+    )
+    assert "earnings" not in line.casefold()
+    assert "\n" not in line
+    assert not line.startswith(("•", "-", "* "))
 
 
 def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
@@ -264,7 +415,7 @@ def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
                 )
                 + "\n```"
             )
-        return FINAL_BRIEF
+        return MODEL_BRIEF
 
     brief = synthesize_morning_brief(
         db_path=db_path,
@@ -274,6 +425,9 @@ def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
     )
 
     assert brief == FINAL_BRIEF
+    assert brief.startswith(f"{SOURCE_COLLECTION_LINE}\n*Market Snapshot*")
+    assert brief.count("*Source Collection:*") == 1
+    assert not brief.startswith(("•", "-", "* "))
     assert len(prompts) == 2
     assert {call["model"] for call in model_calls} == {"gpt-5.6-sol"}
     assert {call["reasoning"] for call in model_calls} == {"high"}
@@ -369,6 +523,7 @@ def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
     assert len(fallback["evidence"]) <= MAX_ARTICLE_CONTENT_CHARS + 50
     assert "represent EVERY record" in prompts[1]
     assert "exactly ONE compact bullet/line" in prompts[1]
+    assert "Do not write a Source Collection line or any source counts" in prompts[1]
     assert (
         "Use section order: *Market Snapshot* first when its routed evidence exists, "
         "then *Portfolio / Watchlist Events* when its routed evidence exists, then "
@@ -387,11 +542,11 @@ def test_weighted_routing_partitions_pass_1_and_labels_all_pass_2_evidence(
 def test_final_brief_validation_enforces_market_portfolio_worth_order() -> None:
     assert (
         normalize_final_brief(
-            FINAL_BRIEF,
+            MODEL_BRIEF,
             has_market_move_evidence=True,
             has_portfolio_watchlist_evidence=True,
         )
-        == FINAL_BRIEF
+        == MODEL_BRIEF
     )
     prior_order = (
         "*Worth Knowing Today*\n• Article\n\n"
@@ -408,6 +563,24 @@ def test_final_brief_validation_enforces_market_portfolio_worth_order() -> None:
     ):
         normalize_final_brief(
             prior_order,
+            has_market_move_evidence=True,
+            has_portfolio_watchlist_evidence=True,
+        )
+
+
+def test_model_cannot_add_a_second_source_collection_line() -> None:
+    with pytest.raises(SynthesisError, match="deterministic code owns"):
+        normalize_final_brief(
+            f"*Source Collection:* invented counts\n{MODEL_BRIEF}",
+            has_market_move_evidence=True,
+            has_portfolio_watchlist_evidence=True,
+        )
+
+
+def test_model_cannot_put_a_preamble_between_collection_and_market() -> None:
+    with pytest.raises(SynthesisError, match="text before its first Slack section"):
+        normalize_final_brief(
+            f"Good morning.\n\n{MODEL_BRIEF}",
             has_market_move_evidence=True,
             has_portfolio_watchlist_evidence=True,
         )
@@ -534,7 +707,7 @@ def test_invalid_pass_1_output_is_retried_once(tmp_path: Path) -> None:
                 return "not JSON"
             universe = _payload_from_prompt(kwargs["prompt"], "TITLE_UNIVERSE_JSON:")
             return json.dumps({"ids": [universe["candidates"][0]["id"]]})
-        return FINAL_BRIEF
+        return MODEL_BRIEF
 
     result = synthesize_morning_brief(
         db_path=db_path,
@@ -596,7 +769,7 @@ def test_empty_universe_preserves_explicit_evidence_thin_brief(tmp_path: Path) -
         model_call=model_call,
     )
 
-    assert result == thin_brief
+    assert result == f"{EMPTY_SOURCE_COLLECTION_LINE}\n{thin_brief}"
     shortlisted = _payload_from_prompt(prompts[1], "SHORTLISTED_EVIDENCE_JSON:")
     assert shortlisted == {
         "run_date": RUN_DATE.isoformat(),
@@ -623,7 +796,7 @@ def test_cli_stdout_and_artifact_are_final_text_only_and_no_temp_json(
         if "PASS 1" in kwargs["prompt"]:
             universe = _payload_from_prompt(kwargs["prompt"], "TITLE_UNIVERSE_JSON:")
             return json.dumps({"ids": [universe["candidates"][0]["id"]]})
-        return f"```mrkdwn\n{FINAL_BRIEF}\n```"
+        return f"```mrkdwn\n{MODEL_BRIEF}\n```"
 
     status = main(
         [
@@ -711,7 +884,7 @@ def test_default_workflow_uses_two_main_agent_turns_in_one_session(
             stdout = json.dumps({"payloads": [{"text": reply}]})
         else:
             stdout = json.dumps(
-                {"status": "ok", "result": {"payloads": [{"text": FINAL_BRIEF}]}}
+                {"status": "ok", "result": {"payloads": [{"text": MODEL_BRIEF}]}}
             )
         return subprocess.CompletedProcess(
             command, 0, stdout=stdout, stderr="diagnostic"


### PR DESCRIPTION
## Summary

- prepend a deterministic source-collection line to every brief
- count SQLite articles and prepared Finnhub news exactly once
- separate article records from market-price observations
- normalize source labels and suppress duplicate provider representations

## Stack

1. Post-ingest synthesis foundation (#70)
2. Evidence routing and section ordering (#71)
3. **This PR:** deterministic source accounting
4. Finnhub persistence (#69)

This PR is based on `feat/morning-brief-evidence-routing`; merge #70 and #71 first.
