### PR TITLE
feat(news): ingest one article from JSON

### DIFF
--- a/src/harness/commands/news.py
+++ b/src/harness/commands/news.py
@@ -15,6 +15,7 @@ from harness.config import get_settings
 NEWS_HELP = (
     "Ingest collected news and check candidate article existence.\n\n"
     "Examples:\n"
+    "  minerva news ingest --input article.json\n"
     "  minerva news ingest --raw-dir ./raw --summaries-dir ./summaries\n"
     "  minerva news ingest --date 2026-07-19\n"
     "  minerva news exist --db invest.db --source-id example --input candidates.json\n"
@@ -40,6 +41,15 @@ def ingest_cli(
         None,
         "--raw-dir",
         help="Explicit raw directory (bypasses --news-root).",
+    ),
+    input_path: str | None = typer.Option(
+        None,
+        "--input",
+        metavar="FILE",
+        help=(
+            "One normalized article JSON object with title, source_id, url, "
+            "published_at, and content (use - for stdin)."
+        ),
     ),
     summaries_dir: Path | None = typer.Option(
         None,
@@ -80,14 +90,41 @@ def ingest_cli(
         help="Optional file to write per-file decisions.",
     ),
 ) -> None:
-    """Ingest raw markdown and matching summaries into the news table."""
-    selected_modes = (
-        int(all_dates) + int(single_date is not None) + int(raw_dir is not None)
+    """Ingest one normalized article or a file-based news batch."""
+    selected_modes = sum(
+        (
+            int(input_path is not None),
+            int(all_dates),
+            int(single_date is not None),
+            int(raw_dir is not None),
+        )
     )
     if selected_modes != 1:
-        _fail("exactly one of --all, --date, or --raw-dir is required", exit_code=2)
+        _fail(
+            "exactly one of --input, --all, --date, or --raw-dir is required",
+            exit_code=2,
+        )
     if summaries_dir is not None and raw_dir is None:
         _fail("--summaries-dir requires --raw-dir", exit_code=2)
+    if input_path is not None:
+        incompatible = [
+            flag
+            for flag, selected in (
+                ("--summaries-dir", summaries_dir is not None),
+                ("--news-root", news_root is not None),
+                ("--news-sources", news_sources is not None),
+                ("--ir-registry", ir_registry is not None),
+                ("--enrich", bool(enrich)),
+                ("--report", report is not None),
+            )
+            if selected
+        ]
+        if incompatible:
+            _fail(
+                "--input cannot be combined with batch option(s): "
+                + ", ".join(incompatible),
+                exit_code=2,
+            )
 
     workspace_root = get_settings().resolved_workspace_root
     resolved_news_root = news_root or workspace_root / "data" / "02-news"
@@ -107,6 +144,19 @@ def ingest_cli(
     )
 
     try:
+        if input_path is not None:
+            article = news.parse_article_input(_read_json_input(input_path))
+            article_result = news.ingest_article(resolved_db_path, article)
+            typer.echo(
+                json.dumps(
+                    article_result,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            return
+
         result = news.ingest(
             db_path=resolved_db_path,
             news_root=resolved_news_root,
@@ -123,6 +173,8 @@ def ingest_cli(
             report.write_text(
                 "\n".join(result.report_lines) + "\n", encoding="utf-8"
             )
+    except news.ArticleInputError as exc:
+        _fail(str(exc), exit_code=2)
     except news.NewsError as exc:
         _fail(str(exc), exit_code=1)
     except (OSError, sqlite3.Error) as exc:
@@ -149,7 +201,7 @@ def exist_cli(
 ) -> None:
     """Return which candidate news items already exist in SQLite."""
     try:
-        raw = _read_candidate_input(input_path)
+        raw = _read_json_input(input_path)
         candidates = news.parse_candidates(raw)
         result = news.check_candidates(db_path, source_id, candidates)
     except news.CandidateInputError as exc:
@@ -162,7 +214,7 @@ def exist_cli(
     typer.echo(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
 
 
-def _read_candidate_input(input_path: str) -> str:
+def _read_json_input(input_path: str) -> str:
     if input_path == "-":
         return typer.get_text_stream("stdin").read()
     return Path(input_path).read_text(encoding="utf-8")

--- a/src/harness/news.py
+++ b/src/harness/news.py
@@ -13,8 +13,9 @@ import json
 import re
 import sqlite3
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
+from time import monotonic, sleep
 from typing import Iterable, Literal, Mapping, Sequence, TypedDict
 from zoneinfo import ZoneInfo
 
@@ -30,6 +31,10 @@ class NewsError(Exception):
 
 class CandidateInputError(NewsError):
     """Raised when candidate JSON does not match the lookup contract."""
+
+
+class ArticleInputError(NewsError):
+    """Raised when single-article JSON does not match the ingest contract."""
 
 
 class SourceRegistryError(NewsError):
@@ -538,6 +543,104 @@ def article_key(source_id: str, date_only: str, title: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Single-article input
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ArticleInput:
+    """Validated normalized article supplied directly by a crawler."""
+
+    title: str
+    source_id: str
+    url: str
+    published_at_raw: str
+    published: ParsedPublished
+    content: str
+    summary: str | None = None
+    section: str | None = None
+    collected_at: str | None = None
+
+
+ArticleIngestStatus = Literal["inserted", "duplicate", "updated"]
+
+
+class ArticleIngestResult(TypedDict):
+    status: ArticleIngestStatus
+    article_key: str
+
+
+_ARTICLE_REQUIRED_FIELDS = (
+    "title",
+    "source_id",
+    "url",
+    "published_at",
+    "content",
+)
+_ARTICLE_OPTIONAL_FIELDS = {"summary", "section", "collected_at"}
+
+
+def _required_article_text(payload: Mapping[str, object], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ArticleInputError(f"article must have a non-empty string {field}")
+    return value.strip()
+
+
+def _optional_article_text(payload: Mapping[str, object], field: str) -> str | None:
+    value = payload.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ArticleInputError(f"article {field} must be a string or null")
+    return value.strip() or None
+
+
+def parse_article_input(text: str) -> ArticleInput:
+    """Parse one normalized Markdown/text article from a JSON object."""
+    try:
+        payload: object = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ArticleInputError(
+            f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ArticleInputError("article JSON must be an object")
+
+    unknown = set(payload) - set(_ARTICLE_REQUIRED_FIELDS) - _ARTICLE_OPTIONAL_FIELDS
+    if unknown:
+        raise ArticleInputError(
+            f"article has unknown field(s): {', '.join(sorted(unknown))}"
+        )
+
+    values = {
+        field: _required_article_text(payload, field)
+        for field in _ARTICLE_REQUIRED_FIELDS
+    }
+    published = normalize_published(values["published_at"])
+    if published is None:
+        raise ArticleInputError("article must have a parseable published_at")
+    if re.match(r"^(?:<!doctype\s+html\b|<html\b)", values["content"], re.IGNORECASE):
+        raise ArticleInputError(
+            "article content must be normalized Markdown/text, not raw HTML"
+        )
+
+    collected_at = _optional_article_text(payload, "collected_at")
+    if collected_at is not None:
+        collected_at = normalize_collected(collected_at)
+
+    return ArticleInput(
+        title=values["title"],
+        source_id=values["source_id"],
+        url=values["url"],
+        published_at_raw=values["published_at"],
+        published=published,
+        content=values["content"],
+        summary=_optional_article_text(payload, "summary"),
+        section=_optional_article_text(payload, "section"),
+        collected_at=collected_at,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Read-only duplicate lookup
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True, slots=True)
@@ -862,6 +965,96 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         _migrate_legacy_news(conn, set(columns))
     else:
         _create_news_schema(conn)
+
+
+def _enable_wal(conn: sqlite3.Connection) -> None:
+    """Enable WAL, retrying its lock-sensitive first-time transition."""
+    deadline = monotonic() + 30
+    while True:
+        try:
+            conn.execute("PRAGMA journal_mode = WAL")
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() or monotonic() >= deadline:
+                raise
+            sleep(0.05)
+
+
+def ingest_article(db_path: Path, article: ArticleInput) -> ArticleIngestResult:
+    """Insert or update one article in a short, serialized WAL transaction."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    key = article_key(article.source_id, article.published.date_only, article.title)
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        conn.execute("PRAGMA busy_timeout = 30000")
+        _enable_wal(conn)
+        conn.execute("BEGIN IMMEDIATE")
+        ensure_schema(conn)
+        existing = conn.execute(
+            f"SELECT {', '.join(_NEWS_COLUMNS)} FROM news "
+            "WHERE url = ? COLLATE BINARY "
+            "ORDER BY CASE WHEN article_key = ? THEN 0 ELSE 1 END, article_key "
+            "LIMIT 1",
+            (article.url, key),
+        ).fetchone()
+        if existing is None:
+            existing = conn.execute(
+                f"SELECT {', '.join(_NEWS_COLUMNS)} FROM news WHERE article_key = ?",
+                (key,),
+            ).fetchone()
+        collected_at = article.collected_at
+        if collected_at is None:
+            collected_at = (
+                existing[-1]
+                if existing is not None
+                else datetime.now(UTC)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z")
+            )
+        values = (
+            key,
+            article.published.epoch,
+            article.published_at_raw,
+            article.title,
+            article.content,
+            article.summary,
+            article.source_id,
+            article.url,
+            article.section,
+            collected_at,
+        )
+
+        if existing is None:
+            placeholders = ", ".join("?" for _ in _NEWS_COLUMNS)
+            conn.execute(
+                f"INSERT INTO news ({', '.join(_NEWS_COLUMNS)}) "
+                f"VALUES ({placeholders})",
+                values,
+            )
+            status: ArticleIngestStatus = "inserted"
+        elif tuple(existing) == values:
+            status = "duplicate"
+        elif existing[0] != key and conn.execute(
+            "SELECT 1 FROM news WHERE article_key = ?", (key,)
+        ).fetchone() is not None:
+            # The database already contains separate URL and article-key
+            # matches. Preserve both rather than guessing which row to merge.
+            status = "duplicate"
+        else:
+            assignments = ", ".join(f"{column} = ?" for column in _NEWS_COLUMNS)
+            conn.execute(
+                f"UPDATE news SET {assignments} WHERE article_key = ?",
+                (*values, existing[0]),
+            )
+            status = "updated"
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return {"status": status, "article_key": key}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness/test_news.py
+++ b/tests/test_harness/test_news.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 from typer.testing import CliRunner
@@ -37,6 +39,18 @@ def _candidate(
     published: str = "2026-07-19",
 ) -> dict[str, str]:
     return {"title": title, "url": url, "published": published}
+
+
+def _article(**overrides: object) -> dict[str, object]:
+    article: dict[str, object] = {
+        "title": "A Big Story",
+        "source_id": "reuters-markets",
+        "url": "https://example.test/story",
+        "published_at": "2026-07-19T09:30:00-04:00",
+        "content": "Normalized article body.",
+    }
+    article.update(overrides)
+    return article
 
 
 def _write_raw(raw_dir: Path, *, title: str = "A   Big Story") -> Path:
@@ -73,6 +87,7 @@ def test_news_commands_are_registered_with_exact_help_surface() -> None:
     assert ingest_help.exit_code == 0
     assert "--raw-dir" in ingest_help.stdout
     assert "--summaries-dir" in ingest_help.stdout
+    assert "--input" in ingest_help.stdout
     assert exist_help.exit_code == 0
     assert "--db" in exist_help.stdout
     assert "--source-id" in exist_help.stdout
@@ -155,6 +170,144 @@ def test_ingest_cli_preserves_stats_report_summary_and_stable_key(
     assert second.exit_code == 0, second.output
     assert json.loads(second.stdout)["duplicates"] == 1
     assert json.loads(second.stdout)["inserted"] == 0
+
+
+def test_ingest_cli_accepts_one_article_from_stdin_or_file_and_upserts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "invest.db"
+    article = _article(summary="Investor summary.", section="markets")
+    args = ["news", "ingest", "--input", "-", "--db", str(db_path)]
+
+    inserted = runner.invoke(app, args, input=json.dumps(article))
+
+    assert inserted.exit_code == 0, inserted.output
+    inserted_result = json.loads(inserted.stdout)
+    assert inserted_result["status"] == "inserted"
+    assert inserted_result["article_key"] == news.article_key(
+        "reuters-markets", "2026-07-19", "A Big Story"
+    )
+
+    input_file = tmp_path / "article.json"
+    input_file.write_text(json.dumps(article), encoding="utf-8")
+    duplicate = runner.invoke(
+        app,
+        ["news", "ingest", "--input", str(input_file), "--db", str(db_path)],
+    )
+    assert duplicate.exit_code == 0, duplicate.output
+    assert json.loads(duplicate.stdout)["status"] == "duplicate"
+
+    article["content"] = "Corrected normalized body."
+    input_file.write_text(json.dumps(article), encoding="utf-8")
+    updated = runner.invoke(
+        app,
+        ["news", "ingest", "--input", str(input_file), "--db", str(db_path)],
+    )
+    assert updated.exit_code == 0, updated.output
+    assert json.loads(updated.stdout)["status"] == "updated"
+
+    article.update(title="Retitled Story", content="Retitled normalized body.")
+    input_file.write_text(json.dumps(article), encoding="utf-8")
+    rekeyed = runner.invoke(
+        app,
+        ["news", "ingest", "--input", str(input_file), "--db", str(db_path)],
+    )
+    assert rekeyed.exit_code == 0, rekeyed.output
+    assert json.loads(rekeyed.stdout) == {
+        "article_key": news.article_key(
+            "reuters-markets", "2026-07-19", "Retitled Story"
+        ),
+        "status": "updated",
+    }
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT title, content, summary, section, collected_at FROM news"
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][:4] == (
+        "Retitled Story",
+        "Retitled normalized body.",
+        "Investor summary.",
+        "markets",
+    )
+    assert rows[0][4].endswith("Z")
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "must be an object"),
+        (_article(content=""), "non-empty string content"),
+        (_article(published_at="July 2026"), "parseable published_at"),
+        (_article(content="<!doctype html><html></html>"), "raw HTML"),
+        (_article(browser_html="<html>raw</html>"), "unknown field"),
+    ],
+)
+def test_ingest_cli_rejects_invalid_single_article_input(
+    tmp_path: Path, payload: object, message: str
+) -> None:
+    db_path = tmp_path / "invest.db"
+
+    result = runner.invoke(
+        app,
+        ["news", "ingest", "--input", "-", "--db", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 2
+    assert message in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not db_path.exists()
+
+
+def test_ingest_cli_rejects_conflicting_single_and_batch_modes(
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "ingest",
+            "--input",
+            "-",
+            "--raw-dir",
+            str(tmp_path / "raw"),
+            "--db",
+            str(tmp_path / "invest.db"),
+        ],
+        input=json.dumps(_article()),
+    )
+
+    assert result.exit_code == 2
+    assert "exactly one of --input, --all, --date, or --raw-dir" in result.stderr
+    assert not (tmp_path / "invest.db").exists()
+
+
+def test_single_article_ingest_allows_concurrent_writers(tmp_path: Path) -> None:
+    db_path = tmp_path / "invest.db"
+    count = 4
+    barrier = Barrier(count)
+
+    def write(index: int) -> str:
+        article = news.parse_article_input(
+            json.dumps(
+                _article(
+                    title=f"Story {index}",
+                    url=f"https://example.test/{index}",
+                )
+            )
+        )
+        barrier.wait()
+        return news.ingest_article(db_path, article)["status"]
+
+    with ThreadPoolExecutor(max_workers=count) as pool:
+        statuses = list(pool.map(write, range(count)))
+
+    assert statuses == ["inserted"] * count
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM news").fetchone()[0] == count
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
 
 
 def test_ingest_cli_reports_malformed_source_registry_without_traceback(


### PR DESCRIPTION
## Summary

- extend `minerva news ingest` with `--input FILE|-` for one normalized article JSON object
- accept parsed Markdown/text directly from crawler agents without intermediate article files
- preserve all existing batch/backfill ingestion modes
- validate modes and the article input contract strictly
- insert or update idempotently using existing URL/article identity rules
- use WAL, a busy timeout, and a short write transaction for parallel crawler agents
- emit deterministic `inserted`, `duplicate`, or `updated` JSON output

## Scope

This PR does not summarize articles or change morning-brief workflows.

## Verification

- `uv run pytest -q` — 415 passed
- direct stdin-to-SQLite smoke test — passed
- concurrent-writer stress test — 20/20 passed
- scoped Ruff checks — passed
- `git diff --check` — passed
