### PR TITLE
feat(news): download Finnhub news directly to SQLite

### DIFF
--- a/src/harness/commands/news.py
+++ b/src/harness/commands/news.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import date
 from pathlib import Path
 from typing import NoReturn
 
@@ -11,16 +12,74 @@ import typer
 
 from harness import news
 from harness.config import get_settings
+from harness.portfolio_state import load_json, portfolio_paths
 
 NEWS_HELP = (
-    "Ingest collected news and check candidate article existence.\n\n"
+    "Download Finnhub news, ingest collected articles, and check candidate existence.\n\n"
     "Examples:\n"
+    "  minerva news download-finnhub --date 2026-07-19\n"
     "  minerva news ingest --raw-dir ./raw --summaries-dir ./summaries\n"
     "  minerva news ingest --date 2026-07-19\n"
     "  minerva news exist --db invest.db --source-id example --input candidates.json\n"
 )
 
 app = typer.Typer(help=NEWS_HELP, no_args_is_help=True)
+
+
+@app.command("download-finnhub")
+def download_finnhub_cli(
+    date_arg: str = typer.Option(
+        ...,
+        "--date",
+        metavar="YYYY-MM-DD",
+        help="America/New_York publication day to download.",
+    ),
+    db_path: Path | None = typer.Option(
+        None,
+        "--db",
+        help="SQLite database (default: <workspace>/data/04-database/invest.db).",
+    ),
+    symbols: list[str] = typer.Option(
+        [],
+        "--symbol",
+        help=(
+            "Only download company news for this Finnhub symbol; may repeat. "
+            "Default: all current holdings and watchlist symbols."
+        ),
+    ),
+) -> None:
+    """Download Finnhub records directly into the canonical news table."""
+    try:
+        if not news.DATE_ONLY_RE.fullmatch(date_arg):
+            raise ValueError
+        publication_date = date.fromisoformat(date_arg)
+    except ValueError:
+        _fail("--date must be a valid YYYY-MM-DD date", exit_code=2)
+
+    settings = get_settings()
+    if not settings.finnhub_api_key:
+        _fail("FINNHUB_API_KEY is not configured", exit_code=1)
+    workspace_root = settings.resolved_workspace_root
+    resolved_db_path = (
+        db_path or workspace_root / "data" / "04-database" / "invest.db"
+    )
+    try:
+        universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+        if not isinstance(universe, list):
+            _fail("portfolio universe must be a JSON array", exit_code=1)
+        result = news.download_finnhub(
+            db_path=resolved_db_path,
+            api_key=settings.finnhub_api_key,
+            publication_date=publication_date,
+            universe=universe,
+            requested_symbols=symbols,
+        )
+    except news.NewsError as exc:
+        _fail(str(exc), exit_code=1)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        _fail(str(exc), exit_code=1)
+
+    typer.echo(json.dumps(result, sort_keys=True, separators=(",", ":")))
 
 
 @app.command("ingest")

--- a/src/harness/finnhub.py
+++ b/src/harness/finnhub.py
@@ -1,0 +1,94 @@
+"""Small Finnhub provider boundary shared by news consumers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+FINNHUB_CALL_DELAY_SECONDS = 0.1
+
+
+@dataclass(slots=True)
+class FinnhubNewsPayload:
+    """Raw Finnhub news grouped by endpoint, plus request failures."""
+
+    general: list[dict[str, object]]
+    company: list[dict[str, object]]
+    errors: int = 0
+
+
+def fetch_finnhub_news(
+    *,
+    api_key: str,
+    publication_date: date,
+    symbols: Mapping[str, str],
+    delay: float = FINNHUB_CALL_DELAY_SECONDS,
+) -> FinnhubNewsPayload:
+    """Fetch general news and one publication day of company news.
+
+    ``symbols`` maps Finnhub symbols to canonical security IDs. Endpoint
+    failures are isolated so one unsupported company does not abort the batch.
+    """
+    session = requests.Session()
+    general: list[dict[str, object]] = []
+    company: list[dict[str, object]] = []
+    errors = 0
+
+    try:
+        time.sleep(delay)
+        response = session.get(
+            f"{FINNHUB_BASE_URL}/news",
+            params={"category": "general", "token": api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, list):
+            general = [dict(item) for item in payload if isinstance(item, dict)]
+    except (requests.RequestException, ValueError) as exc:
+        errors += 1
+        logger.warning("failed to fetch general market news: %s", exc)
+
+    date_string = publication_date.isoformat()
+    for symbol, security_id in symbols.items():
+        try:
+            time.sleep(delay)
+            response = session.get(
+                f"{FINNHUB_BASE_URL}/company-news",
+                params={
+                    "symbol": symbol,
+                    "from": date_string,
+                    "to": date_string,
+                    "token": api_key,
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                continue
+            for raw_item in payload:
+                if not isinstance(raw_item, dict):
+                    continue
+                item = dict(raw_item)
+                item["_security_id"] = security_id
+                item["_finnhub_symbol"] = symbol
+                company.append(item)
+        except (requests.RequestException, ValueError) as exc:
+            errors += 1
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            logger.warning(
+                "skipping company-news for %s: %s",
+                symbol,
+                f"HTTP {status}" if status else type(exc).__name__,
+            )
+
+    return FinnhubNewsPayload(general=general, company=company, errors=errors)

--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -18,6 +18,7 @@ from lxml import html as lxml_html
 
 logger = logging.getLogger(__name__)
 
+from harness.finnhub import fetch_finnhub_news
 from harness.portfolio_state import (
     NON_SECURITY_TICKERS,
     append_jsonl,
@@ -1794,60 +1795,32 @@ def _load_finnhub_payload(
             }
         )
 
-    # General market news
-    news: list[dict[str, Any]] = []
-    try:
-        time_mod.sleep(delay)
-        news_response = session.get(
-            f"{base_url}/news",
-            params={"category": "general", "token": api_key},
-            timeout=30,
-        )
-        news_response.raise_for_status()
-        news = news_response.json() if isinstance(news_response.json(), list) else []
-    except Exception as exc:
-        logger.warning("failed to fetch general market news: %s", exc)
-
-    # Company-specific news
-    company_news: list[dict[str, Any]] = []
-    if universe:
-        date_str = run_date.isoformat()
-        for security in universe:
-            finnhub_sym = str(
-                security.get("finnhub_symbol") or security.get("ticker") or security.get("security_id") or ""
+    company_symbols: dict[str, str] = {}
+    for security in universe or []:
+        finnhub_symbol = str(
+            security.get("finnhub_symbol")
+            or security.get("ticker")
+            or security.get("security_id")
+            or ""
+        ).strip()
+        if finnhub_symbol and security.get("sec_registered"):
+            company_symbols[finnhub_symbol] = str(
+                security.get("security_id") or finnhub_symbol
             ).strip()
-            if not finnhub_sym:
-                continue
-            if not security.get("sec_registered"):
-                continue
-            try:
-                time_mod.sleep(delay)
-                cn_response = session.get(
-                    f"{base_url}/company-news",
-                    params={"symbol": finnhub_sym, "from": date_str, "to": date_str, "token": api_key},
-                    timeout=30,
-                )
-                cn_response.raise_for_status()
-                items = cn_response.json() if isinstance(cn_response.json(), list) else []
-                for item in items:
-                    item["_security_id"] = str(security.get("security_id") or finnhub_sym).strip()
-                    item["_finnhub_symbol"] = finnhub_sym
-                company_news.extend(items)
-            except Exception as exc:
-                status = getattr(getattr(exc, "response", None), "status_code", None)
-                logger.warning(
-                    "skipping company-news for %s: %s",
-                    finnhub_sym,
-                    f"HTTP {status}" if status else type(exc).__name__,
-                )
+    news_payload = fetch_finnhub_news(
+        api_key=api_key,
+        publication_date=run_date,
+        symbols=company_symbols,
+        delay=delay,
+    )
 
     return {
         "earnings": earnings_payload.get("earningsCalendar", earnings_payload.get("earnings", [])),
         "indexes": indexes,
         "rates": [],
         "fx": [],
-        "news": news,
-        "company_news": company_news,
+        "news": news_payload.general,
+        "company_news": news_payload.company,
     }
 
 

--- a/src/harness/news.py
+++ b/src/harness/news.py
@@ -18,6 +18,9 @@ from pathlib import Path
 from typing import Iterable, Literal, Mapping, Sequence, TypedDict
 from zoneinfo import ZoneInfo
 
+from harness.finnhub import fetch_finnhub_news
+from harness.portfolio_state import NON_SECURITY_TICKERS
+
 # Header keys we care about (case-insensitive on the label).
 META_KEYS = {"source", "url", "published", "collected", "section", "status"}
 
@@ -925,6 +928,180 @@ def load_enrichment(paths: Iterable[Path]) -> dict[str, str]:
                     if len(article_path.parts) >= 3:
                         out["/".join(article_path.parts[-3:])] = publication_input
     return out
+
+
+# ---------------------------------------------------------------------------
+# Direct Finnhub download
+# ---------------------------------------------------------------------------
+FINNHUB_PUBLICATION_TIMEZONE = ZoneInfo("America/New_York")
+
+
+def resolve_finnhub_symbols(
+    universe: Sequence[Mapping[str, object]],
+    requested_symbols: Sequence[str] = (),
+) -> dict[str, str]:
+    """Map Finnhub symbols to security IDs for the selected company universe.
+
+    Explicit symbols replace the portfolio universe. Otherwise every current
+    holding/watchlist row with a usable Finnhub symbol or ticker is included;
+    SEC registration is intentionally irrelevant to news availability.
+    """
+    if requested_symbols:
+        selected = {
+            symbol.strip().upper(): symbol.strip().upper()
+            for symbol in requested_symbols
+            if symbol.strip()
+        }
+        return dict(sorted(selected.items()))
+
+    selected: dict[str, str] = {}
+    for security in universe:
+        if not isinstance(security, Mapping):
+            continue
+        security_id = str(
+            security.get("security_id") or security.get("ticker") or ""
+        ).strip().upper()
+        symbol = str(
+            security.get("finnhub_symbol")
+            or security.get("ticker")
+            or security.get("security_id")
+            or ""
+        ).strip().upper()
+        if not symbol or symbol in NON_SECURITY_TICKERS:
+            continue
+        selected[symbol] = security_id or symbol
+    return dict(sorted(selected.items()))
+
+
+def _finnhub_source_id(value: object) -> str:
+    source_id = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower())
+    return source_id.strip("-") or "finnhub"
+
+
+def _normalize_finnhub_article(
+    item: Mapping[str, object],
+    *,
+    publication_date: date,
+    section: str,
+) -> tuple[str, int, str, str, str, str, str, str] | None:
+    timestamp = item.get("datetime")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+        return None
+    try:
+        published = datetime.fromtimestamp(
+            timestamp, timezone.utc
+        ).astimezone(FINNHUB_PUBLICATION_TIMEZONE)
+    except (OSError, OverflowError, ValueError):
+        return None
+    if published.date() != publication_date:
+        return None
+
+    title = str(item.get("headline") or "").strip()
+    if not title:
+        return None
+    source_id = _finnhub_source_id(item.get("source"))
+    published_at_raw = published.isoformat(timespec="seconds")
+    content = str(item.get("summary") or "").strip() or title
+    url = str(item.get("url") or "").strip()
+    key = article_key(source_id, publication_date.isoformat(), title)
+    return (
+        key,
+        int(timestamp),
+        published_at_raw,
+        title,
+        content,
+        source_id,
+        url,
+        section,
+    )
+
+
+def download_finnhub(
+    *,
+    db_path: Path,
+    api_key: str,
+    publication_date: date,
+    universe: Sequence[Mapping[str, object]],
+    requested_symbols: Sequence[str] = (),
+) -> dict[str, int | str]:
+    """Download one New York publication day and persist canonical news rows."""
+    symbols = resolve_finnhub_symbols(universe, requested_symbols)
+    payload = fetch_finnhub_news(
+        api_key=api_key,
+        publication_date=publication_date,
+        symbols=symbols,
+    )
+    scoped_items = [
+        (item, "finnhub-general") for item in payload.general
+    ] + [(item, "finnhub-company") for item in payload.company]
+    stats = {
+        "date": publication_date.isoformat(),
+        "timezone": str(FINNHUB_PUBLICATION_TIMEZONE),
+        "symbols": len(symbols),
+        "fetched": len(scoped_items),
+        "eligible": 0,
+        "inserted": 0,
+        "duplicates": 0,
+        "skipped": 0,
+        "errors": payload.errors,
+    }
+    collected_at = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("BEGIN")
+        ensure_schema(conn)
+        for item, section in scoped_items:
+            normalized = _normalize_finnhub_article(
+                item,
+                publication_date=publication_date,
+                section=section,
+            )
+            if normalized is None:
+                stats["skipped"] += 1
+                continue
+            stats["eligible"] += 1
+            key, epoch, raw, title, content, source, url, row_section = normalized
+            existing = None
+            if url:
+                existing = conn.execute(
+                    "SELECT 1 FROM news WHERE url = ? COLLATE BINARY LIMIT 1",
+                    (url,),
+                ).fetchone()
+            if existing is None:
+                existing = conn.execute(
+                    "SELECT 1 FROM news WHERE article_key = ? COLLATE BINARY LIMIT 1",
+                    (key,),
+                ).fetchone()
+            if existing is not None:
+                stats["duplicates"] += 1
+                continue
+            conn.execute(
+                "INSERT INTO news "
+                "(article_key, published_at, published_at_raw, title, content, "
+                "summary, source, url, section, collected_at) "
+                "VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)",
+                (
+                    key,
+                    epoch,
+                    raw,
+                    title,
+                    content,
+                    source,
+                    url,
+                    row_section,
+                    collected_at,
+                ),
+            )
+            stats["inserted"] += 1
+        conn.commit()
+        stats["db_total"] = conn.execute("SELECT COUNT(*) FROM news").fetchone()[0]
+    finally:
+        conn.close()
+    return stats
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness/test_news_finnhub.py
+++ b/tests/test_harness/test_news_finnhub.py
@@ -1,0 +1,242 @@
+"""Focused behavior for direct Finnhub news downloads."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from harness import news
+from harness.cli import app
+from harness.commands import news as news_commands
+from harness.config import HarnessSettings
+from harness.finnhub import FinnhubNewsPayload
+
+runner = CliRunner()
+
+
+def _timestamp(value: str) -> int:
+    return int(datetime.fromisoformat(value).timestamp())
+
+
+def _realistic_item(
+    *, published: str, url: str = "https://example.test/nvda"
+) -> dict[str, object]:
+    return {
+        "category": "company",
+        "datetime": _timestamp(published),
+        "headline": "Nvidia unveils its next AI platform",
+        "id": 129876543,
+        "image": "https://example.test/image.jpg",
+        "related": "NVDA",
+        "source": "Reuters",
+        "summary": "The company introduced a new platform for AI workloads.",
+        "url": url,
+    }
+
+
+def _settings(tmp_path: Path, *, api_key: str | None = "test-key") -> HarnessSettings:
+    return HarnessSettings(
+        workspace_root=tmp_path / "workspace", finnhub_api_key=api_key
+    )
+
+
+def test_download_finnhub_uses_current_universe_filters_new_york_day_and_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    universe_path = (
+        settings.resolved_workspace_root
+        / "data"
+        / "01-portfolio"
+        / "current"
+        / "universe.json"
+    )
+    universe_path.parent.mkdir(parents=True)
+    universe_path.write_text(
+        json.dumps(
+            [
+                {
+                    "security_id": "KPG",
+                    "ticker": "KPG",
+                    "finnhub_symbol": "KPG.AX",
+                    "sec_registered": False,
+                    "source_kind": "holding",
+                },
+                {
+                    "security_id": "SNOW",
+                    "ticker": "SNOW",
+                    "source_kind": "watchlist",
+                },
+                {"security_id": "CASH", "ticker": "CASH"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, date, dict[str, str]]] = []
+    on_date = _realistic_item(published="2026-07-19T00:15:00-04:00")
+    duplicate = dict(on_date, related="KPG.AX")
+    prior_et_day = _realistic_item(
+        published="2026-07-18T23:59:00-04:00",
+        url="https://example.test/old",
+    )
+
+    def fake_fetch(
+        *, api_key: str, publication_date: date, symbols: dict[str, str]
+    ) -> FinnhubNewsPayload:
+        calls.append((api_key, publication_date, symbols))
+        return FinnhubNewsPayload(
+            general=[on_date, prior_et_day],
+            company=[duplicate],
+            errors=0,
+        )
+
+    monkeypatch.setattr(news_commands, "get_settings", lambda: settings)
+    monkeypatch.setattr(news, "fetch_finnhub_news", fake_fetch)
+    db_path = tmp_path / "invest.db"
+    args = [
+        "news",
+        "download-finnhub",
+        "--date",
+        "2026-07-19",
+        "--db",
+        str(db_path),
+    ]
+
+    first = runner.invoke(app, args)
+    second = runner.invoke(app, args)
+
+    assert first.exit_code == 0, first.output
+    assert json.loads(first.stdout) == {
+        "date": "2026-07-19",
+        "db_total": 1,
+        "duplicates": 1,
+        "eligible": 2,
+        "errors": 0,
+        "fetched": 3,
+        "inserted": 1,
+        "skipped": 1,
+        "symbols": 2,
+        "timezone": "America/New_York",
+    }
+    assert json.loads(second.stdout) == {
+        **json.loads(first.stdout),
+        "duplicates": 2,
+        "inserted": 0,
+    }
+    assert calls == [
+        ("test-key", date(2026, 7, 19), {"KPG.AX": "KPG", "SNOW": "SNOW"}),
+        ("test-key", date(2026, 7, 19), {"KPG.AX": "KPG", "SNOW": "SNOW"}),
+    ]
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT published_at, published_at_raw, title, content, summary, "
+            "source, url, section FROM news"
+        ).fetchone()
+    assert row == (
+        _timestamp("2026-07-19T00:15:00-04:00"),
+        "2026-07-19T00:15:00-04:00",
+        "Nvidia unveils its next AI platform",
+        "The company introduced a new platform for AI workloads.",
+        None,
+        "reuters",
+        "https://example.test/nvda",
+        "finnhub-general",
+    )
+
+
+def test_download_finnhub_symbol_override_preserves_richer_existing_article(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    db_path = tmp_path / "invest.db"
+    item = _realistic_item(published="2026-07-19T12:00:00-04:00")
+    key = news.article_key("reuters", "2026-07-19", str(item["headline"]))
+    with sqlite3.connect(db_path) as conn:
+        news.ensure_schema(conn)
+        conn.execute(
+            "INSERT INTO news VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                key,
+                item["datetime"],
+                "2026-07-19T12:00:00-04:00",
+                item["headline"],
+                "Full crawler article body with substantially richer reporting.",
+                "Existing analyst summary.",
+                "reuters",
+                item["url"],
+                "markets",
+                "2026-07-19T17:00:00Z",
+            ),
+        )
+
+    captured_symbols: list[dict[str, str]] = []
+
+    def fake_fetch(
+        *, api_key: str, publication_date: date, symbols: dict[str, str]
+    ) -> FinnhubNewsPayload:
+        captured_symbols.append(symbols)
+        return FinnhubNewsPayload(general=[], company=[item], errors=0)
+
+    monkeypatch.setattr(news_commands, "get_settings", lambda: settings)
+    monkeypatch.setattr(news, "fetch_finnhub_news", fake_fetch)
+
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "download-finnhub",
+            "--date",
+            "2026-07-19",
+            "--db",
+            str(db_path),
+            "--symbol",
+            "nvda",
+            "--symbol",
+            "NVDA",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["duplicates"] == 1
+    assert json.loads(result.stdout)["inserted"] == 0
+    assert captured_symbols == [{"NVDA": "NVDA"}]
+    with sqlite3.connect(db_path) as conn:
+        stored = conn.execute(
+            "SELECT content, summary, section, COUNT(*) FROM news"
+        ).fetchone()
+    assert stored == (
+        "Full crawler article body with substantially richer reporting.",
+        "Existing analyst summary.",
+        "markets",
+        1,
+    )
+
+
+def test_download_finnhub_requires_configured_api_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path, api_key=None)
+    monkeypatch.setattr(news_commands, "get_settings", lambda: settings)
+    db_path = tmp_path / "invest.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "download-finnhub",
+            "--date",
+            "2026-07-19",
+            "--db",
+            str(db_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "FINNHUB_API_KEY is not configured" in result.stderr
+    assert not db_path.exists()


### PR DESCRIPTION
## Summary

- add `minerva news download-finnhub --date YYYY-MM-DD`
- download general Finnhub news plus company news for holdings/watchlist, with repeatable `--symbol` overrides
- interpret the requested publication day in `America/New_York`
- write directly to `invest.db.news` without intermediate article files
- make reruns idempotent by exact URL and canonical article key; preserve richer crawler rows on collisions
- extract a small shared Finnhub provider boundary for existing market-news collection

Finnhub headline/summary data is stored as source content and leaves `summary` null for the separate summarization step.

## Scope

This PR does not change morning-brief prompts or synthesis.

## Verification

- `uv run pytest -q` — 410 passed
- `uv run minerva news download-finnhub --help` — passed
- mocked provider integration tests — passed
- scoped Ruff checks — passed
- `git diff --check` — passed
