### PR TITLE
feat(news): download daily market movements

### DIFF
--- a/src/harness/commands/news.py
+++ b/src/harness/commands/news.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import date
 from pathlib import Path
 from typing import NoReturn
 
@@ -11,14 +12,19 @@ import typer
 
 from harness import news
 from harness.config import get_settings
+from harness.portfolio_state import NON_SECURITY_TICKERS, load_json, portfolio_paths
+from minerva import prices as prices_mod
 
 NEWS_HELP = (
-    "Ingest collected news and check candidate article existence.\n\n"
+    "Ingest collected news, check article existence, and download market data.\n\n"
     "Examples:\n"
     "  minerva news ingest --raw-dir ./raw --summaries-dir ./summaries\n"
     "  minerva news ingest --date 2026-07-19\n"
     "  minerva news exist --db invest.db --source-id example --input candidates.json\n"
+    "  minerva news download-market-data --date 2026-07-19\n"
 )
+
+DEFAULT_MARKET_INDEXES = ("^GSPC", "^IXIC", "^DJI", "^RUT", "^VIX")
 
 app = typer.Typer(help=NEWS_HELP, no_args_is_help=True)
 
@@ -130,6 +136,90 @@ def ingest_cli(
 
     # Preserve the ingestion script's one-line, sorted JSON stdout contract.
     typer.echo(json.dumps(result.stats, sort_keys=True))
+
+
+def market_instruments(
+    workspace_root: Path,
+    *,
+    indexes: list[str] | None,
+    symbols: list[str],
+) -> list[tuple[str, str | None, str]]:
+    """Return a deterministic holdings/watchlist, index, and explicit universe."""
+    universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+    instruments: list[tuple[str, str | None, str]] = []
+    positions: dict[str, int] = {}
+
+    def add(symbol: str, exchange: str | None, instrument_type: str) -> None:
+        normalized = symbol.strip().upper()
+        if not normalized or normalized in NON_SECURITY_TICKERS:
+            return
+        existing = positions.get(normalized)
+        if existing is not None:
+            if instrument_type == "index":
+                instruments[existing] = (normalized, exchange, instrument_type)
+            return
+        positions[normalized] = len(instruments)
+        instruments.append((normalized, exchange, instrument_type))
+
+    portfolio_rows = universe if isinstance(universe, list) else []
+    for item in sorted(
+        (row for row in portfolio_rows if isinstance(row, dict)),
+        key=lambda row: str(row.get("ticker") or "").upper(),
+    ):
+        add(
+            str(item.get("ticker") or ""),
+            str(item["exchange"]) if item.get("exchange") else None,
+            "security",
+        )
+    for symbol in DEFAULT_MARKET_INDEXES if indexes is None else indexes:
+        add(symbol, None, "index")
+    for symbol in symbols:
+        add(symbol, None, "security")
+    return instruments
+
+
+@app.command("download-market-data")
+def download_market_data_cli(
+    single_date: str = typer.Option(
+        ...,
+        "--date",
+        metavar="YYYY-MM-DD",
+        help="Use the latest completed trading session on or before this date.",
+    ),
+    db_path: Path | None = typer.Option(
+        None,
+        "--db",
+        help="SQLite database (default: <workspace>/data/04-database/invest.db).",
+    ),
+    indexes: list[str] = typer.Option(
+        [],
+        "--index",
+        help="Index symbol; repeat to replace the default index set.",
+    ),
+    symbols: list[str] = typer.Option(
+        [],
+        "--symbol",
+        help="Additional Yahoo symbol; may be repeated.",
+    ),
+) -> None:
+    """Store completed daily market movements in the existing prices table."""
+    try:
+        target_date = date.fromisoformat(single_date)
+    except ValueError:
+        _fail(f"invalid --date: {single_date!r}; expected YYYY-MM-DD", exit_code=2)
+
+    workspace_root = get_settings().resolved_workspace_root
+    resolved_db = db_path or prices_mod.default_db_path(workspace_root)
+    instruments = market_instruments(
+        workspace_root,
+        indexes=list(indexes) if indexes else None,
+        symbols=list(symbols or []),
+    )
+    try:
+        result = prices_mod.download_market_data(resolved_db, instruments, target_date)
+    except (OSError, sqlite3.Error) as exc:
+        _fail(str(exc), exit_code=1)
+    typer.echo(json.dumps(result, sort_keys=True, separators=(",", ":")))
 
 
 @app.command("exist")

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -1,7 +1,7 @@
-"""52-week price position tracking.
+"""Yahoo price snapshots and completed daily market movements.
 
-Pulls current price and 52-week high/low from Yahoo Finance, persists dated
-snapshots to invest.db, and reports where each ticker sits in its 52-week band:
+Pulls prices from Yahoo Finance, persists dated snapshots to invest.db, and
+reports where each ticker sits in its 52-week band:
 
     range_pct = (current - low) / (high - low)   # 0 = on 52w low, 1 = on 52w high
 
@@ -9,8 +9,8 @@ Yahoo covers US and international listings with one keyless call per ticker.
 range_pct is computed on read (via the ``price_position`` view), never stored, so a
 corrected input never leaves a stale value behind.
 
-Network access is isolated in ``fetch_price`` and injected into ``refresh_prices`` as
-a ``fetcher`` callable, which keeps the orchestration testable without mocking HTTP.
+Network access stays behind injectable fetchers, keeping orchestration testable
+without live HTTP.
 """
 
 from __future__ import annotations
@@ -18,10 +18,13 @@ from __future__ import annotations
 import logging
 import sqlite3
 import time
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, date, datetime, timedelta
+from datetime import time as datetime_time
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
 
@@ -51,29 +54,43 @@ _EXCHANGE_SUFFIX = {
     "BME": ".MC",    # Madrid
 }
 
-# Mirrored in hard-disk/data/04-database/schema.sql. Kept here so tests and the CLI
-# can materialize the table + view into any database without reading that file.
-_SCHEMA_SQL = """
+# Runtime source of truth for the prices schema. ``ensure_schema`` creates fresh
+# databases and migrates existing workspace databases without an external file.
+_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS prices (
-    id          INTEGER PRIMARY KEY,
-    ticker      TEXT NOT NULL,
-    as_of       TEXT NOT NULL,
-    current     REAL,
-    wk52_low    REAL,
-    wk52_high   REAL,
-    currency    TEXT,
-    source      TEXT NOT NULL DEFAULT 'yahoo',
-    fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    id              INTEGER PRIMARY KEY,
+    ticker          TEXT NOT NULL,
+    as_of           TEXT NOT NULL,
+    current         REAL,
+    wk52_low        REAL,
+    wk52_high       REAL,
+    currency        TEXT,
+    source          TEXT NOT NULL DEFAULT 'yahoo',
+    fetched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    previous_close  REAL,
+    change_pct      REAL,
+    instrument_type TEXT NOT NULL DEFAULT 'security',
     UNIQUE (ticker, as_of)
 );
-CREATE VIEW IF NOT EXISTS price_position AS
-SELECT
-    ticker, as_of, current, wk52_low, wk52_high, currency,
-    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
-FROM prices;
 CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices(ticker);
 CREATE INDEX IF NOT EXISTS idx_prices_asof   ON prices(as_of);
 """
+
+_PRICE_POSITION_SQL = """
+DROP VIEW IF EXISTS price_position;
+CREATE VIEW price_position AS
+SELECT
+    ticker, as_of, current, wk52_low, wk52_high, currency,
+    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct,
+    previous_close, change_pct, instrument_type
+FROM prices;
+"""
+
+_MIGRATION_COLUMNS = {
+    "previous_close": "REAL",
+    "change_pct": "REAL",
+    "instrument_type": "TEXT NOT NULL DEFAULT 'security'",
+}
 
 
 @dataclass(slots=True)
@@ -87,6 +104,9 @@ class PriceRow:
     wk52_high: float | None
     currency: str | None = None
     source: str = "yahoo"
+    previous_close: float | None = None
+    change_pct: float | None = None
+    instrument_type: str = "security"
 
 
 def range_pct(row: PriceRow) -> float | None:
@@ -98,6 +118,13 @@ def range_pct(row: PriceRow) -> float | None:
     if span == 0:
         return None
     return (current - low) / span
+
+
+def daily_change_pct(current: float | None, previous: float | None) -> float | None:
+    """Return close-to-close change in percentage points, rounded deterministically."""
+    if current is None or previous in {None, 0}:
+        return None
+    return round((current - previous) / previous * 100, 6)
 
 
 def yahoo_symbol(ticker: str, exchange: str | None) -> str:
@@ -145,9 +172,16 @@ def tracked_companies(db_path: str | Path) -> list[tuple[str, str | None]]:
 
 
 def ensure_schema(db_path: str | Path) -> None:
-    """Create the prices table + view if absent. Idempotent."""
-    with sqlite3.connect(str(db_path)) as conn:
-        conn.executescript(_SCHEMA_SQL)
+    """Create or minimally migrate the prices table and compatible view."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as conn:
+        conn.executescript(_TABLE_SQL)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(prices)")}
+        for name, declaration in _MIGRATION_COLUMNS.items():
+            if name not in columns:
+                conn.execute(f"ALTER TABLE prices ADD COLUMN {name} {declaration}")
+        conn.executescript(_PRICE_POSITION_SQL)
         conn.commit()
 
 
@@ -159,15 +193,22 @@ def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
             conn.execute(
                 """
                 INSERT INTO prices
-                    (ticker, as_of, current, wk52_low, wk52_high, currency, source, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                    (ticker, as_of, current, wk52_low, wk52_high, currency, source,
+                     fetched_at, previous_close, change_pct, instrument_type)
+                VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), ?, ?, ?)
                 ON CONFLICT(ticker, as_of) DO UPDATE SET
-                    current    = excluded.current,
-                    wk52_low   = excluded.wk52_low,
-                    wk52_high  = excluded.wk52_high,
-                    currency   = excluded.currency,
-                    source     = excluded.source,
-                    fetched_at = excluded.fetched_at
+                    current         = excluded.current,
+                    wk52_low        = excluded.wk52_low,
+                    wk52_high       = excluded.wk52_high,
+                    currency        = excluded.currency,
+                    source          = excluded.source,
+                    fetched_at      = excluded.fetched_at,
+                    previous_close  = COALESCE(excluded.previous_close, prices.previous_close),
+                    change_pct      = CASE
+                        WHEN excluded.previous_close IS NULL THEN prices.change_pct
+                        ELSE excluded.change_pct
+                    END,
+                    instrument_type = excluded.instrument_type
                 """,
                 (
                     row.ticker,
@@ -177,6 +218,9 @@ def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
                     row.wk52_high,
                     row.currency,
                     row.source,
+                    row.previous_close,
+                    row.change_pct,
+                    row.instrument_type,
                 ),
             )
             written += 1
@@ -252,12 +296,169 @@ def fetch_price(
 
     return PriceRow(
         ticker=ticker.upper(),
-        as_of=datetime.now(timezone.utc).date().isoformat(),
+        as_of=datetime.now(UTC).date().isoformat(),
         current=price,
         wk52_low=to_float(meta.get("fiftyTwoWeekLow")),
         wk52_high=to_float(meta.get("fiftyTwoWeekHigh")),
         currency=meta.get("currency"),
     )
+
+
+def market_movement_from_chart(
+    ticker: str,
+    target_date: date,
+    payload: dict[str, Any],
+    *,
+    instrument_type: str = "security",
+    now: datetime | None = None,
+) -> PriceRow:
+    """Select the latest two completed Yahoo sessions on or before a date."""
+    results = (payload.get("chart") or {}).get("result") or []
+    if not results:
+        raise ValueError(f"no chart data for {ticker}")
+    chart = results[0]
+    meta = chart.get("meta") or {}
+    timezone_name = str(meta.get("exchangeTimezoneName") or "UTC")
+    try:
+        exchange_timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"unknown exchange timezone {timezone_name}") from exc
+
+    current_time = now or datetime.now(UTC)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=UTC)
+    local_today = current_time.astimezone(exchange_timezone).date()
+    completed_through = min(target_date, local_today)
+    if completed_through == local_today:
+        regular_end = to_float(
+            ((meta.get("currentTradingPeriod") or {}).get("regular") or {}).get("end")
+        )
+        if regular_end is None or current_time.timestamp() < regular_end:
+            completed_through -= timedelta(days=1)
+
+    timestamps = chart.get("timestamp") or []
+    quotes = ((chart.get("indicators") or {}).get("quote") or [{}])[0]
+    closes = quotes.get("close") or []
+    sessions: dict[date, float] = {}
+    for timestamp, raw_close in zip(timestamps, closes, strict=False):
+        close = to_float(raw_close)
+        if close is None:
+            continue
+        session_date = (
+            datetime.fromtimestamp(float(timestamp), tz=UTC)
+            .astimezone(exchange_timezone)
+            .date()
+        )
+        if session_date <= completed_through:
+            sessions[session_date] = close
+
+    selected = sorted(sessions.items())[-2:]
+    if len(selected) < 2:
+        raise ValueError(f"fewer than two completed trading sessions for {ticker}")
+    (_, previous_close), (as_of, current_close) = selected
+
+    return PriceRow(
+        ticker=ticker.strip().upper(),
+        as_of=as_of.isoformat(),
+        current=current_close,
+        wk52_low=to_float(meta.get("fiftyTwoWeekLow")),
+        wk52_high=to_float(meta.get("fiftyTwoWeekHigh")),
+        currency=meta.get("currency"),
+        previous_close=previous_close,
+        change_pct=daily_change_pct(current_close, previous_close),
+        instrument_type=instrument_type,
+    )
+
+
+def fetch_market_movement(
+    ticker: str,
+    *,
+    target_date: date,
+    exchange: str | None = None,
+    instrument_type: str = "security",
+    session: requests.Session | None = None,
+    limiter: RateLimiter | None = None,
+) -> PriceRow:
+    """Fetch Yahoo daily history and return one completed close-to-close movement."""
+    session = session or requests.Session()
+    symbol = yahoo_symbol(ticker, exchange)
+    if limiter is not None:
+        limiter.acquire()
+
+    # Thirty-two calendar days comfortably spans ordinary exchange closures while
+    # Yahoo timestamps, rather than calendar arithmetic, determine the two sessions.
+    query_end = min(
+        target_date + timedelta(days=1),
+        datetime.now(UTC).date() + timedelta(days=1),
+    )
+    query_start = query_end - timedelta(days=32)
+    response = session.get(
+        YAHOO_CHART_URL.format(symbol=symbol),
+        params={
+            "interval": "1d",
+            "period1": int(
+                datetime.combine(query_start, datetime_time(), tzinfo=UTC).timestamp()
+            ),
+            "period2": int(
+                datetime.combine(query_end, datetime_time(), tzinfo=UTC).timestamp()
+            ),
+        },
+        headers=YAHOO_HEADERS,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return market_movement_from_chart(
+        ticker,
+        target_date,
+        response.json(),
+        instrument_type=instrument_type,
+    )
+
+
+def download_market_data(
+    db_path: str | Path,
+    instruments: Sequence[tuple[str, str | None, str]],
+    target_date: date,
+    *,
+    fetcher: Callable[..., PriceRow] | None = None,
+    limiter: RateLimiter | None = None,
+) -> dict[str, Any]:
+    """Fetch and upsert daily movements with compact per-symbol accounting."""
+    ensure_schema(db_path)
+    active_fetcher = fetcher or fetch_market_movement
+    limiter = limiter or RateLimiter()
+    session = requests.Session()
+    fetched: list[PriceRow] = []
+    errors: list[dict[str, str]] = []
+
+    for ticker, exchange, instrument_type in instruments:
+        try:
+            row = active_fetcher(
+                ticker,
+                target_date=target_date,
+                exchange=exchange,
+                instrument_type=instrument_type,
+                session=session,
+                limiter=limiter,
+            )
+            row.instrument_type = instrument_type
+            row.change_pct = daily_change_pct(row.current, row.previous_close)
+            fetched.append(row)
+        except Exception as exc:  # noqa: BLE001 — isolate one symbol's failure
+            logger.warning("market data fetch failed for %s: %s", ticker, exc)
+            message = str(exc)
+            if isinstance(exc, requests.HTTPError) and exc.response is not None:
+                message = f"HTTP {exc.response.status_code}"
+            errors.append({"symbol": ticker, "error": message})
+
+    if fetched:
+        upsert_prices(db_path, fetched)
+    return {
+        "requested": len(instruments),
+        "written": len(fetched),
+        "trading_dates": sorted({row.as_of for row in fetched}),
+        "errors": errors,
+    }
 
 
 def refresh_prices(
@@ -288,4 +489,3 @@ def refresh_prices(
         upsert_prices(db_path, fetched)
 
     return {"fetched": len(fetched), "errors": errors}
-

--- a/tests/test_harness/test_news_market_data.py
+++ b/tests/test_harness/test_news_market_data.py
@@ -1,0 +1,107 @@
+"""Focused tests for ``news download-market-data``."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from harness.cli import app
+from harness.commands import news as news_commands
+from harness.config import HarnessSettings
+from harness.portfolio_state import portfolio_paths, write_json
+
+runner = CliRunner()
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    paths = portfolio_paths(workspace)
+    paths.current.mkdir(parents=True)
+    write_json(
+        paths.universe,
+        [
+            {"ticker": "AAPL", "exchange": "NASDAQ"},
+            {"ticker": "TOI", "exchange": "TSXV"},
+        ],
+    )
+    return workspace
+
+
+def test_market_instruments_use_default_or_explicit_indexes_and_symbols(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    defaults = news_commands.market_instruments(
+        workspace, indexes=None, symbols=["nvda", "^gspc"]
+    )
+    custom = news_commands.market_instruments(
+        workspace, indexes=["^STOXX50E"], symbols=["BTC-USD"]
+    )
+
+    assert [item[0] for item in defaults] == [
+        "AAPL",
+        "TOI",
+        "^GSPC",
+        "^IXIC",
+        "^DJI",
+        "^RUT",
+        "^VIX",
+        "NVDA",
+    ]
+    assert [item[0] for item in custom] == ["AAPL", "TOI", "^STOXX50E", "BTC-USD"]
+    assert {symbol: kind for symbol, _, kind in custom} == {
+        "AAPL": "security",
+        "TOI": "security",
+        "^STOXX50E": "index",
+        "BTC-USD": "security",
+    }
+
+
+def test_download_market_data_cli_emits_compact_accounting(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    db_path = tmp_path / "invest.db"
+
+    def fake_download(db, instruments, target_date):
+        assert (db, target_date) == (db_path, date(2026, 7, 5))
+        assert [item[0] for item in instruments] == ["AAPL", "TOI", "^GSPC", "BAD"]
+        return {
+            "requested": 4,
+            "written": 3,
+            "trading_dates": ["2026-07-02"],
+            "errors": [{"symbol": "BAD", "error": "no chart data"}],
+        }
+
+    monkeypatch.setattr(
+        news_commands,
+        "get_settings",
+        lambda: HarnessSettings(workspace_root=workspace),
+    )
+    monkeypatch.setattr(news_commands.prices_mod, "download_market_data", fake_download)
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "download-market-data",
+            "--date",
+            "2026-07-05",
+            "--db",
+            str(db_path),
+            "--index",
+            "^GSPC",
+            "--symbol",
+            "BAD",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "errors": [{"error": "no chart data", "symbol": "BAD"}],
+        "requested": 4,
+        "trading_dates": ["2026-07-02"],
+        "written": 3,
+    }

--- a/tests/test_minerva/test_prices.py
+++ b/tests/test_minerva/test_prices.py
@@ -8,12 +8,16 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 from minerva.prices import (
     PriceRow,
     RateLimiter,
+    daily_change_pct,
+    download_market_data,
     ensure_schema,
+    market_movement_from_chart,
     range_pct,
     read_positions,
     refresh_prices,
@@ -25,6 +29,26 @@ from minerva.prices import (
 
 def _row(ticker: str, current: float, low: float, high: float, as_of: str = "2026-07-01") -> PriceRow:
     return PriceRow(ticker=ticker, as_of=as_of, current=current, wk52_low=low, wk52_high=high, currency="USD")
+
+
+YAHOO_DAILY_RESPONSE = {
+    "chart": {
+        "result": [
+            {
+                "meta": {
+                    "currency": "USD",
+                    "exchangeTimezoneName": "America/New_York",
+                    "fiftyTwoWeekLow": 80.0,
+                    "fiftyTwoWeekHigh": 130.0,
+                    "currentTradingPeriod": {"regular": {"end": 1783368000}},
+                },
+                "timestamp": [1782912600, 1782999000, 1783344600],
+                "indicators": {"quote": [{"close": [100.0, 110.0, 121.0]}]},
+            }
+        ],
+        "error": None,
+    }
+}
 
 
 class TestRangePct:
@@ -64,6 +88,33 @@ class TestYahooSymbol:
         assert yahoo_symbol("FOO", "NOPE") == "FOO"
 
 
+class TestMarketMovement:
+    def test_uses_actual_sessions_and_excludes_an_incomplete_current_day(self):
+        weekend = market_movement_from_chart(
+            "AAPL",
+            date(2026, 7, 5),
+            YAHOO_DAILY_RESPONSE,
+            now=datetime(2026, 7, 6, 14, tzinfo=UTC),
+        )
+        current_session = market_movement_from_chart(
+            "AAPL",
+            date(2026, 7, 6),
+            YAHOO_DAILY_RESPONSE,
+            now=datetime(2026, 7, 6, 14, tzinfo=UTC),
+        )
+
+        assert (weekend.as_of, weekend.current, weekend.previous_close) == (
+            "2026-07-02",
+            110.0,
+            100.0,
+        )
+        assert current_session.as_of == "2026-07-02"
+
+    def test_percentage_math_is_stored_in_percentage_points(self):
+        assert daily_change_pct(97.5, 100.0) == -2.5
+        assert daily_change_pct(10.0, 0.0) is None
+
+
 class TestSchemaAndPersistence:
     def test_ensure_schema_creates_table_and_view(self, tmp_path: Path):
         db = tmp_path / "test.db"
@@ -76,10 +127,43 @@ class TestSchemaAndPersistence:
             }
         assert objects == {"prices", "price_position"}
 
-    def test_ensure_schema_is_idempotent(self, tmp_path: Path):
-        db = tmp_path / "test.db"
+    def test_migrates_legacy_schema_and_preserves_price_position(self, tmp_path: Path):
+        db = tmp_path / "legacy.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE prices (
+                    id INTEGER PRIMARY KEY, ticker TEXT NOT NULL, as_of TEXT NOT NULL,
+                    current REAL, wk52_low REAL, wk52_high REAL, currency TEXT,
+                    source TEXT NOT NULL DEFAULT 'yahoo', fetched_at TEXT NOT NULL,
+                    UNIQUE (ticker, as_of)
+                );
+                CREATE VIEW price_position AS
+                SELECT ticker, as_of, current, wk52_low, wk52_high, currency,
+                       ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
+                FROM prices;
+                INSERT INTO prices
+                    (ticker, as_of, current, wk52_low, wk52_high, currency, fetched_at)
+                VALUES ('AAPL', '2026-07-01', 150, 100, 200, 'USD', datetime('now'));
+                """
+            )
+
         ensure_schema(db)
         ensure_schema(db)
+
+        with sqlite3.connect(db) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(prices)")}
+            view_columns = [
+                row[1] for row in conn.execute("PRAGMA table_info(price_position)")
+            ]
+            position = conn.execute(
+                "SELECT range_pct, previous_close, instrument_type FROM price_position"
+            ).fetchone()
+        assert {"previous_close", "change_pct", "instrument_type"} <= columns
+        assert view_columns[:7] == [
+            "ticker", "as_of", "current", "wk52_low", "wk52_high", "currency", "range_pct"
+        ]
+        assert position == (0.5, None, "security")
 
     def test_upsert_then_read(self, tmp_path: Path):
         db = tmp_path / "test.db"
@@ -139,6 +223,47 @@ class TestTrackedCompanies:
 
 
 class TestRefreshPrices:
+    def test_download_market_data_is_idempotent_and_reports_errors(
+        self, tmp_path: Path
+    ):
+        db = tmp_path / "test.db"
+
+        def fake_fetcher(ticker: str, *, target_date: date, **_kw) -> PriceRow:
+            if ticker == "BAD":
+                raise ValueError("no chart data")
+            return market_movement_from_chart(
+                ticker,
+                target_date,
+                YAHOO_DAILY_RESPONSE,
+                now=datetime(2026, 7, 6, 14, tzinfo=UTC),
+            )
+
+        instruments = [("AAPL", None, "security"), ("BAD", None, "security")]
+        first = download_market_data(
+            db, instruments, date(2026, 7, 5), fetcher=fake_fetcher
+        )
+        second = download_market_data(
+            db, instruments, date(2026, 7, 5), fetcher=fake_fetcher
+        )
+        # The legacy portfolio refresh path must not erase stored movement fields.
+        upsert_prices(db, [_row("AAPL", 110, 80, 130, as_of="2026-07-02")])
+
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT ticker, as_of, current, previous_close, change_pct FROM prices"
+            ).fetchall()
+        assert rows == [("AAPL", "2026-07-02", 110.0, 100.0, 10.0)]
+        assert (
+            first
+            == second
+            == {
+                "requested": 2,
+                "written": 1,
+                "trading_dates": ["2026-07-02"],
+                "errors": [{"symbol": "BAD", "error": "no chart data"}],
+            }
+        )
+
     def test_refresh_persists_all_with_fake_fetcher(self, tmp_path: Path):
         db = tmp_path / "test.db"
         ensure_schema(db)


### PR DESCRIPTION
## Summary

- add `minerva news download-market-data --date YYYY-MM-DD`
- store the latest two completed trading-session closes and close-to-close percentage movement in the existing `prices` table
- migrate `prices` with `previous_close`, `change_pct`, and `instrument_type` while preserving existing `portfolio prices` consumers and `price_position`
- include holdings/watchlist and default indexes: S&P 500, Nasdaq Composite, Dow, Russell 2000, and VIX
- support repeatable `--index` and `--symbol` overrides
- use actual Yahoo trading sessions so weekends and holidays require no calendar guessing
- make reruns idempotent and report per-symbol errors compactly

## Scope

This PR does not change news collection, article summarization, or morning-brief workflows.

## Verification

- `uv run pytest -q` — 412 passed
- `uv run minerva news download-market-data --help` — passed
- mocked Yahoo chart tests — passed
- migration/backward-compatibility tests — passed
- scoped Ruff checks — passed
- `git diff --check` — passed
