### PR TITLE
feat(cli): add summarize and upgrade Gemini Flash

### DIFF
--- a/src/harness/cli.py
+++ b/src/harness/cli.py
@@ -39,6 +39,7 @@ app = typer.Typer(
         "Examples:\n"
         "  minerva sec 10k AAPL --items 7\n"
         "  minerva extract -f apple-10k.md \"What are the key risks?\"\n"
+        "  minerva summarize -f earnings-call.txt\n"
         "  minerva extract-files -q questions.md -F selected-files.txt -o data/extractions/summary\n"
         "  minerva run \"sec 10k AAPL --items 1A | extract 'What are the top 3 risk factors?'\"\n"
     ),

--- a/src/harness/commands/__init__.py
+++ b/src/harness/commands/__init__.py
@@ -31,5 +31,6 @@ def register_commands(app: typer.Typer) -> None:
     app.add_typer(plot.app, name="plot")
     app.add_typer(extract.app, name="extract")
     app.add_typer(extract.extract_files_app, name="extract-files")
+    app.add_typer(extract.summarize_app, name="summarize")
     app.add_typer(fileinfo.app, name="fileinfo")
     app.add_typer(research.app, name="research")

--- a/src/harness/commands/extract.py
+++ b/src/harness/commands/extract.py
@@ -1,4 +1,4 @@
-"""LLM extraction commands backed by Gemini or OpenAI."""
+"""LLM extraction and summarization commands backed by Gemini or OpenAI."""
 
 from __future__ import annotations
 
@@ -31,6 +31,14 @@ EXTRACT_HELP = (
     "  minerva run \"sec 10k AAPL --items 1A | extract 'What are the top 3 risk factors?'\"\n"
 )
 
+SUMMARIZE_HELP = (
+    "Summarize UTF-8 text from a file or stdin.\n\n"
+    "Examples:\n"
+    "  minerva summarize --file earnings-call.txt\n"
+    "  cat filing.md | minerva summarize --max-tokens 2000\n"
+    "  minerva summarize -f notes.md --model gemini-3.6-flash --thinking high\n"
+)
+
 EXTRACT_FILES_HELP = (
     "Apply one extraction prompt or question pack across many UTF-8 text/markdown files.\n\n"
     "Examples:\n"
@@ -44,15 +52,16 @@ EXTRACT_FILES_HELP = (
     "    -o data/extractions/summary\n"
     "  minerva extract-files --questions-file questions.md \\\n"
     "    --files 'data/sources/**/*.md' --out data/extractions/summary \\\n"
-    "    --model gemini-3-flash --thinking minimal --concurrency 4\n"
+    "    --model gemini-3.6-flash --thinking minimal --concurrency 4\n"
     "  minerva extract-files -q questions.md -f 'data/**/*.md' -o out \\\n"
     "    --model gpt-5.5 --concurrency 2\n"
 )
 
-DEFAULT_MODEL = "gemini-3-flash"
+DEFAULT_MODEL = "gemini-3.6-flash"
 DEFAULT_MAX_TOKENS = 16384
 DEFAULT_CONCURRENCY = 4
 MODEL_ALIASES: dict[str, str] = {
+    # Gemini 3.6 Flash already uses Google's stable provider model code; no alias needed.
     # OpenClaw/user-facing shorthand; Google GenAI expects the preview model id today.
     "gemini-3-flash": "gemini-3-flash-preview",
     # Accept provider-qualified OpenClaw-style names while sending OpenAI its model id.
@@ -84,10 +93,17 @@ SYSTEM_PROMPT = (
     "Cite section/page numbers when possible. If the prompt contains multiple "
     "questions, answer each under a clearly labeled markdown heading."
 )
+SUMMARY_PROMPT = (
+    "Summarize the document below concisely and accurately. Preserve material facts, "
+    "figures, qualifications, and conclusions. Return only the summary without a preamble."
+)
 
 VALID_THINKING_LEVELS: frozenset[str] = frozenset({"off", "minimal", "low", "medium", "high", "adaptive"})
 
 app = typer.Typer(help=EXTRACT_HELP, no_args_is_help=False, invoke_without_command=True)
+summarize_app = typer.Typer(
+    help=SUMMARIZE_HELP, no_args_is_help=False, invoke_without_command=True
+)
 extract_files_app = typer.Typer(help=EXTRACT_FILES_HELP, no_args_is_help=False, invoke_without_command=True)
 # ---------------------------------------------------------------------------
 # `extract`
@@ -227,6 +243,100 @@ def extract_cli_command(
             settings=settings,
         )
     )
+# ---------------------------------------------------------------------------
+# `summarize`
+# ---------------------------------------------------------------------------
+
+
+def summarize_command(
+    *,
+    file_path: str | None = None,
+    model: str = DEFAULT_MODEL,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    thinking: str | None = None,
+    stdin: bytes = b"",
+    settings: HarnessSettings,
+) -> CommandResult:
+    """Summarize one UTF-8 text input using the shared extraction model backend."""
+    start = time.perf_counter()
+    try:
+        document_text = _read_summary_text(file_path=file_path, stdin=stdin)
+        resolved_thinking = _resolve_default_thinking(model, thinking)
+        _build_thinking_config(model, resolved_thinking)
+        api_key = _api_key_for_model(settings, model)
+        if not api_key:
+            return _missing_api_key_result(model, start)
+        prompt = f"{SUMMARY_PROMPT}\n\nDocument:\n{document_text}"
+        answer = _generate_answer(
+            prompt=prompt,
+            document_text=document_text,
+            model=model,
+            max_tokens=max_tokens,
+            thinking=resolved_thinking,
+            api_key=api_key,
+        )
+    except _UsageError as exc:
+        return error_result(exc.what, exc.what_to_do, exc.alternatives, start)
+    except ValueError as exc:
+        return error_result(
+            f"invalid summarization configuration: {exc}",
+            "use a supported model/thinking combination, or omit `--thinking`",
+            [
+                "`--thinking minimal` for gemini-3-*",
+                "`--thinking adaptive` for gemini-2.5-*",
+            ],
+            start,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return error_result(
+            f"summarization failed: {exc}",
+            "verify the input, API key, and model name, then retry",
+            [
+                "`minerva summarize --file document.txt`",
+                "`cat document.txt | minerva summarize`",
+            ],
+            start,
+        )
+    return CommandResult.from_text(answer.strip(), duration_ms=elapsed_ms(start))
+
+
+@summarize_app.callback()
+def summarize_cli_command(
+    ctx: typer.Context,
+    file_path: str | None = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Path to a UTF-8 text file. Omit to read from stdin.",
+    ),
+    model: str = typer.Option(
+        DEFAULT_MODEL, "--model", help="Model to use (Gemini or OpenAI)."
+    ),
+    max_tokens: int = typer.Option(
+        DEFAULT_MAX_TOKENS, "--max-tokens", help="Maximum summary output tokens."
+    ),
+    thinking: str | None = typer.Option(
+        None,
+        "--thinking",
+        help="Thinking level: off|minimal|low|medium|high|adaptive (model-aware).",
+    ),
+) -> None:
+    """Summarize one UTF-8 text input and print only the summary."""
+    stdin = b"" if file_path else typer.get_binary_stream("stdin").read()
+    if not file_path and not stdin:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
+    result = summarize_command(
+        file_path=file_path,
+        model=model,
+        max_tokens=max_tokens,
+        thinking=thinking,
+        stdin=stdin,
+        settings=get_settings(),
+    )
+    _print_summary(result)
+
+
 # ---------------------------------------------------------------------------
 # `extract-files`
 # ---------------------------------------------------------------------------
@@ -623,6 +733,46 @@ def _build_prompt_pack(*, question: str | None, questions_file: str | None) -> s
         ]
     )
 
+
+def _read_summary_text(*, file_path: str | None, stdin: bytes) -> str:
+    if file_path:
+        path = resolve_path(file_path)
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            raise _UsageError(
+                f"could not read input file `{file_path}`: {exc}",
+                "pass a readable UTF-8 text file",
+                ["`minerva summarize --file path/to/document.txt`"],
+            ) from exc
+    elif stdin:
+        raw = stdin
+    else:
+        raise _UsageError(
+            "no input text was provided for `summarize`",
+            "pass `--file PATH` or pipe UTF-8 text into the command",
+            [
+                "`minerva summarize --file document.txt`",
+                "`cat document.txt | minerva summarize`",
+            ],
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _UsageError(
+            "input is not valid UTF-8 text",
+            "convert the input to UTF-8 text before summarizing it",
+            ["`iconv -f <source-encoding> -t UTF-8 input.txt > input-utf8.txt`"],
+        ) from exc
+    if not text.strip():
+        raise _UsageError(
+            "input text is empty",
+            "provide non-empty UTF-8 text to summarize",
+            ["`minerva summarize --file document.txt`"],
+        )
+    return text
+
+
 def _read_document_text(*, file_path: str | None, stdin: bytes) -> str:
     if file_path:
         return resolve_path(file_path).read_text(encoding="utf-8")
@@ -702,7 +852,7 @@ def _is_gemini_3(model: str) -> bool:
     return model.startswith("gemini-3")
 
 def _is_gemini_3_flash(model: str) -> bool:
-    return model.startswith("gemini-3-flash")
+    return model.startswith(("gemini-3-flash", "gemini-3.6-flash"))
 
 def _is_gemini_25(model: str) -> bool:
     return model.startswith("gemini-2.5")
@@ -724,7 +874,7 @@ def _missing_api_key_result(model: str, start: float) -> CommandResult:
         return error_result(
             "OPENAI_API_KEY is not set",
             "set OPENAI_API_KEY and retry, or choose a Gemini model with GEMINI_API_KEY configured",
-            ["`export OPENAI_API_KEY=...`", "`--model gemini-3-flash`"],
+            ["`export OPENAI_API_KEY=...`", "`--model gemini-3.6-flash`"],
             start,
         )
     return error_result(
@@ -982,6 +1132,17 @@ async def _run_extractions(
 # ---------------------------------------------------------------------------
 # CLI plumbing
 # ---------------------------------------------------------------------------
+def _print_summary(result: CommandResult) -> None:
+    if result.exit_code == 0:
+        typer.echo(result.stdout.decode("utf-8"))
+        return
+    envelope = OutputEnvelope.from_result(
+        result, workspace_root=get_settings().ensure_workspace_root()
+    )
+    typer.echo(envelope.render())
+    raise typer.Exit(result.exit_code)
+
+
 def _print(result: CommandResult) -> None:
     envelope = OutputEnvelope.from_result(result, workspace_root=get_settings().ensure_workspace_root())
     typer.echo(envelope.render())

--- a/tests/test_harness/test_extract.py
+++ b/tests/test_harness/test_extract.py
@@ -279,9 +279,10 @@ def test_build_thinking_config_unknown_model_with_thinking_raises() -> None:
         extract._build_thinking_config("some-other-model", "minimal")
 
 
-def test_api_model_name_maps_user_facing_gemini_3_flash_alias() -> None:
+def test_api_model_name_maps_only_legacy_gemini_3_flash_alias() -> None:
     assert extract._api_model_name("gemini-3-flash") == "gemini-3-flash-preview"
     assert extract._api_model_name("gemini-3-flash-preview") == "gemini-3-flash-preview"
+    assert extract._api_model_name("gemini-3.6-flash") == "gemini-3.6-flash"
 
 
 def test_api_model_name_maps_provider_qualified_openai_alias() -> None:
@@ -289,7 +290,7 @@ def test_api_model_name_maps_provider_qualified_openai_alias() -> None:
     assert extract._api_model_name("gpt-5.5") == "gpt-5.5"
 
 
-def test_extract_command_default_thinking_for_gemini_3_flash(tmp_path: Path, monkeypatch) -> None:
+def test_extract_command_defaults_to_gemini_36_flash_with_minimal_thinking(tmp_path: Path, monkeypatch) -> None:
     settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
     file_path = tmp_path / "doc.md"
     file_path.write_text("body", encoding="utf-8")
@@ -303,6 +304,7 @@ def test_extract_command_default_thinking_for_gemini_3_flash(tmp_path: Path, mon
 
     extract.extract_command(question="Q", file_path=str(file_path), settings=settings)
 
+    assert captured["model"] == "gemini-3.6-flash"
     assert captured["thinking"] == "minimal"
 
 
@@ -527,8 +529,8 @@ def test_extract_files_one_call_per_file_writes_outputs(tmp_path: Path, monkeypa
     manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
     assert len(manifest["entries"]) == 2
     assert all(entry["status"] == "ok" for entry in manifest["entries"])
-    assert manifest["model"]
-    assert manifest["api_model"]
+    assert manifest["model"] == "gemini-3.6-flash"
+    assert manifest["api_model"] == "gemini-3.6-flash"
 
 
 def test_extract_files_questions_file_passes_pack(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_harness/test_summarize.py
+++ b/tests/test_harness/test_summarize.py
@@ -1,0 +1,84 @@
+"""Behavioral tests for the top-level summarize command."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from harness.cli import app
+from harness.commands import extract
+from harness.config import HarnessSettings
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_generation(tmp_path: Path, monkeypatch) -> dict:
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "Model summary"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+    monkeypatch.setattr(
+        "harness.commands.extract.get_settings",
+        lambda: HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key"),
+    )
+    return captured
+
+
+def test_summarize_file_emits_only_summary_and_forwards_controls(
+    tmp_path: Path, captured_generation: dict
+) -> None:
+    source = tmp_path / "notes.txt"
+    source.write_text("Revenue grew while margins contracted.", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "summarize",
+            "-f",
+            str(source),
+            "--model",
+            "gemini-3-pro",
+            "--max-tokens",
+            "512",
+            "--thinking",
+            "high",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Model summary\n"
+    assert captured_generation["model"] == "gemini-3-pro"
+    assert captured_generation["max_tokens"] == 512
+    assert captured_generation["thinking"] == "high"
+    assert "Revenue grew while margins contracted." in captured_generation["prompt"]
+
+
+def test_summarize_reads_stdin_with_new_default(captured_generation: dict) -> None:
+    result = runner.invoke(app, ["summarize"], input="Résumé source")
+
+    assert result.exit_code == 0
+    assert result.output == "Model summary\n"
+    assert captured_generation["model"] == "gemini-3.6-flash"
+    assert captured_generation["thinking"] == "minimal"
+    assert "Résumé source" in captured_generation["prompt"]
+
+
+def test_summarize_rejects_non_utf8_stdin_actionably(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    result = extract.summarize_command(stdin=b"\xff\xfe", settings=settings)
+
+    assert result.exit_code == 1
+    assert b"valid UTF-8" in result.stderr
+    assert b"convert" in result.stderr
+
+
+def test_bare_summarize_shows_help_without_calling_model() -> None:
+    result = runner.invoke(app, ["summarize"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "--file" in result.output
+    assert "What went wrong" not in result.output


### PR DESCRIPTION
## Summary

- add a general top-level `minerva summarize` command for UTF-8 files or stdin
- reuse the existing Gemini/OpenAI extraction backend and expose consistent model, token, and thinking controls
- change the default model for `extract`, `extract-files`, and `summarize` to `gemini-3.6-flash`
- preserve existing extraction CLI behavior apart from the requested model default

## Scope

This PR does not change news ingestion or the morning-brief workflow.

## Verification

- `uv run pytest -q` — 411 passed
- `uv run minerva summarize --help` — passed
- scoped Ruff checks — passed
- `git diff --check` — passed
