### PR TITLE
feat: add hardened browser CLI

### DIFF
--- a/src/browser/.gitignore
+++ b/src/browser/.gitignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+PLAN.md
+TEST-RESULTS.md
+TIKTOK-RESEARCH.md
+TIKTOK-RESEARCH-NO-ORACLE.md

--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -1,0 +1,109 @@
+# Browser CLI
+
+`browser` controls Chrome through a local command server and a Manifest V3 extension bridge. It does not launch a headless browser: commands operate on a dedicated managed Chrome window, while `close-idle` is the one explicitly global cleanup command.
+
+## Architecture
+
+```text
+browser (CLI)
+  -> local command server (Unix socket, with localhost fallback)
+    -> WebSocket bridge (ws://127.0.0.1:19224)
+      -> Chrome MV3 extension service worker
+        -> chrome.tabs / chrome.scripting / Chrome DevTools Protocol
+```
+
+The first page command creates a dedicated automation window and managed tab. Later commands use that tab unless `--new`, `--window`, or a command-specific `--tab <alias>` is supplied. Managed tabs have sequential aliases (`t0`, `t1`, ...).
+
+## Setup
+
+Requirements: Node.js 20 or newer and Chrome/Chromium 121 or newer. Chrome 121 includes the MV3 WebSocket service-worker lifetime behavior, 30-second alarms, and `tabs.lastAccessed` data required by the bridge and `close-idle`.
+
+```bash
+cd src/browser
+npm install
+npm run build
+npm link                    # optional: installs the `browser` command
+```
+
+Load the extension:
+
+1. Open `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked**.
+4. Select `src/browser/extension`.
+5. Keep Chrome running, then check the connection with `browser status`.
+
+The CLI starts its local server on the first command. Concurrent cold starts elect one command-server winner without unlinking a live socket; only that winner binds the extension bridge. Run `browser stop` to stop it. The local Unix socket is owner-only where supported; the TCP and WebSocket fallbacks bind to `127.0.0.1`. The loopback HTTP command endpoint rejects every request carrying an `Origin` header and accepts only `application/json`, preventing browser pages and no-CORS requests from dispatching commands without relying on CORS response policy.
+
+The WebSocket server accepts only `chrome-extension://` origins and promotes a connection only after the expected extension hello handshake; unauthenticated candidates time out. This prevents ordinary web pages from replacing the extension. It is not a shared-secret pairing protocol: another process running as the same local user can still connect to loopback while impersonating an extension origin, so the same-user local-process trust boundary remains.
+
+## Usage
+
+```bash
+# Default managed tab
+browser open "https://news.ycombinator.com"
+browser snapshot
+browser extract ".titleline" --json --limit 5
+browser click "More"
+browser type "Search" "browser CLI"
+browser screenshot ./artifacts/page.png
+browser status
+
+# Multiple managed tabs
+browser open "https://site-a.example"          # creates t0
+browser open "https://site-b.example" --new    # creates and activates t1
+browser tabs
+browser snapshot --tab t0
+browser focus t0
+browser close t1
+
+browser stop
+```
+
+Run `browser help` for the command list or `browser <command> --help` for exact arguments and options. Options are command-specific: unsupported flags, duplicate flags, ambiguous combinations, and surplus positional arguments fail instead of being ignored.
+
+## `close-idle` safety
+
+`browser close-idle` is intentionally **global**. Unlike action commands, it considers both managed and unmanaged tabs across all Chrome windows. Only tabs in normal windows can be closed.
+
+Always preview first:
+
+```bash
+browser close-idle --hours 6 --dry-run
+browser close-idle --hours 6
+```
+
+Safety rules:
+
+- `--hours` is required and must be a positive safe integer. Values such as `0`, `1.5`, `6hours`, and unsafe integers are rejected.
+- `--tab` and every unrelated option are rejected because cleanup is global.
+- Pinned, audible, active, non-normal-window, recently accessed, and timestamp-less tabs are always skipped. “Active” includes the active tab in every background window, not only the focused window.
+- Every initially eligible candidate is fetched, has its window checked, and is then fetched a final time immediately before its individual removal. A tab that became active, pinned, audible, recent, or moved while the window lookup was pending is skipped.
+- Tabs are removed one at a time. A vanished tab or one failed operation does not abort later candidates.
+- Output separately reports eligible, closed, skipped, and failed counts, with skip reasons and per-tab failures.
+- Managed-tab registry cleanup is batched and idempotent; `chrome.tabs.onRemoved` and command cleanup cannot cause duplicate state writes.
+
+`--dry-run` performs the same candidate revalidation but never calls `chrome.tabs.remove`.
+
+## Oracle commands
+
+`browser describe` and `browser ask` capture a screenshot and accessibility tree, then call OpenRouter. Set `OPENROUTER_API_KEY` in the environment or a nearby `.env` file. Other commands do not require an external API.
+
+## Development and verification
+
+```bash
+npm run check       # TypeScript typecheck + syntax-check extension modules
+npm test            # parser, close-idle, state/concurrency, formatting, and smoke tests
+npm run build       # compile src/ to dist/
+npm run smoke       # invoke every command through offline fakes
+```
+
+The smoke suite parses and dispatches every command without starting the WebSocket server, connecting to Chrome, closing tabs, or calling OpenRouter. Live Chrome behavior still requires manually loading the unpacked extension; automated tests intentionally do not perform destructive live-browser operations.
+
+## Notes
+
+- `screenshot` targets the selected tab only through Chrome DevTools Protocol. If full-page capture fails, it attempts a target-specific CDP viewport capture; if both fail, the command reports both errors rather than risking a screenshot of another tab.
+- `wait --stable` fingerprints the selected subtree's DOM, text, form state, key computed styles, scroll dimensions/position, and bounding rectangle; it returns after that fingerprint is unchanged for 500 ms.
+- Accessibility snapshot baselines, element refs (`e1`, `e2`, ...), and dialog state are scoped per managed tab.
+- Managed aliases persist through extension service-worker restarts using `chrome.storage.session`.
+- If the bridge disconnects, reload the extension in `chrome://extensions` and run `browser status`.

--- a/src/browser/bin/browser
+++ b/src/browser/bin/browser
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { main } from "../dist/client.js";
+
+void main();

--- a/src/browser/extension/browser-boundaries.js
+++ b/src/browser/extension/browser-boundaries.js
@@ -1,0 +1,89 @@
+/** Pure boundary helpers shared by the MV3 worker and unit tests. */
+
+function entriesArray(entries) {
+  return Array.from(entries || []);
+}
+
+/**
+ * Resolve an explicit tab parameter without ever interpreting a numeric string
+ * as a Chrome tab id. Integer ids are accepted only when already registered;
+ * strings are matched only as exact aliases (aliases happen to normally be tN).
+ */
+export function resolveManagedTabIdentifier(entries, activeTabId, params = {}) {
+  const managed = entriesArray(entries);
+  const raw = params.tabId ?? params.alias;
+
+  if (raw == null || (typeof raw === "string" && !raw.trim())) {
+    return activeTabId;
+  }
+
+  if (Number.isInteger(raw)) {
+    if (managed.some((entry) => entry?.tabId === raw)) {
+      return raw;
+    }
+    throw new Error(`Unknown managed tab id "${raw}".`);
+  }
+
+  if (typeof raw !== "string") {
+    throw new Error("Managed tab identifier must be a registered alias.");
+  }
+
+  const alias = raw.trim();
+  const entry = managed.find((candidate) => candidate?.alias === alias);
+  if (!entry) {
+    throw new Error(`Unknown managed tab alias "${alias}".`);
+  }
+  return entry.tabId;
+}
+
+export function assertManagedTabRegistered(entries, tabId) {
+  if (!Number.isInteger(tabId) || !entriesArray(entries).some((entry) => entry?.tabId === tabId)) {
+    throw new Error(`Tab ${tabId ?? "(none)"} is not a registered managed tab.`);
+  }
+  return tabId;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Capture only through a tab-id-specific CDP session. Full-page failure may
+ * fall back to a CDP viewport capture of the same target, never to the active
+ * tab of a window.
+ */
+export async function captureTargetViaCdp({
+  tabId,
+  fullPage,
+  format = "png",
+  quality = 80,
+  captureFullPage,
+  captureViewport,
+}) {
+  if (!fullPage) {
+    try {
+      return {
+        dataUrl: await captureViewport(tabId, format, quality),
+        mode: "viewport",
+      };
+    } catch (error) {
+      throw new Error(`Target-specific CDP viewport capture failed for tab ${tabId}: ${errorMessage(error)}`);
+    }
+  }
+
+  try {
+    return await captureFullPage(tabId);
+  } catch (fullPageError) {
+    try {
+      return {
+        dataUrl: await captureViewport(tabId, "png", quality),
+        mode: "viewport",
+        warning: `Full-page CDP capture failed; used target-specific CDP viewport capture instead (${errorMessage(fullPageError)}).`,
+      };
+    } catch (viewportError) {
+      throw new Error(
+        `Screenshot capture failed for tab ${tabId}: full-page CDP capture failed (${errorMessage(fullPageError)}); target-specific CDP viewport capture failed (${errorMessage(viewportError)}).`,
+      );
+    }
+  }
+}

--- a/src/browser/extension/close-idle.js
+++ b/src/browser/extension/close-idle.js
@@ -1,0 +1,166 @@
+const HOUR_MS = 60 * 60 * 1000;
+
+export function assertValidIdleHours(hours) {
+  if (!Number.isSafeInteger(hours) || hours <= 0) {
+    throw new Error("hours must be a positive safe integer.");
+  }
+}
+
+function tabDetails(tab, now) {
+  const lastAccessed = Number.isFinite(tab?.lastAccessed) ? tab.lastAccessed : null;
+  return {
+    id: tab?.id,
+    windowId: Number.isInteger(tab?.windowId) ? tab.windowId : null,
+    url: tab?.url || "about:blank",
+    title: tab?.title || "",
+    lastAccessed,
+    idleHours: lastAccessed == null ? null : Number(((now - lastAccessed) / HOUR_MS).toFixed(1)),
+  };
+}
+
+function skipReason(tab, window, cutoff) {
+  if (!Number.isInteger(tab?.id)) {
+    return "invalid-tab-id";
+  }
+  if (window?.type !== "normal") {
+    return "non-normal-window";
+  }
+  if (tab.pinned) {
+    return "pinned";
+  }
+  if (tab.audible) {
+    return "audible";
+  }
+  // Every window has an active tab. This intentionally protects active tabs in
+  // background windows as well as the last-focused window.
+  if (tab.active) {
+    return "active";
+  }
+  if (!Number.isFinite(tab.lastAccessed) || tab.lastAccessed <= 0) {
+    return "missing-last-accessed";
+  }
+  if (tab.lastAccessed > cutoff) {
+    return "not-idle";
+  }
+  return null;
+}
+
+function isVanishedError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /(?:no tab with id|tab (?:was )?not found|invalid tab id|does not exist)/i.test(message);
+}
+
+/**
+ * Globally clean up idle tabs. Managed and unmanaged tabs are both considered,
+ * but only inactive, unpinned, inaudible tabs in normal windows can qualify.
+ */
+export async function closeIdleTabs({ chromeApi, hours, dryRun = false, now = () => Date.now(), shouldContinue = () => true }) {
+  assertValidIdleHours(hours);
+  if (!chromeApi?.windows?.getAll || !chromeApi?.windows?.get || !chromeApi?.tabs?.get || !chromeApi?.tabs?.remove) {
+    throw new Error("Chrome tabs/windows APIs are unavailable.");
+  }
+
+  const startedAt = now();
+  const cutoff = startedAt - hours * HOUR_MS;
+  const windows = await chromeApi.windows.getAll({ populate: true });
+  const initialCandidates = [];
+  const skipped = [];
+  const failed = [];
+
+  for (const window of Array.isArray(windows) ? windows : []) {
+    for (const tab of Array.isArray(window?.tabs) ? window.tabs : []) {
+      const reason = skipReason(tab, window, cutoff);
+      if (reason) {
+        skipped.push({ ...tabDetails(tab, startedAt), reason });
+      } else {
+        initialCandidates.push(tabDetails(tab, startedAt));
+      }
+    }
+  }
+
+  const eligible = [];
+  const closed = [];
+
+  // Process sequentially so each get/window/get/remove sequence is a fresh
+  // safety check immediately before that individual destructive operation.
+  for (const candidate of initialCandidates) {
+    if (!shouldContinue()) {
+      break;
+    }
+    let currentTab;
+    let currentWindow;
+    let validatedWindowId;
+    try {
+      const tabBeforeWindowCheck = await chromeApi.tabs.get(candidate.id);
+      validatedWindowId = tabBeforeWindowCheck.windowId;
+      currentWindow = await chromeApi.windows.get(validatedWindowId, { populate: false });
+      // windows.get can yield while the tab changes protection state or moves.
+      // Fetch it again so no stale tab object reaches the removal decision.
+      currentTab = await chromeApi.tabs.get(candidate.id);
+    } catch (error) {
+      if (isVanishedError(error)) {
+        skipped.push({ ...candidate, reason: "vanished" });
+      } else {
+        failed.push({
+          ...candidate,
+          stage: "revalidate",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      continue;
+    }
+
+    if (!shouldContinue()) {
+      break;
+    }
+
+    const checkedAt = now();
+    const details = tabDetails(currentTab, checkedAt);
+    if (currentTab.windowId !== validatedWindowId) {
+      skipped.push({ ...details, reason: "revalidated-window-changed" });
+      continue;
+    }
+
+    const reason = skipReason(currentTab, currentWindow, cutoff);
+    if (reason) {
+      skipped.push({ ...details, reason: `revalidated-${reason}` });
+      continue;
+    }
+
+    eligible.push(details);
+    if (dryRun) {
+      continue;
+    }
+    if (!shouldContinue()) {
+      break;
+    }
+
+    try {
+      await chromeApi.tabs.remove(currentTab.id);
+      closed.push(details);
+    } catch (error) {
+      if (isVanishedError(error)) {
+        skipped.push({ ...details, reason: "vanished-before-close" });
+      } else {
+        failed.push({
+          ...details,
+          stage: "close",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  return {
+    dryRun: Boolean(dryRun),
+    hours,
+    eligibleCount: eligible.length,
+    closedCount: closed.length,
+    skippedCount: skipped.length,
+    failedCount: failed.length,
+    eligible,
+    closed,
+    skipped,
+    failed,
+  };
+}

--- a/src/browser/extension/manifest.json
+++ b/src/browser/extension/manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": 3,
+  "minimum_chrome_version": "121",
+  "name": "Browser CLI Bridge",
+  "version": "0.1.0",
+  "description": "Bridge Browser CLI commands to a dedicated Chrome automation window.",
+  "permissions": [
+    "tabs",
+    "windows",
+    "scripting",
+    "debugger",
+    "storage",
+    "alarms"
+  ],
+  "host_permissions": [
+    "<all_urls>",
+    "http://127.0.0.1/*",
+    "http://localhost/*"
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' ws://127.0.0.1:19224 ws://localhost:19224"
+  },
+  "background": {
+    "service_worker": "service-worker.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Browser CLI Bridge"
+  }
+}

--- a/src/browser/extension/runtime-state.js
+++ b/src/browser/extension/runtime-state.js
@@ -1,0 +1,60 @@
+/** Serialize MV3 session-state loading and writes across concurrent callers. */
+export class SerializedStateStore {
+  constructor({ storage, keys, read, apply, empty }) {
+    this.storage = storage;
+    this.keys = keys;
+    this.read = read;
+    this.apply = apply;
+    this.empty = empty;
+    this.loaded = false;
+    this.loadPromise = null;
+    this.writeTail = Promise.resolve();
+  }
+
+  async load() {
+    if (this.loaded) {
+      return;
+    }
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    this.loadPromise = (async () => {
+      try {
+        this.apply(await this.storage.get(this.keys));
+      } catch {
+        this.apply(this.empty());
+      } finally {
+        this.loaded = true;
+        this.loadPromise = null;
+      }
+    })();
+
+    return this.loadPromise;
+  }
+
+  async save() {
+    if (!this.loaded) {
+      await this.load();
+    }
+    // Capture a complete immutable snapshot at mutation time, then preserve
+    // write order even if chrome.storage resolves writes out of order.
+    const snapshot = structuredClone(this.read());
+    const write = this.writeTail.then(() => this.storage.set(snapshot));
+    this.writeTail = write.catch(() => undefined);
+    await write.catch(() => undefined);
+  }
+}
+
+/** A tiny serial queue used to keep extension commands from racing each other. */
+export class SerialTaskQueue {
+  constructor() {
+    this.tail = Promise.resolve();
+  }
+
+  enqueue(task) {
+    const result = this.tail.then(task, task);
+    this.tail = result.catch(() => undefined);
+    return result;
+  }
+}

--- a/src/browser/extension/service-worker.js
+++ b/src/browser/extension/service-worker.js
@@ -1,0 +1,2924 @@
+import { closeIdleTabs } from "./close-idle.js";
+import {
+  assertManagedTabRegistered,
+  captureTargetViaCdp,
+  resolveManagedTabIdentifier,
+} from "./browser-boundaries.js";
+import { SerializedStateStore, SerialTaskQueue } from "./runtime-state.js";
+
+const BRIDGE_URL = "ws://127.0.0.1:19224";
+const PREVIEW_CHARS = 500;
+const MAX_FULL_PAGE_DIMENSION = 16384;
+const BRIDGE_RECONNECT_ALARM = "browser-v2-bridge-reconnect";
+const BRIDGE_RECONNECT_PERIOD_MINUTES = 0.5;
+
+let socket = null;
+let reconnectTimer = null;
+let keepaliveTimer = null;
+let reconnectDelayMs = 1000;
+const requestQueue = new SerialTaskQueue();
+const cancelledRequestsBySocket = new WeakMap();
+
+let managedTabs = new Map();
+let activeTabId = null;
+let nextTabAliasId = 0;
+const tabSessionStates = new Map();
+let stateMutationBatchDepth = 0;
+let stateMutationBatchDirty = false;
+
+function createTabState() {
+  return {
+    snapshotBaseline: null,
+    refMap: {},
+    nextRefId: 1,
+    dialog: null,
+  };
+}
+
+function getTabState(tabId) {
+  if (!Number.isInteger(tabId)) {
+    return createTabState();
+  }
+  if (!tabSessionStates.has(tabId)) {
+    tabSessionStates.set(tabId, createTabState());
+  }
+  return tabSessionStates.get(tabId);
+}
+
+function clearSessionState(tabId) {
+  if (!Number.isInteger(tabId)) {
+    return;
+  }
+  tabSessionStates.set(tabId, createTabState());
+}
+
+function clearRefMap(tabId) {
+  const tabState = getTabState(tabId);
+  tabState.refMap = {};
+  tabState.nextRefId = 1;
+}
+
+function managedTabRecordFromTab(tab, alias) {
+  return {
+    tabId: tab.id,
+    windowId: Number.isInteger(tab.windowId) ? tab.windowId : null,
+    url: tab.url || "about:blank",
+    title: tab.title || "",
+    alias,
+  };
+}
+
+function getNextTabAlias() {
+  const alias = `t${nextTabAliasId}`;
+  nextTabAliasId += 1;
+  return alias;
+}
+
+function refreshNextTabAliasId() {
+  const aliases = Array.from(managedTabs.values())
+    .map((entry) => {
+      const match = /^t(\d+)$/.exec(entry.alias || "");
+      return match ? Number.parseInt(match[1], 10) : -1;
+    })
+    .filter((value) => Number.isFinite(value));
+  nextTabAliasId = aliases.length > 0 ? Math.max(...aliases) + 1 : 0;
+}
+
+function getManagedTabEntry(tabId) {
+  return Number.isInteger(tabId) ? managedTabs.get(tabId) ?? null : null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function throwIfCancelled(context, operation = "operation") {
+  if (context?.shouldContinue && !context.shouldContinue()) {
+    throw new Error(`Command cancelled before ${operation}.`);
+  }
+}
+
+async function cancellableSleep(ms, context) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    throwIfCancelled(context, "wait completed");
+    await sleep(Math.min(100, Math.max(0, deadline - Date.now())));
+  }
+  throwIfCancelled(context, "wait completed");
+}
+
+function postActionDelay(minMs = 300, maxMs = 800) {
+  const minimum = Number.isFinite(minMs) ? Math.max(0, Math.floor(minMs)) : 300;
+  const maximum = Number.isFinite(maxMs) ? Math.max(minimum, Math.floor(maxMs)) : 800;
+  const delay = minimum === maximum ? minimum : Math.floor(Math.random() * (maximum - minimum + 1)) + minimum;
+  return sleep(delay);
+}
+
+function log(...parts) {
+  console.log("[browser-extension]", ...parts);
+}
+
+function sendTo(targetSocket, payload) {
+  if (!targetSocket || targetSocket.readyState !== WebSocket.OPEN) {
+    return;
+  }
+  targetSocket.send(JSON.stringify(payload));
+}
+
+const statePersistence = new SerializedStateStore({
+  storage: chrome.storage.session,
+  keys: ["managedTabs", "activeTabId"],
+  empty: () => ({ managedTabs: [], activeTabId: null }),
+  read: () => ({
+    managedTabs: Array.from(managedTabs.values()),
+    activeTabId,
+  }),
+  apply: (stored) => {
+    const storedTabs = Array.isArray(stored?.managedTabs) ? stored.managedTabs : [];
+    managedTabs = new Map(
+      storedTabs
+        .filter((entry) => Number.isInteger(entry?.tabId) && typeof entry?.alias === "string")
+        .map((entry) => [
+          entry.tabId,
+          {
+            tabId: entry.tabId,
+            windowId: Number.isInteger(entry.windowId) ? entry.windowId : null,
+            url: typeof entry.url === "string" ? entry.url : "about:blank",
+            title: typeof entry.title === "string" ? entry.title : "",
+            alias: entry.alias,
+          },
+        ]),
+    );
+    activeTabId = Number.isInteger(stored?.activeTabId) ? stored.activeTabId : null;
+    if (activeTabId != null && !managedTabs.has(activeTabId)) {
+      activeTabId = managedTabs.keys().next().value ?? null;
+    }
+    refreshNextTabAliasId();
+  },
+});
+
+async function loadState() {
+  await statePersistence.load();
+}
+
+async function saveState() {
+  if (stateMutationBatchDepth > 0) {
+    stateMutationBatchDirty = true;
+    return;
+  }
+  await statePersistence.save();
+}
+
+function beginStateMutationBatch() {
+  stateMutationBatchDepth += 1;
+}
+
+async function endStateMutationBatch() {
+  stateMutationBatchDepth = Math.max(0, stateMutationBatchDepth - 1);
+  if (stateMutationBatchDepth === 0 && stateMutationBatchDirty) {
+    stateMutationBatchDirty = false;
+    await statePersistence.save();
+  }
+}
+
+async function addManagedTab(tab) {
+  if (!tab || tab.id == null) {
+    return;
+  }
+  await loadState();
+  const existing = getManagedTabEntry(tab.id);
+  managedTabs.set(tab.id, managedTabRecordFromTab(tab, existing?.alias || getNextTabAlias()));
+  activeTabId = tab.id;
+  await saveState();
+}
+
+async function updateManagedTab(tab) {
+  if (!tab || tab.id == null) {
+    return;
+  }
+  await loadState();
+  const existing = getManagedTabEntry(tab.id);
+  if (!existing) {
+    return;
+  }
+  managedTabs.set(tab.id, managedTabRecordFromTab(tab, existing.alias));
+  await saveState();
+}
+
+async function removeManagedTabs(tabIds) {
+  await loadState();
+  let changed = false;
+  for (const tabId of tabIds) {
+    if (!Number.isInteger(tabId)) {
+      continue;
+    }
+    const wasManaged = managedTabs.delete(tabId);
+    if (wasManaged) {
+      changed = true;
+      tabSessionStates.delete(tabId);
+      void debuggerPool.forceDetach(tabId).catch(() => undefined);
+    }
+    if (activeTabId === tabId) {
+      activeTabId = managedTabs.keys().next().value ?? null;
+      changed = true;
+    }
+  }
+  if (changed) {
+    await saveState();
+  }
+}
+
+async function removeManagedTab(tabId) {
+  await removeManagedTabs([tabId]);
+}
+
+async function setActiveTab(tabId) {
+  await loadState();
+  if (!Number.isInteger(tabId) || !managedTabs.has(tabId)) {
+    throw new Error(`No managed tab found for ${tabId}.`);
+  }
+  activeTabId = tabId;
+  await saveState();
+}
+
+async function resolveTabParam(params = {}) {
+  await loadState();
+  return resolveManagedTabIdentifier(managedTabs.values(), activeTabId, params);
+}
+
+function listManagedTabs() {
+  return Array.from(managedTabs.values()).map((entry) => ({
+    alias: entry.alias,
+    tabId: entry.tabId,
+    url: entry.url,
+    title: entry.title,
+    active: entry.tabId === activeTabId,
+  }));
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) {
+    return;
+  }
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connectBridge();
+  }, reconnectDelayMs);
+  reconnectDelayMs = Math.min(reconnectDelayMs * 2, 10000);
+}
+
+function connectBridge() {
+  if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
+    return;
+  }
+
+  const connection = new WebSocket(BRIDGE_URL);
+  socket = connection;
+  cancelledRequestsBySocket.set(connection, new Set());
+
+  connection.addEventListener("open", () => {
+    reconnectDelayMs = 1000;
+    sendTo(connection, { type: "hello", source: "browser-cli-v2-extension" });
+    if (keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+    }
+    keepaliveTimer = setInterval(() => {
+      sendTo(connection, { type: "keepalive", source: "browser-cli-v2-extension" });
+    }, 20_000);
+    log("Connected to bridge");
+  });
+
+  connection.addEventListener("message", (event) => {
+    handleBridgeMessage(connection, event.data);
+  });
+
+  connection.addEventListener("close", () => {
+    if (socket === connection) {
+      socket = null;
+    }
+    if (keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+      keepaliveTimer = null;
+    }
+    log("Bridge socket closed. Reconnecting...");
+    scheduleReconnect();
+  });
+
+  connection.addEventListener("error", () => {
+    log("Bridge socket error. Reconnecting...");
+    scheduleReconnect();
+  });
+}
+
+function ensureReconnectAlarm() {
+  chrome.alarms.create(BRIDGE_RECONNECT_ALARM, {
+    delayInMinutes: BRIDGE_RECONNECT_PERIOD_MINUTES,
+    periodInMinutes: BRIDGE_RECONNECT_PERIOD_MINUTES,
+  });
+}
+
+function isRestrictedUrl(url) {
+  if (typeof url !== "string" || !url) {
+    return false;
+  }
+
+  const lowered = url.toLowerCase();
+  if (lowered === "about:blank") {
+    return false;
+  }
+
+  return (
+    lowered.startsWith("chrome://") ||
+    lowered.startsWith("chrome-extension://") ||
+    lowered.startsWith("devtools://") ||
+    lowered.startsWith("edge://") ||
+    lowered.startsWith("view-source:") ||
+    lowered.startsWith("about:")
+  );
+}
+
+function normalizeUrl(value) {
+  const raw = String(value || "").trim();
+  if (!raw) {
+    return "";
+  }
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(raw)) {
+    return raw;
+  }
+  return `https://${raw}`;
+}
+
+function isProbablySelector(target) {
+  return (
+    target.startsWith(".") ||
+    target.startsWith("#") ||
+    target.startsWith("[") ||
+    target.startsWith("/") ||
+    target.startsWith("xpath=") ||
+    target.startsWith("css=") ||
+    target.startsWith("text=") ||
+    target.startsWith("role=") ||
+    /[\s>+~:[\].#=]/.test(target)
+  );
+}
+
+function resolveTargetRef(tabId, target) {
+  const raw = String(target || "").trim();
+  const tabState = getTabState(tabId);
+  if (/^e\d+$/.test(raw) && tabState.refMap[raw]) {
+    return tabState.refMap[raw];
+  }
+  return raw;
+}
+
+async function getActiveTab() {
+  const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (tabs[0]?.id != null) {
+    return tabs[0];
+  }
+
+  const fallback = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (fallback[0]?.id != null) {
+    return fallback[0];
+  }
+
+  const anyActive = await chrome.tabs.query({ active: true });
+  if (anyActive[0]?.id != null) {
+    return anyActive[0];
+  }
+
+  throw new Error("No active tab found. Focus a Chrome window and retry.");
+}
+
+async function createManagedWindow(context = {}) {
+  throwIfCancelled(context, "window creation");
+  const createdWindow = await chrome.windows.create({
+    url: "about:blank",
+    focused: true,
+    type: "normal",
+  });
+
+  let tab = createdWindow.tabs?.find((candidate) => candidate?.id != null) ?? null;
+  if (!tab && Number.isInteger(createdWindow.id)) {
+    const tabs = await chrome.tabs.query({ windowId: createdWindow.id });
+    tab = tabs.find((candidate) => candidate?.id != null) ?? null;
+  }
+
+  if (!tab || tab.id == null) {
+    throw new Error("Failed to create automation window tab.");
+  }
+
+  await addManagedTab(tab);
+  return tab;
+}
+
+async function getManagedTab(options = {}) {
+  const { allowFallback = true, requireScriptable = false } = options;
+  await loadState();
+  const explicitTabId = Number.isInteger(options.tabId) ? options.tabId : null;
+  if (explicitTabId != null) {
+    assertManagedTabRegistered(managedTabs.values(), explicitTabId);
+  }
+  const candidateIds = [];
+  if (explicitTabId != null) {
+    candidateIds.push(explicitTabId);
+  } else if (activeTabId != null) {
+    candidateIds.push(activeTabId);
+  }
+
+  for (const tabId of managedTabs.keys()) {
+    if (!candidateIds.includes(tabId)) {
+      candidateIds.push(tabId);
+    }
+  }
+
+  for (const candidateId of candidateIds) {
+    try {
+      const tab = await chrome.tabs.get(candidateId);
+      await updateManagedTab(tab);
+      if (explicitTabId == null && activeTabId !== tab.id) {
+        await setActiveTab(tab.id);
+      }
+      if (requireScriptable && isRestrictedUrl(tab.url || "")) {
+        throw new Error(
+          `Managed tab is on a restricted URL (${tab.url || "unknown"}). Run browser open <url> to move it to a normal page.`,
+        );
+      }
+      return tab;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("restricted URL")) {
+        throw error;
+      }
+      if (managedTabs.has(candidateId)) {
+        await removeManagedTab(candidateId);
+      }
+      if (explicitTabId != null) {
+        throw new Error(`Managed tab ${candidateId} is no longer available.`);
+      }
+    }
+  }
+
+  if (managedTabs.size === 0 && allowFallback) {
+    const managed = await createManagedWindow(options.context);
+
+    if (requireScriptable && isRestrictedUrl(managed.url || "")) {
+      throw new Error(
+        `Managed tab is on a restricted URL (${managed.url || "unknown"}). Open a regular http/https page first.`,
+      );
+    }
+
+    return managed;
+  }
+
+  throw new Error("No managed tab available. Run browser open <url> first.");
+}
+
+function waitForTabComplete(tabId, timeoutMs = 10000, context = {}) {
+  return new Promise((resolve, reject) => {
+    let done = false;
+    const deadline = Date.now() + timeoutMs;
+
+    const finish = (value) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      clearInterval(pollTimer);
+      resolve(value);
+    };
+
+    const fail = (message) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      clearInterval(pollTimer);
+      reject(new Error(message));
+    };
+
+    const checkCurrent = async () => {
+      try {
+        throwIfCancelled(context, "navigation wait completed");
+        const current = await chrome.tabs.get(tabId);
+        if (current.status === "complete") {
+          finish(current);
+          return;
+        }
+        if (Date.now() > deadline) {
+          fail("Timed out waiting for tab to finish loading.");
+        }
+      } catch {
+        fail("Tab is no longer available.");
+      }
+    };
+
+    const onUpdated = (updatedTabId, changeInfo, updatedTab) => {
+      if (updatedTabId === tabId && changeInfo.status === "complete") {
+        finish(updatedTab);
+      }
+    };
+
+    chrome.tabs.onUpdated.addListener(onUpdated);
+
+    const pollTimer = setInterval(() => {
+      void checkCurrent();
+    }, 200);
+
+    void checkCurrent();
+  });
+}
+
+async function runInTab(tabId, func, args = []) {
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func,
+      args,
+    });
+    return results?.[0]?.result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot execute in managed tab: ${message}`);
+  }
+}
+
+async function waitForSelector(tabId, selector, timeoutMs = 10000, context = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    throwIfCancelled(context, "selector wait completed");
+    const visible = await runInTab(
+      tabId,
+      (targetSelector) => {
+        let node = null;
+        try {
+          node = document.querySelector(targetSelector);
+        } catch {
+          return false;
+        }
+        if (!node) {
+          return false;
+        }
+        const rect = node.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      },
+      [selector],
+    );
+    if (visible) {
+      return;
+    }
+    await cancellableSleep(150, context);
+  }
+  throwIfCancelled(context, "selector wait completed");
+  throw new Error(`Timed out waiting for selector "${selector}".`);
+}
+
+async function readPreview(tabId) {
+  try {
+    const data = await runInTab(
+      tabId,
+      (previewChars) => {
+        const preview = (document.body?.innerText || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, previewChars);
+        return {
+          title: document.title || "(untitled)",
+          url: window.location.href,
+          preview,
+        };
+      },
+      [PREVIEW_CHARS],
+    );
+    return data || { title: "", url: "about:blank", preview: "" };
+  } catch {
+    const tab = await chrome.tabs.get(tabId);
+    return {
+      title: tab.title || "(untitled)",
+      url: tab.url || "about:blank",
+      preview: "[Preview unavailable for this page]",
+    };
+  }
+}
+
+function axValue(raw) {
+  if (raw == null) {
+    return null;
+  }
+  if (typeof raw === "object" && raw !== null) {
+    if (Object.prototype.hasOwnProperty.call(raw, "value")) {
+      return raw.value;
+    }
+    if (Object.prototype.hasOwnProperty.call(raw, "type")) {
+      return raw.type;
+    }
+  }
+  return raw;
+}
+
+function readAxProperty(node, name) {
+  const match = Array.isArray(node?.properties) ? node.properties.find((property) => property?.name === name) : null;
+  return match ? axValue(match.value) : null;
+}
+
+function axRoleName(node) {
+  return String(axValue(node?.role) || "").trim();
+}
+
+function axNodeName(node) {
+  return String(axValue(node?.name) || "").replace(/\s+/g, " ").trim();
+}
+
+function shouldSkipAxNode(node) {
+  if (!node || node.ignored) {
+    return true;
+  }
+  const role = axRoleName(node).toLowerCase();
+  return role === "none" || role === "presentation" || role === "inlinetextbox";
+}
+
+function serializeAxNode(node) {
+  const roleMap = {
+    rootwebarea: "page",
+    webarea: "page",
+    statictext: "text",
+    textfield: "textbox",
+    textbox: "textbox",
+  };
+  const role = axRoleName(node);
+  const normalizedRole = roleMap[role.toLowerCase()] || role.toLowerCase() || "node";
+  const name = axNodeName(node);
+  const parts = [normalizedRole];
+  if (name) {
+    parts.push(`"${name}"`);
+  }
+
+  const states = [];
+  const checked = readAxProperty(node, "checked");
+  const selected = readAxProperty(node, "selected");
+  const expanded = readAxProperty(node, "expanded");
+  const required = readAxProperty(node, "required");
+  const editable = readAxProperty(node, "editable");
+  const level = readAxProperty(node, "level");
+  const current = readAxProperty(node, "current");
+  const value = axValue(node?.value);
+  const restriction = readAxProperty(node, "restriction");
+
+  if (checked !== null) {
+    states.push(`checked=${checked}`);
+  }
+  if (selected !== null) {
+    states.push(`selected=${selected}`);
+  }
+  if (expanded !== null) {
+    states.push(`expanded=${expanded}`);
+  }
+  if (restriction === "disabled") {
+    states.push("disabled");
+  }
+  if (required === true) {
+    states.push("required");
+  }
+  if (value != null && `${value}`.trim()) {
+    states.push(`value="${String(value).replace(/\s+/g, " ").trim()}"`);
+  }
+  if (level != null) {
+    states.push(`level=${level}`);
+  }
+  if (current != null) {
+    states.push(`current=${current}`);
+  }
+  if (editable != null) {
+    states.push("editable");
+  }
+
+  return `${parts.join(" ")}${states.length > 0 ? ` [${states.join("] [")}]` : ""}`;
+}
+
+function buildSnapshotPayload(nodes, options = {}) {
+  const depthLimit = Number.isFinite(options.depth) && options.depth >= 0 ? options.depth : Number.POSITIVE_INFINITY;
+  const targetBackendNodeId = options.backendNodeId ?? null;
+  const nodeMap = new Map(nodes.map((node) => [node.nodeId, node]));
+  const parentIds = new Set();
+  for (const node of nodes) {
+    for (const childId of node.childIds || []) {
+      parentIds.add(childId);
+    }
+  }
+
+  let root =
+    (targetBackendNodeId != null && nodes.find((node) => node.backendDOMNodeId === targetBackendNodeId)) ||
+    nodes.find((node) => !parentIds.has(node.nodeId)) ||
+    nodes[0] ||
+    null;
+
+  if (!root) {
+    return { lines: [], entries: [] };
+  }
+
+  const lines = [];
+  const entries = [];
+
+  const visit = (node, depth, path) => {
+    if (!node) {
+      return;
+    }
+    const skip = shouldSkipAxNode(node);
+    const nextPathBase = path.slice();
+    if (!skip) {
+      if (depth <= depthLimit) {
+        const line = `${"  ".repeat(depth)}${serializeAxNode(node)}`;
+        lines.push(line);
+        entries.push({
+          key: `${path.join(".")}:${axRoleName(node)}:${axNodeName(node)}`,
+          role: axRoleName(node),
+          name: axNodeName(node),
+          state: serializeAxNode(node),
+          path: path.join("."),
+        });
+      }
+    }
+
+    const childDepth = skip ? depth : depth + 1;
+    if (childDepth > depthLimit) {
+      return;
+    }
+    const childIds = Array.isArray(node.childIds) ? node.childIds : [];
+    childIds.forEach((childId, index) => {
+      const child = nodeMap.get(childId);
+      visit(child, childDepth, skip ? path.concat(index) : nextPathBase.concat(index));
+    });
+  };
+
+  visit(root, 0, [0]);
+  return { lines, entries };
+}
+
+function parseSerializedState(state) {
+  const value = String(state || "").trim();
+  const bracketIndex = value.indexOf(" [");
+  return {
+    label: bracketIndex === -1 ? value : value.slice(0, bracketIndex).trim(),
+    attributes: Array.from(value.matchAll(/\[([^\]]+)\]/g)).map((match) => match[1].trim()),
+  };
+}
+
+function formatChangedState(previousState, nextState) {
+  const previous = parseSerializedState(previousState);
+  const next = parseSerializedState(nextState);
+  if (previous.label && previous.label === next.label) {
+    const previousAttributes = previous.attributes.join("] [") || "state unavailable";
+    const nextAttributes = next.attributes.join("] [") || "state unavailable";
+    return `${next.label} [${previousAttributes} -> ${nextAttributes}]`;
+  }
+  return `${previousState} -> ${nextState}`;
+}
+
+function computeStateChanges(beforeSnapshot, afterSnapshot, limit = 20) {
+  if ((beforeSnapshot?.snapshot || "") === (afterSnapshot?.snapshot || "")) {
+    return ["No state changes detected."];
+  }
+
+  const previousEntries = Array.isArray(beforeSnapshot?.entries) ? beforeSnapshot.entries : [];
+  const nextEntries = Array.isArray(afterSnapshot?.entries) ? afterSnapshot.entries : [];
+  const previousMap = new Map(previousEntries.map((entry) => [entry.key, entry]));
+  const nextMap = new Map(nextEntries.map((entry) => [entry.key, entry]));
+  const changes = [];
+
+  for (const [key, nextEntry] of nextMap.entries()) {
+    const previousEntry = previousMap.get(key);
+    if (!previousEntry) {
+      changes.push(`ADDED: ${nextEntry.state}`);
+    } else if (previousEntry.state !== nextEntry.state) {
+      changes.push(`CHANGED: ${formatChangedState(previousEntry.state, nextEntry.state)}`);
+    }
+    if (changes.length >= limit) {
+      return changes;
+    }
+  }
+
+  for (const [key, previousEntry] of previousMap.entries()) {
+    if (!nextMap.has(key)) {
+      changes.push(`REMOVED: ${previousEntry.state}`);
+    }
+    if (changes.length >= limit) {
+      return changes;
+    }
+  }
+
+  return changes.length > 0 ? changes : ["No state changes detected."];
+}
+
+async function captureWriteStateChanges(tabId, action) {
+  let beforeSnapshot = null;
+  try {
+    beforeSnapshot = await captureAxTree(tabId, { depth: 3 });
+  } catch (error) {
+    log("Pre-action AX snapshot failed:", error instanceof Error ? error.message : String(error));
+  }
+
+  const result = await action();
+
+  if (!beforeSnapshot) {
+    return {
+      result,
+      stateChanges: ["Unable to capture pre-action state."],
+    };
+  }
+
+  try {
+    const afterSnapshot = await captureAxTree(tabId, { depth: 3 });
+    return {
+      result,
+      stateChanges: computeStateChanges(beforeSnapshot, afterSnapshot),
+    };
+  } catch (error) {
+    return {
+      result,
+      stateChanges: [`Unable to capture post-action state: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+}
+
+async function maybePostActionDelay(params) {
+  if (params?.noDelay) {
+    return;
+  }
+  await postActionDelay();
+}
+
+async function captureAxTree(tabId, options = {}) {
+  return withDebugger(tabId, async (target) => {
+    await chrome.debugger.sendCommand(target, "Accessibility.enable");
+    let response;
+    let backendNodeId = null;
+
+    if (typeof options.scope === "string" && options.scope.trim()) {
+      const documentNode = await chrome.debugger.sendCommand(target, "DOM.getDocument", { depth: -1, pierce: true });
+      const rootNodeId = documentNode?.root?.nodeId;
+      if (!rootNodeId) {
+        throw new Error("Unable to resolve DOM document for snapshot.");
+      }
+      const query = await chrome.debugger.sendCommand(target, "DOM.querySelector", {
+        nodeId: rootNodeId,
+        selector: options.scope,
+      });
+      if (!query?.nodeId) {
+        throw new Error(`No element matches scope selector "${options.scope}".`);
+      }
+      const described = await chrome.debugger.sendCommand(target, "DOM.describeNode", { nodeId: query.nodeId });
+      backendNodeId = described?.node?.backendNodeId ?? null;
+      response = await chrome.debugger.sendCommand(target, "Accessibility.getPartialAXTree", {
+        nodeId: query.nodeId,
+        fetchRelatives: true,
+      });
+    } else {
+      response = await chrome.debugger.sendCommand(target, "Accessibility.getFullAXTree");
+    }
+
+    const nodes = Array.isArray(response?.nodes) ? response.nodes : [];
+    const payload = buildSnapshotPayload(nodes, {
+      depth: options.depth,
+      backendNodeId,
+    });
+    return {
+      snapshot: payload.lines.join("\n"),
+      entries: payload.entries,
+    };
+  });
+}
+
+class DebuggerPool {
+  constructor() {
+    this.sessions = new Map();
+    chrome.debugger.onEvent.addListener((source, method, params) => {
+      const tabId = source?.tabId;
+      if (!Number.isInteger(tabId)) {
+        return;
+      }
+      const tabState = getTabState(tabId);
+      if (method === "Page.javascriptDialogOpening") {
+        tabState.dialog = {
+          open: true,
+          type: params?.type || "dialog",
+          message: params?.message || "",
+          defaultPrompt: params?.defaultPrompt || "",
+          hasBrowserHandler: Boolean(params?.hasBrowserHandler),
+        };
+      }
+      if (method === "Page.javascriptDialogClosed") {
+        tabState.dialog = null;
+      }
+    });
+  }
+
+  getSession(tabId) {
+    if (!this.sessions.has(tabId)) {
+      this.sessions.set(tabId, {
+        target: { tabId },
+        attached: false,
+        refCount: 0,
+        queue: Promise.resolve(),
+        idleTimer: null,
+      });
+    }
+    return this.sessions.get(tabId);
+  }
+
+  async ensureAttached(session) {
+    if (session.attached) {
+      return;
+    }
+    await chrome.debugger.attach(session.target, "1.3");
+    session.attached = true;
+    await chrome.debugger.sendCommand(session.target, "Page.enable");
+    await chrome.debugger.sendCommand(session.target, "Runtime.enable");
+    await chrome.debugger.sendCommand(session.target, "DOM.enable");
+    // Note: Input domain has no "enable" method — it's always available once debugger is attached.
+  }
+
+  scheduleDetach(session) {
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer);
+    }
+    session.idleTimer = setTimeout(() => {
+      void this.forceDetach(session.target.tabId);
+    }, 2000);
+  }
+
+  async forceDetach(tabId) {
+    const session = this.getSession(tabId);
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = null;
+    }
+    if (!session.attached) {
+      return;
+    }
+    session.refCount = 0;
+    try {
+      await chrome.debugger.detach(session.target);
+    } catch {
+      // Ignore detach failures.
+    }
+    session.attached = false;
+    getTabState(tabId).dialog = null;
+  }
+
+  async run(tabId, callback, timeoutMs = 10000) {
+    const session = this.getSession(tabId);
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = null;
+    }
+
+    const operation = async () => {
+      await this.ensureAttached(session);
+      session.refCount += 1;
+      try {
+        return await Promise.race([
+          callback(session.target),
+          new Promise((_, reject) => {
+            setTimeout(() => reject(new Error("Debugger operation timed out.")), timeoutMs);
+          }),
+        ]);
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("timed out")) {
+          log("Debugger session timed out; forcing detach for tab", tabId);
+          await this.forceDetach(tabId);
+        }
+        throw error;
+      } finally {
+        session.refCount = Math.max(0, session.refCount - 1);
+        if (session.refCount === 0) {
+          this.scheduleDetach(session);
+        }
+      }
+    };
+
+    const queued = session.queue.then(operation, operation);
+    session.queue = queued.catch(() => undefined);
+    return queued;
+  }
+}
+
+const debuggerPool = new DebuggerPool();
+
+async function withDebugger(tabId, callback, timeoutMs = 10000) {
+  return debuggerPool.run(tabId, callback, timeoutMs);
+}
+
+async function getPlatformModifier() {
+  const info = await chrome.runtime.getPlatformInfo();
+  return info.os === "mac" ? 4 : 2;
+}
+
+function keyDescriptionForCharacter(character) {
+  if (character === "\n") {
+    return {
+      key: "Enter",
+      code: "Enter",
+      windowsVirtualKeyCode: 13,
+      text: "\r",
+      unmodifiedText: "\r",
+    };
+  }
+
+  if (character === "\t") {
+    return {
+      key: "Tab",
+      code: "Tab",
+      windowsVirtualKeyCode: 9,
+      text: "\t",
+      unmodifiedText: "\t",
+    };
+  }
+
+  const upper = character.toUpperCase();
+  const lower = character.toLowerCase();
+  if (/^[a-z]$/i.test(character)) {
+    return {
+      key: character,
+      code: `Key${upper}`,
+      windowsVirtualKeyCode: upper.charCodeAt(0),
+      text: character,
+      unmodifiedText: lower,
+    };
+  }
+
+  if (/^[0-9]$/.test(character)) {
+    return {
+      key: character,
+      code: `Digit${character}`,
+      windowsVirtualKeyCode: character.charCodeAt(0),
+      text: character,
+      unmodifiedText: character,
+    };
+  }
+
+  return {
+    key: character,
+    code: "Unidentified",
+    windowsVirtualKeyCode: character.charCodeAt(0),
+    text: character,
+    unmodifiedText: character,
+  };
+}
+
+async function dispatchCharacter(target, character) {
+  const description = keyDescriptionForCharacter(character);
+  // keyDown without text/unmodifiedText — otherwise Chrome inserts the char twice
+  // (once on keyDown with text, once on the char event).
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: description.key,
+    code: description.code,
+    windowsVirtualKeyCode: description.windowsVirtualKeyCode,
+  });
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "char",
+    ...description,
+  });
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: description.key,
+    code: description.code,
+    windowsVirtualKeyCode: description.windowsVirtualKeyCode,
+  });
+}
+
+async function dispatchShortcut(target, options) {
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "rawKeyDown",
+    ...options,
+  });
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: options.key,
+    code: options.code,
+    windowsVirtualKeyCode: options.windowsVirtualKeyCode,
+    modifiers: options.modifiers,
+  });
+}
+
+async function dispatchBackspace(target) {
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "rawKeyDown",
+    key: "Backspace",
+    code: "Backspace",
+    windowsVirtualKeyCode: 8,
+  });
+  await chrome.debugger.sendCommand(target, "Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Backspace",
+    code: "Backspace",
+    windowsVirtualKeyCode: 8,
+  });
+}
+
+async function resolveWritableTarget(tabId, target, index) {
+  return runInTab(
+    tabId,
+    (rawTarget, rawIndex, selectorHint) => {
+      const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+      const cssEscape = (value) => (window.CSS && typeof window.CSS.escape === "function" ? window.CSS.escape(value) : value);
+      const isVisible = (node) => {
+        if (!(node instanceof Element)) {
+          return false;
+        }
+        const rect = node.getBoundingClientRect();
+        const style = window.getComputedStyle(node);
+        return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+      };
+      const uniqueSelector = (element) => {
+        if (!(element instanceof Element)) {
+          return null;
+        }
+        if (element.id) {
+          return `#${cssEscape(element.id)}`;
+        }
+        for (const attr of ["data-e2e", "data-testid", "name", "aria-label", "placeholder"]) {
+          const value = element.getAttribute(attr);
+          if (value && document.querySelectorAll(`${element.tagName.toLowerCase()}[${attr}="${cssEscape(value)}"]`).length === 1) {
+            return `${element.tagName.toLowerCase()}[${attr}="${cssEscape(value)}"]`;
+          }
+        }
+        const parts = [];
+        let current = element;
+        while (current && current instanceof Element && current !== document.body) {
+          let part = current.tagName.toLowerCase();
+          if (current.classList.length > 0) {
+            part += `.${Array.from(current.classList)
+              .slice(0, 2)
+              .map((value) => cssEscape(value))
+              .join(".")}`;
+          }
+          const siblings = current.parentElement
+            ? Array.from(current.parentElement.children).filter((child) => child.tagName === current.tagName)
+            : [];
+          if (siblings.length > 1) {
+            part += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+          }
+          parts.unshift(part);
+          const selector = parts.join(" > ");
+          if (document.querySelectorAll(selector).length === 1) {
+            return selector;
+          }
+          current = current.parentElement;
+        }
+        return parts.join(" > ") || element.tagName.toLowerCase();
+      };
+
+      const candidateSelector = "input, textarea, [contenteditable='true'], [contenteditable=''], [role='textbox'], [aria-label], [name]";
+      let matches = [];
+      if (selectorHint) {
+        try {
+          matches = Array.from(document.querySelectorAll(rawTarget));
+        } catch {
+          matches = [];
+        }
+      }
+
+      const targetText = normalize(rawTarget).toLowerCase();
+      if (matches.length === 0 && targetText) {
+        const exact = [];
+        const partial = [];
+        for (const node of Array.from(document.querySelectorAll(candidateSelector))) {
+          const text = normalize(
+            node.innerText ||
+              node.textContent ||
+              node.getAttribute("aria-label") ||
+              node.getAttribute("name") ||
+              node.getAttribute("placeholder") ||
+              node.getAttribute("value"),
+          );
+          if (!text) {
+            continue;
+          }
+          const lowered = text.toLowerCase();
+          if (lowered === targetText) {
+            exact.push(node);
+          } else if (lowered.includes(targetText)) {
+            partial.push(node);
+          }
+        }
+        matches = exact.length > 0 ? exact : partial;
+      }
+
+      const suggestions = Array.from(document.querySelectorAll(candidateSelector))
+        .map((node) =>
+          normalize(
+            node.innerText ||
+              node.textContent ||
+              node.getAttribute("aria-label") ||
+              node.getAttribute("name") ||
+              node.getAttribute("placeholder"),
+          ),
+        )
+        .filter(Boolean)
+        .slice(0, 8);
+
+      if (matches.length === 0) {
+        return {
+          ok: false,
+          error: suggestions.length > 0 ? `No writable element matching "${rawTarget}". Available inputs: ${suggestions.map((item) => `"${item}"`).join(", ")}` : `No writable element matching "${rawTarget}".`,
+        };
+      }
+
+      const indexValue = Number.isFinite(rawIndex) ? rawIndex : 0;
+      if (indexValue >= matches.length) {
+        return {
+          ok: false,
+          error: `Match index ${indexValue} is out of range for "${rawTarget}" (${matches.length} matches).`,
+        };
+      }
+
+      const element = matches[indexValue];
+      const writable =
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement ||
+        (element instanceof HTMLElement && element.isContentEditable) ||
+        element.getAttribute("role") === "textbox";
+      if (!writable) {
+        return { ok: false, error: `Element "${rawTarget}" is not a writable input.` };
+      }
+
+      return {
+        ok: true,
+        selector: uniqueSelector(element),
+        description: normalize(
+          element.getAttribute("aria-label") ||
+            element.getAttribute("name") ||
+            element.getAttribute("placeholder") ||
+            element.innerText ||
+            element.textContent ||
+            rawTarget,
+        ),
+      };
+    },
+    [target, index, isProbablySelector(target)],
+  );
+}
+
+async function readElementValue(tabId, selector) {
+  return runInTab(
+    tabId,
+    (targetSelector) => {
+      if (!targetSelector) {
+        return "";
+      }
+      const element = document.querySelector(targetSelector);
+      if (!element) {
+        return "";
+      }
+      if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+        return element.value;
+      }
+      return (element.innerText || element.textContent || "").replace(/\s+/g, " ").trim();
+    },
+    [selector],
+  );
+}
+
+async function resolveUploadTarget(tabId, target) {
+  return runInTab(
+    tabId,
+    (rawTarget) => {
+      const cssEscape = (value) => (window.CSS && typeof window.CSS.escape === "function" ? window.CSS.escape(value) : value);
+      const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+      const selectorHint = rawTarget && (rawTarget.startsWith(".") || rawTarget.startsWith("#") || rawTarget.startsWith("[") || /[\s>+~:[\].#=]/.test(rawTarget));
+      const buildSelector = (element) => {
+        if (!(element instanceof Element)) {
+          return null;
+        }
+        if (element.id) {
+          return `#${cssEscape(element.id)}`;
+        }
+        for (const attr of ["data-e2e", "data-testid", "name", "accept"]) {
+          const value = element.getAttribute(attr);
+          if (value && document.querySelectorAll(`${element.tagName.toLowerCase()}[${attr}="${cssEscape(value)}"]`).length === 1) {
+            return `${element.tagName.toLowerCase()}[${attr}="${cssEscape(value)}"]`;
+          }
+        }
+        const parts = [];
+        let current = element;
+        while (current && current instanceof Element && current !== document.body) {
+          let part = current.tagName.toLowerCase();
+          const siblings = current.parentElement
+            ? Array.from(current.parentElement.children).filter((child) => child.tagName === current.tagName)
+            : [];
+          if (siblings.length > 1) {
+            part += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+          }
+          parts.unshift(part);
+          const selector = parts.join(" > ");
+          if (document.querySelectorAll(selector).length === 1) {
+            return selector;
+          }
+          current = current.parentElement;
+        }
+        return parts.join(" > ") || element.tagName.toLowerCase();
+      };
+
+      const isFileInput = (node) => node instanceof HTMLInputElement && node.type === "file";
+      let element = null;
+      if (selectorHint) {
+        try {
+          element = document.querySelector(rawTarget);
+        } catch {
+          element = null;
+        }
+      } else if (typeof rawTarget === "string" && rawTarget.trim()) {
+        const exact = Array.from(document.querySelectorAll("input[type='file']")).find((node) => {
+          const label = normalize(node.getAttribute("aria-label") || node.getAttribute("name") || node.getAttribute("accept"));
+          return label.toLowerCase() === rawTarget.trim().toLowerCase();
+        });
+        element = exact || null;
+      }
+
+      let input = null;
+      if (isFileInput(element)) {
+        input = element;
+      } else if (element instanceof Element) {
+        input =
+          element.closest("input[type='file']") ||
+          element.querySelector("input[type='file']") ||
+          (element.parentElement ? element.parentElement.querySelector("input[type='file']") : null);
+      }
+
+      if (!input && selectorHint) {
+        try {
+          input = document.querySelector(`${rawTarget} input[type='file']`);
+        } catch {
+          input = null;
+        }
+      }
+
+      const available = Array.from(document.querySelectorAll("input[type='file']")).map((node) => ({
+        selector: buildSelector(node),
+        accept: node.getAttribute("accept") || "",
+      }));
+
+      if (!input) {
+        return {
+          ok: false,
+          error:
+            available.length > 0
+              ? `No matching input[type=file] for "${rawTarget}". File inputs on page: ${available.map((item) => `${item.selector || "input[type=file]"}${item.accept ? ` (accept=${item.accept})` : ""}`).join(", ")}`
+              : `No matching input[type=file] for "${rawTarget}". No file inputs are present on the page.`,
+        };
+      }
+
+      return {
+        ok: true,
+        selector: buildSelector(input),
+        accept: input.getAttribute("accept") || "",
+      };
+    },
+    [target],
+  );
+}
+
+async function runOpen(params, context = {}) {
+  const normalizedUrl = normalizeUrl(params.url);
+  if (!normalizedUrl) {
+    throw new Error("Missing required argument <url>.");
+  }
+
+  await loadState();
+  const requestedTabId = await resolveTabParam(params);
+  let tab;
+  if (params.newTab) {
+    if (params.newWindow || managedTabs.size === 0) {
+      tab = await createManagedWindow(context);
+      throwIfCancelled(context, "navigation");
+      await chrome.tabs.update(tab.id, { url: normalizedUrl, active: true });
+    } else {
+      const sourceTab = await getManagedTab({ tabId: requestedTabId, allowFallback: false, requireScriptable: false });
+      throwIfCancelled(context, "tab creation");
+      tab = await chrome.tabs.create({
+        url: normalizedUrl,
+        active: true,
+        ...(Number.isInteger(sourceTab.windowId) ? { windowId: sourceTab.windowId } : {}),
+      });
+      await addManagedTab(tab);
+    }
+  } else {
+    tab = await getManagedTab({ tabId: requestedTabId, allowFallback: true, requireScriptable: false, context });
+    throwIfCancelled(context, "navigation");
+    await chrome.tabs.update(tab.id, { url: normalizedUrl, active: true });
+  }
+
+  await waitForTabComplete(tab.id, 10000, context);
+  const updatedTab = await chrome.tabs.get(tab.id);
+  await addManagedTab(updatedTab);
+  clearSessionState(updatedTab.id);
+
+  const waitSelector = typeof params.wait === "string" ? params.wait.trim() : "";
+  if (waitSelector) {
+    if (isRestrictedUrl(updatedTab.url || "")) {
+      throw new Error(`Cannot apply --wait on restricted URL (${updatedTab.url || "unknown"}).`);
+    }
+    await waitForSelector(updatedTab.id, waitSelector, 10000, context);
+  }
+
+  const preview = await readPreview(updatedTab.id);
+  await maybePostActionDelay(params);
+  return preview;
+}
+
+async function runClick(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const rawTarget = String(params.target || "").trim();
+  const target = resolveTargetRef(tab.id, rawTarget);
+  if (!target) {
+    throw new Error("Missing required argument <target>.");
+  }
+
+  const index = Number.isFinite(params.index) ? Math.max(0, Number(params.index)) : 0;
+  const textOnly = Boolean(params.text);
+  const includeCoords = Boolean(params.coords);
+  const { result, stateChanges } = await captureWriteStateChanges(tab.id, async () => {
+    throwIfCancelled(context, "click");
+    const clickResult = await runInTab(tab.id, (rawTargetValue, rawIndex, selectorHint, explicitTextOnly, wantCoords) => {
+      const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+      const isVisible = (node) => {
+        if (!(node instanceof Element)) {
+          return false;
+        }
+        const rect = node.getBoundingClientRect();
+        const style = window.getComputedStyle(node);
+        return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+      };
+      const describeNode = (node) => {
+        if (!(node instanceof Element)) {
+          return "element";
+        }
+        const tag = node.tagName.toLowerCase();
+        if (node.id) {
+          return `${tag}#${node.id}`;
+        }
+        if (node.classList.length > 0) {
+          return `${tag}.${Array.from(node.classList).slice(0, 2).join(".")}`;
+        }
+        const dataE2e = node.getAttribute("data-e2e");
+        if (dataE2e) {
+          return `${tag}[data-e2e='${dataE2e}']`;
+        }
+        return tag;
+      };
+      const targetText = normalize(rawTargetValue).toLowerCase();
+      const indexValue = Number.isFinite(rawIndex) ? rawIndex : 0;
+      const candidateBuckets = [];
+
+      let matches = [];
+      if (selectorHint && !explicitTextOnly) {
+        try {
+          matches = Array.from(document.querySelectorAll(rawTargetValue));
+        } catch {
+          matches = [];
+        }
+      }
+
+      if (matches.length === 0 && targetText) {
+        const primaryCandidates = Array.from(
+          document.querySelectorAll("a, button, input, textarea, select, label, summary, [role='button'], [role='link']"),
+        ).filter(isVisible);
+        candidateBuckets.push(...primaryCandidates);
+        const exact = [];
+        const partial = [];
+        for (const node of primaryCandidates) {
+          const text = normalize(node.innerText || node.textContent || node.getAttribute("aria-label") || node.getAttribute("value"));
+          if (!text) {
+            continue;
+          }
+          const lower = text.toLowerCase();
+          if (lower === targetText) {
+            exact.push(node);
+          } else if (lower.includes(targetText)) {
+            partial.push(node);
+          }
+        }
+        matches = exact.length > 0 ? exact : partial;
+      }
+
+      if (matches.length === 0 && targetText) {
+        const allVisible = Array.from(document.querySelectorAll("body *")).filter(isVisible);
+        const scored = [];
+        for (const node of allVisible) {
+          const text = normalize(
+            node.innerText ||
+              node.textContent ||
+              node.getAttribute("aria-label") ||
+              node.getAttribute("data-e2e") ||
+              node.getAttribute("value"),
+          );
+          if (!text) {
+            continue;
+          }
+          const lower = text.toLowerCase();
+          if (!lower.includes(targetText) && lower !== targetText) {
+            continue;
+          }
+          const style = window.getComputedStyle(node);
+          const clickableScore =
+            (style.cursor === "pointer" ? 3 : 0) +
+            (typeof node.onclick === "function" ? 3 : 0) +
+            (node.hasAttribute("role") ? 2 : 0) +
+            (node.hasAttribute("data-e2e") ? 2 : 0) +
+            (node.hasAttribute("tabindex") ? 1 : 0);
+          scored.push({
+            node,
+            clickableScore,
+            exact: lower === targetText ? 1 : 0,
+          });
+        }
+        scored.sort((left, right) => right.exact - left.exact || right.clickableScore - left.clickableScore);
+        matches = scored.map((item) => item.node);
+        candidateBuckets.push(...matches);
+      }
+
+      if (matches.length === 0) {
+        const clickableSuggestions = Array.from(
+          new Set(
+            Array.from(document.querySelectorAll("button, a, [role='button'], [role='link'], [onclick], [data-e2e]"))
+              .filter(isVisible)
+              .map((node) => ({
+                text: normalize(
+                  node.innerText || node.textContent || node.getAttribute("aria-label") || node.getAttribute("data-e2e") || node.getAttribute("value"),
+                ),
+                desc: describeNode(node),
+              }))
+              .filter((item) => item.text)
+              .slice(0, 8)
+              .map((item) => `  "${item.text}" (${item.desc})`),
+          ),
+        );
+        const similar = clickableSuggestions.find((item) => item.toLowerCase().includes(targetText));
+        return {
+          ok: false,
+          error: `No element matching "${rawTargetValue}".\nVisible clickable elements on page:\n${clickableSuggestions.join("\n") || "  (none found)"}${similar ? `\nDid you mean ${similar.trim()}?` : ""}`,
+        };
+      }
+
+      if (indexValue >= matches.length) {
+        return {
+          ok: false,
+          error: `Match index ${indexValue} is out of range for "${rawTargetValue}" (${matches.length} matches).`,
+        };
+      }
+
+      const element = matches[indexValue];
+      if (!element) {
+        return {
+          ok: false,
+          error: `No element matching "${rawTargetValue}".`,
+        };
+      }
+
+      if (element instanceof HTMLElement) {
+        element.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });
+        element.click();
+      } else if (typeof element.click === "function") {
+        element.click();
+      }
+
+      const rect = typeof element.getBoundingClientRect === "function" ? element.getBoundingClientRect() : null;
+      return {
+        ok: true,
+        coords:
+          wantCoords && rect
+            ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+            : undefined,
+      };
+    }, [target, index, isProbablySelector(target), textOnly, includeCoords]);
+
+    await waitForTabComplete(tab.id, 2000, context).catch(() => undefined);
+    return clickResult;
+  });
+
+  if (!result?.ok) {
+    throw new Error(result?.error || `No element matching "${target}".`);
+  }
+
+  const preview = await readPreview(tab.id);
+  await maybePostActionDelay(params);
+  return {
+    clicked: rawTarget,
+    target,
+    ...(result.coords ? { coords: result.coords } : {}),
+    stateChanges,
+    ...preview,
+  };
+}
+
+async function runType(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const rawTarget = String(params.target || "").trim();
+  const target = resolveTargetRef(tab.id, rawTarget);
+  if (!target) {
+    throw new Error("Missing required argument <target>.");
+  }
+  if (typeof params.text !== "string") {
+    throw new Error("Missing required argument <text>.");
+  }
+
+  const text = params.text;
+  const index = Number.isFinite(params.index) ? Math.max(0, Number(params.index)) : 0;
+
+  const { result, stateChanges } = await captureWriteStateChanges(tab.id, () => {
+    throwIfCancelled(context, "typing");
+    return runInTab(tab.id, (rawTarget, rawText, rawIndex, selectorHint) => {
+      const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+      const targetText = normalize(rawTarget).toLowerCase();
+      const indexValue = Number.isFinite(rawIndex) ? rawIndex : 0;
+
+      let matches = [];
+      if (selectorHint) {
+        try {
+          matches = Array.from(document.querySelectorAll(rawTarget));
+        } catch {
+          matches = [];
+        }
+      }
+
+      if (matches.length === 0 && targetText) {
+        const candidates = Array.from(
+          document.querySelectorAll("input, textarea, [contenteditable='true'], [role='textbox'], [aria-label], [name]"),
+        );
+        const exact = [];
+        const partial = [];
+        for (const node of candidates) {
+          const textContent = normalize(
+            node.innerText ||
+              node.textContent ||
+              node.getAttribute("aria-label") ||
+              node.getAttribute("name") ||
+              node.getAttribute("placeholder"),
+          );
+          if (!textContent) {
+            continue;
+          }
+          const lower = textContent.toLowerCase();
+          if (lower === targetText) {
+            exact.push(node);
+          } else if (lower.includes(targetText)) {
+            partial.push(node);
+          }
+        }
+        matches = exact.length > 0 ? exact : partial;
+      }
+
+      if (matches.length === 0) {
+        const suggestions = Array.from(document.querySelectorAll("input, textarea, [contenteditable='true'], [role='textbox']"))
+          .map((node) =>
+            normalize(
+              node.innerText ||
+                node.textContent ||
+                node.getAttribute("aria-label") ||
+                node.getAttribute("name") ||
+                node.getAttribute("placeholder"),
+            ),
+          )
+          .filter(Boolean)
+          .slice(0, 8);
+        return {
+          ok: false,
+          error:
+            suggestions.length > 0
+              ? `No writable element matching "${rawTarget}". Available inputs: ${suggestions.map((item) => `"${item}"`).join(", ")}`
+              : `No writable element matching "${rawTarget}".`,
+        };
+      }
+
+      if (indexValue >= matches.length) {
+        return {
+          ok: false,
+          error: `Match index ${indexValue} is out of range for "${rawTarget}" (${matches.length} matches).`,
+        };
+      }
+
+      const element = matches[indexValue];
+
+      if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+        element.focus();
+        element.value = "";
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+        element.value = rawText;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+        element.dispatchEvent(new Event("change", { bubbles: true }));
+        return { ok: true };
+      }
+
+      if (element instanceof HTMLElement && element.isContentEditable) {
+        element.focus();
+        element.textContent = rawText;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+        element.dispatchEvent(new Event("change", { bubbles: true }));
+        return { ok: true };
+      }
+
+      return { ok: false, error: `Element "${rawTarget}" is not a writable input.` };
+    }, [target, text, index, isProbablySelector(target)]);
+  });
+
+  if (!result?.ok) {
+    throw new Error(result?.error || `No writable element matching "${target}".`);
+  }
+
+  await maybePostActionDelay(params);
+  return {
+    typedInto: rawTarget,
+    target,
+    text,
+    stateChanges,
+  };
+}
+
+async function runFill(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const rawTarget = String(params.target || "").trim();
+  const target = resolveTargetRef(tab.id, rawTarget);
+  if (!target) {
+    throw new Error("Missing required argument <target>.");
+  }
+
+  const text = typeof params.text === "string" ? params.text : "";
+  const clear = Boolean(params.clear);
+  const append = Boolean(params.append);
+  const index = Number.isFinite(params.index) ? Math.max(0, Number(params.index)) : 0;
+
+  const resolved = await resolveWritableTarget(tab.id, target, index);
+  if (!resolved?.ok) {
+    throw new Error(resolved?.error || `No writable element matching "${rawTarget}".`);
+  }
+
+  const previous = await readElementValue(tab.id, resolved.selector);
+  const intended = clear ? "" : append ? `${previous}${text}` : text;
+  const { stateChanges } = await captureWriteStateChanges(tab.id, async () => {
+    throwIfCancelled(context, "fill");
+    await runInTab(tab.id, (selector) => {
+      const element = selector ? document.querySelector(selector) : null;
+      if (element instanceof HTMLElement) {
+        element.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });
+        element.focus();
+        element.click();
+      }
+    }, [resolved.selector]);
+    throwIfCancelled(context, "fill input dispatch");
+    await withDebugger(tab.id, async (debugTarget) => {
+      const modifiers = await getPlatformModifier();
+      if (!append) {
+        throwIfCancelled(context, "fill selection");
+        await dispatchShortcut(debugTarget, {
+          key: "a",
+          code: "KeyA",
+          windowsVirtualKeyCode: 65,
+          modifiers,
+        });
+        throwIfCancelled(context, "fill deletion");
+        await dispatchBackspace(debugTarget);
+      }
+
+      if (!clear) {
+        for (const character of Array.from(text)) {
+          throwIfCancelled(context, "fill character dispatch");
+          await dispatchCharacter(debugTarget, character);
+        }
+      }
+    });
+  });
+
+  const actual = await readElementValue(tab.id, resolved.selector);
+  await maybePostActionDelay(params);
+  return {
+    filledInto: rawTarget,
+    target: resolved.selector || target,
+    intended,
+    actual,
+    match: actual === intended,
+    stateChanges,
+  };
+}
+
+async function runUpload(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const rawTarget = String(params.target || "").trim();
+  const target = resolveTargetRef(tab.id, rawTarget);
+  const filepath = String(params.filepath || "").trim();
+  if (!target) {
+    throw new Error("Missing required argument <target>.");
+  }
+  if (!filepath) {
+    throw new Error("Missing required argument <filepath>.");
+  }
+  const resolved = await resolveUploadTarget(tab.id, target);
+  if (!resolved?.ok || !resolved.selector) {
+    throw new Error(resolved?.error || `No matching input[type=file] for "${rawTarget}".`);
+  }
+
+  const { stateChanges } = await captureWriteStateChanges(tab.id, async () => {
+    throwIfCancelled(context, "file upload");
+    await withDebugger(tab.id, async (debugTarget) => {
+      const documentNode = await chrome.debugger.sendCommand(debugTarget, "DOM.getDocument", { depth: -1, pierce: true });
+      const rootNodeId = documentNode?.root?.nodeId;
+      if (!rootNodeId) {
+        throw new Error("Unable to resolve DOM document for upload.");
+      }
+      const query = await chrome.debugger.sendCommand(debugTarget, "DOM.querySelector", {
+        nodeId: rootNodeId,
+        selector: resolved.selector,
+      });
+      const nodeId = query?.nodeId;
+      if (!nodeId) {
+        throw new Error(`Resolved upload selector no longer matches: ${resolved.selector}`);
+      }
+      throwIfCancelled(context, "file selection");
+      await chrome.debugger.sendCommand(debugTarget, "DOM.setFileInputFiles", {
+        files: [filepath],
+        nodeId,
+      });
+    });
+  });
+
+  const preview = await readPreview(tab.id);
+  await maybePostActionDelay(params);
+  return {
+    uploaded: filepath,
+    target: rawTarget,
+    selector: resolved.selector,
+    stateChanges,
+    ...preview,
+  };
+}
+
+function parseDelayRange(value) {
+  const raw = String(value || "").trim();
+  if (!raw) {
+    return null;
+  }
+  const rangeMatch = raw.match(/^(\d+)\s*-\s*(\d+)$/);
+  if (rangeMatch) {
+    const min = Number.parseInt(rangeMatch[1], 10);
+    const max = Number.parseInt(rangeMatch[2], 10);
+    if (Number.isFinite(min) && Number.isFinite(max) && min >= 0 && max >= min) {
+      return { min, max };
+    }
+    throw new Error(`Invalid --ms range "${raw}". Use min-max in milliseconds.`);
+  }
+  const fixed = Number.parseInt(raw, 10);
+  if (Number.isFinite(fixed) && fixed >= 0) {
+    return { min: fixed, max: fixed };
+  }
+  throw new Error(`Invalid --ms value "${raw}". Use a number or min-max range.`);
+}
+
+async function currentWaitContext(tabId) {
+  const preview = await readPreview(tabId);
+  return `${preview.title || "(untitled)"} @ ${preview.url} :: ${(preview.preview || "").slice(0, 200)}`;
+}
+
+async function runWait(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const selector = typeof params.selector === "string" && params.selector ? resolveTargetRef(tab.id, params.selector) : null;
+  const text = typeof params.text === "string" && params.text ? params.text : null;
+  const gone = typeof params.gone === "string" && params.gone ? resolveTargetRef(tab.id, params.gone) : null;
+  const stable = typeof params.stable === "string" && params.stable ? resolveTargetRef(tab.id, params.stable) : null;
+  const ms = typeof params.ms === "string" && params.ms ? params.ms : null;
+  const timeoutMs = Number.isFinite(params.timeout) ? Math.max(0, Number(params.timeout)) : 15000;
+
+  if (ms) {
+    const range = parseDelayRange(ms);
+    const delay = range.min === range.max ? range.min : Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
+    await cancellableSleep(delay, context);
+    const preview = await readPreview(tab.id);
+    return {
+      waitedMs: delay,
+      condition: "delay",
+      ...preview,
+    };
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStableValue = "";
+  let stableSince = 0;
+
+  while (Date.now() < deadline) {
+    throwIfCancelled(context, "wait completed");
+    const result = await runInTab(
+      tab.id,
+      (targetSelector, targetText, goneSelector, stableSelector) => {
+        const isVisible = (node) => {
+          if (!(node instanceof Element)) {
+            return false;
+          }
+          const rect = node.getBoundingClientRect();
+          const style = window.getComputedStyle(node);
+          return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+        };
+
+        if (targetSelector) {
+          let node = null;
+          try {
+            node = document.querySelector(targetSelector);
+          } catch {
+            return { ok: false, mode: "selector", value: null };
+          }
+          return { ok: Boolean(node && isVisible(node)), mode: "selector", value: null };
+        }
+
+        if (targetText) {
+          return {
+            ok: (document.body?.innerText || "").includes(targetText),
+            mode: "text",
+            value: null,
+          };
+        }
+
+        if (goneSelector) {
+          let node = null;
+          try {
+            node = document.querySelector(goneSelector);
+          } catch {
+            return { ok: true, mode: "gone", value: null };
+          }
+          return { ok: !node || !isVisible(node), mode: "gone", value: null };
+        }
+
+        if (stableSelector) {
+          let node = null;
+          try {
+            node = document.querySelector(stableSelector);
+          } catch {
+            return { ok: false, mode: "stable", value: "" };
+          }
+          if (!node) {
+            return { ok: false, mode: "stable", value: "" };
+          }
+          const rect = node.getBoundingClientRect();
+          const style = window.getComputedStyle(node);
+          const formState = Array.from(node.matches("input, textarea, select, option, details") ? [node] : [])
+            .concat(Array.from(node.querySelectorAll("input, textarea, select, option, details")))
+            .map((element) => ({
+              value: "value" in element ? element.value : undefined,
+              checked: "checked" in element ? element.checked : undefined,
+              selected: "selected" in element ? element.selected : undefined,
+              open: "open" in element ? element.open : undefined,
+              disabled: "disabled" in element ? element.disabled : undefined,
+            }));
+          const value = JSON.stringify({
+            html: node.outerHTML,
+            text: node.innerText || node.textContent || "",
+            rect: [rect.x, rect.y, rect.width, rect.height],
+            layout: [node.scrollWidth, node.scrollHeight, node.scrollLeft, node.scrollTop],
+            style: [style.display, style.visibility, style.opacity, style.position],
+            formState,
+          });
+          return { ok: true, mode: "stable", value };
+        }
+
+        return { ok: false, mode: "unknown", value: null };
+      },
+      [selector, text, gone, stable],
+    );
+
+    if (result?.mode === "stable") {
+      if (!result.ok) {
+        await cancellableSleep(200, context);
+        continue;
+      }
+      if (result.value === lastStableValue) {
+        if (!stableSince) {
+          stableSince = Date.now();
+        }
+        if (Date.now() - stableSince >= 500) {
+          const preview = await readPreview(tab.id);
+          return {
+            waitedFor: stable,
+            condition: "stable",
+            ...preview,
+          };
+        }
+      } else {
+        lastStableValue = result.value;
+        stableSince = Date.now();
+      }
+    } else if (result?.ok) {
+      const preview = await readPreview(tab.id);
+      return {
+        waitedFor: selector || text || gone,
+        condition: result.mode,
+        ...preview,
+      };
+    }
+
+    await cancellableSleep(200, context);
+  }
+
+  throwIfCancelled(context, "wait completed");
+  const waitContext = await currentWaitContext(tab.id);
+  const waitedFor = selector ? `selector "${selector}"` : text ? `text "${text}"` : gone ? `gone "${gone}"` : `stable "${stable}"`;
+  throw new Error(`Timed out waiting for ${waitedFor}. Current page state: ${waitContext}`);
+}
+
+async function runSnapshot(params) {
+  const depth = Number.isFinite(params.depth) ? Number(params.depth) : -1;
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const scope = typeof params.scope === "string" && params.scope ? resolveTargetRef(tab.id, params.scope) : null;
+  const snapshot = await captureAxTree(tab.id, { scope, depth });
+  getTabState(tab.id).snapshotBaseline = snapshot;
+  const preview = await readPreview(tab.id);
+  return {
+    snapshot: snapshot.snapshot,
+    ...preview,
+  };
+}
+
+async function runDiff(params) {
+  const depth = Number.isFinite(params.depth) ? Number(params.depth) : -1;
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const scope = typeof params.scope === "string" && params.scope ? resolveTargetRef(tab.id, params.scope) : null;
+  const tabState = getTabState(tab.id);
+  const current = await captureAxTree(tab.id, { scope, depth });
+  const previous = tabState.snapshotBaseline;
+  tabState.snapshotBaseline = current;
+  const preview = await readPreview(tab.id);
+
+  if (!previous) {
+    return {
+      diff: current.snapshot,
+      mode: "full",
+      ...preview,
+    };
+  }
+
+  const previousMap = new Map(previous.entries.map((entry) => [entry.key, entry]));
+  const currentMap = new Map(current.entries.map((entry) => [entry.key, entry]));
+  const lines = [];
+
+  for (const [key, nextEntry] of currentMap.entries()) {
+    const prevEntry = previousMap.get(key);
+    if (!prevEntry) {
+      lines.push(`ADDED: ${nextEntry.state}`);
+      continue;
+    }
+    if (prevEntry.state !== nextEntry.state) {
+      lines.push(`CHANGED: ${prevEntry.state} -> ${nextEntry.state}`);
+    }
+  }
+
+  for (const [key, prevEntry] of previousMap.entries()) {
+    if (!currentMap.has(key)) {
+      lines.push(`REMOVED: ${prevEntry.state}`);
+    }
+  }
+
+  return {
+    diff: lines.join("\n") || "No changes since last snapshot.",
+    mode: "diff",
+    ...preview,
+  };
+}
+
+async function runInspect(params) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const scope = typeof params.scope === "string" && params.scope ? resolveTargetRef(tab.id, params.scope) : null;
+  const includeHidden = Boolean(params.all);
+  const includeCoords = Boolean(params.coords);
+  const inspected = await runInTab(
+    tab.id,
+    (scopeSelector, allElements, wantCoords) => {
+      const cssEscape = (value) => (window.CSS && typeof window.CSS.escape === "function" ? window.CSS.escape(value) : value);
+      const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+      const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+      if (!root) {
+        return { error: `No element matches scope selector "${scopeSelector}".`, elements: [] };
+      }
+
+      const isVisible = (node) => {
+        if (!(node instanceof Element)) {
+          return false;
+        }
+        const rect = node.getBoundingClientRect();
+        const style = window.getComputedStyle(node);
+        return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+      };
+
+      const selectorFor = (element) => {
+        if (!(element instanceof Element)) {
+          return null;
+        }
+        if (element.id) {
+          return `#${cssEscape(element.id)}`;
+        }
+        for (const attr of ["data-e2e", "data-testid", "name", "aria-label", "placeholder", "href", "accept"]) {
+          const value = element.getAttribute(attr);
+          if (value && document.querySelectorAll(`${element.tagName.toLowerCase()}[${attr}="${cssEscape(value)}"]`).length === 1) {
+            return `${element.tagName.toLowerCase()}[${attr}="${cssEscape(value)}"]`;
+          }
+        }
+        const parts = [];
+        let current = element;
+        while (current && current instanceof Element && current !== document.body) {
+          let part = current.tagName.toLowerCase();
+          if (current.classList.length > 0) {
+            part += `.${Array.from(current.classList)
+              .slice(0, 2)
+              .map((value) => cssEscape(value))
+              .join(".")}`;
+          }
+          const siblings = current.parentElement
+            ? Array.from(current.parentElement.children).filter((child) => child.tagName === current.tagName)
+            : [];
+          if (siblings.length > 1) {
+            part += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+          }
+          parts.unshift(part);
+          const selector = parts.join(" > ");
+          if (document.querySelectorAll(selector).length === 1) {
+            return selector;
+          }
+          current = current.parentElement;
+        }
+        return parts.join(" > ") || element.tagName.toLowerCase();
+      };
+
+      const candidates = Array.from(
+        root.querySelectorAll(
+          "input, textarea, select, button, [role], [contenteditable], a[href], [onclick], [data-e2e], summary",
+        ),
+      );
+
+      const elements = [];
+      for (const element of candidates) {
+        if (!(element instanceof HTMLElement || element instanceof SVGElement)) {
+          continue;
+        }
+        if (!allElements && !isVisible(element)) {
+          continue;
+        }
+        const tag = element.tagName.toLowerCase();
+        const role = element.getAttribute("role") || (tag === "a" ? "link" : tag === "button" ? "button" : tag);
+        const text = normalize(element.innerText || element.textContent);
+        const label = normalize(
+          element.getAttribute("aria-label") ||
+            element.getAttribute("name") ||
+            element.getAttribute("placeholder") ||
+            (element.labels && element.labels[0] ? element.labels[0].innerText || element.labels[0].textContent : ""),
+        );
+        const rect = typeof element.getBoundingClientRect === "function" ? element.getBoundingClientRect() : null;
+        elements.push({
+          tag,
+          role,
+          type: element instanceof HTMLInputElement ? element.type : undefined,
+          text: text || undefined,
+          label: label || undefined,
+          checked: element instanceof HTMLInputElement && /checkbox|radio/.test(element.type) ? element.checked : undefined,
+          enabled: !(element instanceof HTMLInputElement || element instanceof HTMLButtonElement || element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement)
+            ? element.getAttribute("aria-disabled") !== "true"
+            : !element.disabled,
+          visible: isVisible(element),
+          contenteditable: element instanceof HTMLElement ? element.isContentEditable || undefined : undefined,
+          accept: element instanceof HTMLInputElement && element.type === "file" ? element.accept || undefined : undefined,
+          selector: selectorFor(element),
+          coords:
+            rect && wantCoords
+              ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+              : undefined,
+          charCount: text ? text.length : undefined,
+        });
+      }
+
+      return { elements };
+    },
+    [scope, includeHidden, includeCoords],
+  );
+
+  if (inspected?.error) {
+    throw new Error(inspected.error);
+  }
+
+  clearRefMap(tab.id);
+  const elements = Array.isArray(inspected?.elements) ? inspected.elements : [];
+  const preview = await readPreview(tab.id);
+  const tabState = getTabState(tab.id);
+  const withRefs = elements.map((element) => {
+    const ref = `e${tabState.nextRefId++}`;
+    if (element.selector) {
+      tabState.refMap[ref] = element.selector;
+    }
+    return {
+      ref,
+      ...element,
+    };
+  });
+
+  return {
+    url: preview.url,
+    title: preview.title,
+    elements: withRefs,
+  };
+}
+
+async function runExtract(params) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const selector = typeof params.selector === "string" && params.selector ? resolveTargetRef(tab.id, params.selector) : null;
+  const scope = typeof params.scope === "string" && params.scope ? resolveTargetRef(tab.id, params.scope) : null;
+  const asJson = Boolean(params.json);
+  const rawLimit = Number(params.limit);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 20;
+  const result = await runInTab(
+    tab.id,
+    (targetSelector, scopeSelector, outputJson, itemLimit) => {
+      const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+      const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+      if (!root) {
+        return outputJson ? [] : "";
+      }
+
+      if (!targetSelector) {
+        if (outputJson) {
+          return Array.from(root.querySelectorAll("a[href]"))
+            .map((anchor) => ({
+              text: normalize(anchor.innerText || anchor.textContent),
+              href: anchor.href || null,
+            }))
+            .filter((item) => item.text)
+            .slice(0, itemLimit);
+        }
+
+        return ((root === document ? document.body?.innerText : root.innerText) || "")
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .slice(0, itemLimit)
+          .join("\n");
+      }
+
+      let nodes = [];
+      try {
+        nodes = Array.from(root.querySelectorAll(targetSelector));
+      } catch {
+        return { error: `Invalid selector "${targetSelector}".` };
+      }
+
+      if (nodes.length === 0) {
+        const alternatives = Array.from(root.querySelectorAll("[id], [class], [role], main, form, section, article"))
+          .slice(0, 8)
+          .map((node) => {
+            const tag = node.tagName.toLowerCase();
+            if (node.id) {
+              return `${tag}#${node.id}`;
+            }
+            if (node.classList.length > 0) {
+              return `${tag}.${Array.from(node.classList).slice(0, 2).join(".")}`;
+            }
+            const role = node.getAttribute("role");
+            if (role) {
+              return `${tag}[role="${role}"]`;
+            }
+            return tag;
+          });
+        return {
+          error: `No elements match selector "${targetSelector}". Nearby selectors: ${alternatives.join(", ") || "(none found)"}`,
+        };
+      }
+
+      if (outputJson) {
+        return nodes
+          .map((node) => {
+            const anchor = node instanceof HTMLAnchorElement ? node : node.querySelector("a[href]");
+            return {
+              text: normalize(node.innerText || node.textContent),
+              href: anchor?.href || null,
+            };
+          })
+          .filter((item) => item.text)
+          .slice(0, itemLimit);
+      }
+
+      return nodes
+        .map((node) => normalize(node.innerText || node.textContent))
+        .filter(Boolean)
+        .slice(0, itemLimit)
+        .join("\n");
+    },
+    [selector, scope, asJson, limit],
+  );
+  if (result?.error) {
+    throw new Error(result.error);
+  }
+  return result;
+}
+
+async function runHtml(params) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: true });
+  const selector = typeof params.selector === "string" && params.selector ? resolveTargetRef(tab.id, params.selector) : null;
+  const rawLimit = Number(params.limit);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 120;
+
+  return runInTab(
+    tab.id,
+    (targetSelector, lineLimit) => {
+      const root = targetSelector ? document.querySelector(targetSelector) : document.documentElement;
+      if (!root) {
+        return "";
+      }
+
+      const clone = root.cloneNode(true);
+      if (!(clone instanceof Element)) {
+        return "";
+      }
+
+      for (const node of clone.querySelectorAll("script, style, noscript")) {
+        node.remove();
+      }
+
+      return clone.outerHTML
+        .replace(/>\s+</g, ">\n<")
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .slice(0, lineLimit)
+        .join("\n");
+    },
+    [selector, limit],
+  );
+}
+
+async function evaluateViaDebugger(tabId, expression) {
+  return withDebugger(tabId, async (target) => {
+    const frameTree = await chrome.debugger.sendCommand(target, "Page.getFrameTree");
+    const frameId = frameTree?.frameTree?.frame?.id;
+    if (!frameId) {
+      throw new Error("Unable to resolve frame id for evaluation.");
+    }
+
+    const isolatedWorld = await chrome.debugger.sendCommand(target, "Page.createIsolatedWorld", {
+      frameId,
+      worldName: "browserCliV2Eval",
+      grantUniveralAccess: true,
+    });
+    const contextId = isolatedWorld?.executionContextId;
+    if (!contextId) {
+      throw new Error("Unable to create isolated world for evaluation.");
+    }
+
+    const evaluation = await chrome.debugger.sendCommand(target, "Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+      userGesture: true,
+      allowUnsafeEvalBlockedByCSP: true,
+      contextId,
+    });
+
+    if (evaluation?.exceptionDetails) {
+      const message =
+        evaluation.exceptionDetails.text ||
+        evaluation.result?.description ||
+        evaluation.result?.value ||
+        "Evaluation failed.";
+      throw new Error(String(message));
+    }
+
+    const result = evaluation?.result;
+    if (!result) {
+      return null;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(result, "value")) {
+      return result.value;
+    }
+
+    if (typeof result.unserializableValue === "string") {
+      return result.unserializableValue;
+    }
+
+    return result.description ?? null;
+  });
+}
+
+async function runEval(params) {
+  const expression = String(params.expression || "").trim();
+  if (!expression) {
+    throw new Error("Missing required argument <js>.");
+  }
+
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: false });
+  return evaluateViaDebugger(tab.id, expression);
+}
+
+async function runDialog(params, context = {}) {
+  const accept = params.accept;
+  const dismiss = Boolean(params.dismiss);
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: false });
+  const tabState = getTabState(tab.id);
+
+  if (accept || dismiss) {
+    if (!tabState.dialog?.open) {
+      throw new Error("No browser dialog is currently recorded as open.");
+    }
+
+    const target = { tabId: tab.id };
+    throwIfCancelled(context, "dialog handling");
+    await debuggerPool.forceDetach(tab.id).catch(() => undefined);
+    try {
+      await chrome.debugger.attach(target, "1.3");
+      throwIfCancelled(context, "dialog handling");
+      await chrome.debugger.sendCommand(target, "Page.handleJavaScriptDialog", {
+        accept: Boolean(accept) && !dismiss,
+        promptText: typeof accept === "string" ? accept : "",
+      });
+    } catch (error) {
+      throw new Error(`Failed to handle browser dialog: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      try {
+        await chrome.debugger.detach(target);
+      } catch {
+        // Ignore detach failures after dialog handling.
+      }
+    }
+    const handled = tabState.dialog;
+    tabState.dialog = null;
+    return {
+      handled: dismiss ? "dismissed" : "accepted",
+      type: handled?.type || "dialog",
+      message: handled?.message || "",
+      url: tab.url || "about:blank",
+      title: tab.title || "",
+    };
+  }
+
+  return {
+    open: Boolean(tabState.dialog?.open),
+    ...(tabState.dialog || {}),
+    url: tab.url || "about:blank",
+    title: tab.title || "",
+  };
+}
+
+async function runTabs() {
+  await loadState();
+  const entries = await Promise.all(
+    Array.from(managedTabs.keys()).map(async (tabId) => {
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        await updateManagedTab(tab);
+        const entry = getManagedTabEntry(tabId);
+        return entry
+          ? {
+              alias: entry.alias,
+              tabId: entry.tabId,
+              url: tab.url || entry.url,
+              title: tab.title || entry.title,
+              active: tab.id === activeTabId,
+            }
+          : null;
+      } catch {
+        await removeManagedTab(tabId);
+        return null;
+      }
+    }),
+  );
+
+  return entries.filter(Boolean);
+}
+
+async function runFocus(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: false });
+  throwIfCancelled(context, "window focus");
+  await chrome.windows.update(tab.windowId, { focused: true }).catch(() => undefined);
+  throwIfCancelled(context, "tab focus");
+  await chrome.tabs.update(tab.id, { active: true }).catch(() => undefined);
+  const updatedTab = await chrome.tabs.get(tab.id);
+  await addManagedTab(updatedTab);
+  return {
+    alias: getManagedTabEntry(updatedTab.id)?.alias || null,
+    tabId: updatedTab.id,
+    url: updatedTab.url || "about:blank",
+    title: updatedTab.title || "",
+    active: true,
+  };
+}
+
+async function runClose(params, context = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: false });
+  const entry = getManagedTabEntry(tab.id);
+  const closed = {
+    alias: entry?.alias || null,
+    tabId: tab.id,
+    url: tab.url || "about:blank",
+    title: tab.title || "",
+  };
+
+  if (context.shouldContinue && !context.shouldContinue()) {
+    throw new Error("Command cancelled before tab removal.");
+  }
+
+  beginStateMutationBatch();
+  try {
+    await chrome.tabs.remove(tab.id);
+    await removeManagedTab(tab.id);
+  } finally {
+    await endStateMutationBatch();
+  }
+  return closed;
+}
+
+async function runCloseIdle(params, context = {}) {
+  beginStateMutationBatch();
+  try {
+    const result = await closeIdleTabs({
+      chromeApi: chrome,
+      hours: params.hours,
+      dryRun: Boolean(params.dryRun),
+      shouldContinue: context.shouldContinue,
+    });
+    await removeManagedTabs(result.closed.map((tab) => tab.id));
+    return result;
+  } finally {
+    await endStateMutationBatch();
+  }
+}
+
+async function runStatus(params = {}) {
+  await loadState();
+
+  const hasExplicitTab =
+    params.tabId != null && !(typeof params.tabId === "string" && !params.tabId.trim()) ||
+    params.alias != null && !(typeof params.alias === "string" && !params.alias.trim());
+  const requestedTabId = hasExplicitTab ? await resolveTabParam(params) : activeTabId;
+  let managedTab = null;
+  let activeManagedTab = null;
+  const resolvedActiveTabId = activeTabId;
+
+  if (requestedTabId != null) {
+    const lookup = getManagedTab({ tabId: requestedTabId, allowFallback: false, requireScriptable: false });
+    managedTab = hasExplicitTab ? await lookup : await lookup.catch(() => null);
+  }
+
+  if (resolvedActiveTabId != null) {
+    activeManagedTab = await getManagedTab({ tabId: resolvedActiveTabId, allowFallback: false, requireScriptable: false }).catch(() => null);
+  }
+
+  const activeTab = await getActiveTab().catch(() => null);
+  const tab = hasExplicitTab ? managedTab : managedTab || activeManagedTab || activeTab;
+  const managedEntry = tab?.id != null ? getManagedTabEntry(tab.id) : null;
+  const activeEntry = activeManagedTab?.id != null ? getManagedTabEntry(activeManagedTab.id) : null;
+
+  return {
+    url: tab?.url || "about:blank",
+    title: tab?.title || "",
+    tabId: tab?.id ?? null,
+    managedTabId: managedTab?.id ?? activeManagedTab?.id ?? null,
+    managedWindowId: managedTab?.windowId ?? activeManagedTab?.windowId ?? null,
+    activeTabId: activeTab?.id ?? null,
+    activeManagedTabId: activeManagedTab?.id ?? null,
+    managedAlias: managedEntry?.alias ?? null,
+    activeManagedAlias: activeEntry?.alias ?? null,
+    managedTabs: listManagedTabs(),
+    usingManagedTab: Boolean(managedTab || activeManagedTab),
+  };
+}
+
+async function captureFullPage(tabId) {
+  return withDebugger(tabId, async (target) => {
+    const metrics = await chrome.debugger.sendCommand(target, "Page.getLayoutMetrics");
+    const contentSize = metrics?.cssContentSize || metrics?.contentSize;
+
+    let width = Math.ceil(Number(contentSize?.width || 0));
+    let height = Math.ceil(Number(contentSize?.height || 0));
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      throw new Error("Unable to determine page dimensions for full-page screenshot.");
+    }
+
+    width = Math.max(1, Math.min(width, MAX_FULL_PAGE_DIMENSION));
+    height = Math.max(1, Math.min(height, MAX_FULL_PAGE_DIMENSION));
+
+    const captured = await chrome.debugger.sendCommand(target, "Page.captureScreenshot", {
+      format: "png",
+      fromSurface: true,
+      captureBeyondViewport: true,
+      clip: {
+        x: 0,
+        y: 0,
+        width,
+        height,
+        scale: 1,
+      },
+    });
+
+    if (!captured?.data) {
+      throw new Error("Full-page screenshot returned no image data.");
+    }
+
+    return {
+      dataUrl: `data:image/png;base64,${captured.data}`,
+      mode: "full-page",
+    };
+  });
+}
+
+async function captureViewportViaDebugger(tabId, format = "png", quality = 80) {
+  return withDebugger(tabId, async (target) => {
+    const normalizedFormat = format === "jpeg" ? "jpeg" : "png";
+    const captured = await chrome.debugger.sendCommand(target, "Page.captureScreenshot", {
+      format: normalizedFormat,
+      fromSurface: true,
+      ...(normalizedFormat === "jpeg" ? { quality } : {}),
+    });
+    if (!captured?.data) {
+      throw new Error("Viewport screenshot returned no image data.");
+    }
+    return `data:image/${normalizedFormat};base64,${captured.data}`;
+  });
+}
+
+async function dataUrlToBlob(dataUrl) {
+  const match = /^data:([^;,]+)?(?:;charset=[^;,]+)?(;base64)?,(.*)$/s.exec(dataUrl);
+  if (!match) {
+    throw new Error("Invalid data URL.");
+  }
+
+  const mimeType = match[1] || "application/octet-stream";
+  const isBase64 = Boolean(match[2]);
+  const payload = match[3] || "";
+  const bytesString = isBase64 ? atob(payload) : decodeURIComponent(payload);
+  const bytes = new Uint8Array(bytesString.length);
+
+  for (let index = 0; index < bytesString.length; index += 1) {
+    bytes[index] = bytesString.charCodeAt(index);
+  }
+
+  return new Blob([bytes], { type: mimeType });
+}
+
+async function blobToDataUrl(blob) {
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+
+  return `data:${blob.type || "application/octet-stream"};base64,${btoa(binary)}`;
+}
+
+async function resizeCapturedImage(dataUrl, maxWidth, format, quality) {
+  const targetWidth = Number.isFinite(maxWidth) ? Math.max(1, Math.floor(maxWidth)) : 0;
+  if (!targetWidth) {
+    return dataUrl;
+  }
+
+  const blob = await dataUrlToBlob(dataUrl);
+  const bitmap = await createImageBitmap(blob);
+
+  try {
+    if (bitmap.width <= targetWidth) {
+      return dataUrl;
+    }
+
+    const scale = targetWidth / bitmap.width;
+    const width = targetWidth;
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Failed to create offscreen canvas context.");
+    }
+
+    context.drawImage(bitmap, 0, 0, width, height);
+
+    const normalizedFormat = format === "png" ? "image/png" : "image/jpeg";
+    const blobQuality = Math.max(0, Math.min(1, (Number.isFinite(quality) ? quality : 80) / 100));
+    const resized = await canvas.convertToBlob({
+      type: normalizedFormat,
+      quality: blobQuality,
+    });
+
+    return blobToDataUrl(resized);
+  } finally {
+    bitmap.close();
+  }
+}
+
+async function runScreenshot(params = {}) {
+  const tabId = await resolveTabParam(params);
+  const tab = await getManagedTab({ tabId, allowFallback: false, requireScriptable: false });
+  const url = tab.url || "about:blank";
+  const title = tab.title || "";
+  const useCompressedCapture = params.maxWidth != null || params.format != null;
+
+  if (useCompressedCapture) {
+    const quality = Number.isFinite(params.quality) ? Math.max(0, Math.min(100, Number(params.quality))) : 80;
+    const format = params.format === "png" ? "png" : "jpeg";
+    const captured = await captureTargetViaCdp({
+      tabId: tab.id,
+      fullPage: false,
+      format,
+      quality,
+      captureFullPage,
+      captureViewport: captureViewportViaDebugger,
+    });
+    const dataUrl = await resizeCapturedImage(captured.dataUrl, params.maxWidth, format, quality);
+
+    return {
+      dataUrl,
+      mode: params.maxWidth != null ? "viewport-resized" : captured.mode,
+      tabId: tab.id,
+      url,
+      title,
+    };
+  }
+
+  const captured = await captureTargetViaCdp({
+    tabId: tab.id,
+    fullPage: true,
+    captureFullPage,
+    captureViewport: captureViewportViaDebugger,
+  });
+  return {
+    ...captured,
+    tabId: tab.id,
+    url,
+    title,
+  };
+}
+
+async function dispatchAction(action, params, context = {}) {
+  switch (action) {
+    case "open":
+      return runOpen(params, context);
+    case "tabs":
+      return runTabs();
+    case "focus":
+      return runFocus(params, context);
+    case "close":
+      return runClose(params, context);
+    case "close-idle":
+      return runCloseIdle(params, context);
+    case "click":
+      return runClick(params, context);
+    case "type":
+      return runType(params, context);
+    case "fill":
+      return runFill(params, context);
+    case "upload":
+      return runUpload(params, context);
+    case "wait":
+      return runWait(params, context);
+    case "snapshot":
+      return runSnapshot(params);
+    case "diff":
+      return runDiff(params);
+    case "inspect":
+      return runInspect(params);
+    case "extract":
+      return runExtract(params);
+    case "screenshot":
+      return runScreenshot(params);
+    case "html":
+      return runHtml(params);
+    case "eval":
+      return runEval(params);
+    case "dialog":
+      return runDialog(params, context);
+    case "status":
+      return runStatus(params);
+    default:
+      throw new Error(`Unknown action "${action}".`);
+  }
+}
+
+function handleBridgeMessage(sourceSocket, rawData) {
+  let payload;
+  try {
+    payload = JSON.parse(String(rawData));
+  } catch {
+    return;
+  }
+
+  const id = typeof payload?.id === "string" ? payload.id : "";
+  if (!id) {
+    return;
+  }
+
+  const cancelledRequests = cancelledRequestsBySocket.get(sourceSocket) ?? new Set();
+  cancelledRequestsBySocket.set(sourceSocket, cancelledRequests);
+  if (payload?.type === "cancel") {
+    // Cancellation is recorded synchronously instead of waiting behind the
+    // command queue. Queued destructive requests therefore expire safely.
+    cancelledRequests.add(id);
+    return;
+  }
+
+  void requestQueue.enqueue(() => handleRequest(payload, sourceSocket));
+}
+
+async function handleRequest(payload, responseSocket) {
+  const id = typeof payload?.id === "string" ? payload.id : "";
+  const action = typeof payload?.action === "string" ? payload.action : "";
+  const params = payload?.params && typeof payload.params === "object" ? payload.params : {};
+  const deadline = Number.isFinite(payload?.deadline) ? payload.deadline : Number.POSITIVE_INFINITY;
+  const cancelledRequests = cancelledRequestsBySocket.get(responseSocket) ?? new Set();
+  cancelledRequestsBySocket.set(responseSocket, cancelledRequests);
+  const shouldContinue = () =>
+    !cancelledRequests.has(id) && responseSocket.readyState === WebSocket.OPEN && Date.now() <= deadline;
+
+  if (!id || !action || !shouldContinue()) {
+    cancelledRequests.delete(id);
+    return;
+  }
+
+  try {
+    const data = await dispatchAction(action, params, { shouldContinue });
+    if (shouldContinue()) {
+      sendTo(responseSocket, { id, ok: true, data });
+    }
+  } catch (error) {
+    if (!shouldContinue()) {
+      return;
+    }
+    const baseError = error instanceof Error ? error.message : String(error);
+    const targetTabId = await resolveTabParam(params).catch(() => null);
+    const dialog = targetTabId != null ? getTabState(targetTabId).dialog : null;
+    const dialogSuffix =
+      action !== "dialog" && dialog?.open
+        ? ` Dialog open: [${dialog.type}] "${dialog.message}". Use browser dialog --accept or --dismiss.`
+        : "";
+    sendTo(responseSocket, {
+      id,
+      ok: false,
+      error: `${baseError}${dialogSuffix}`,
+    });
+  } finally {
+    cancelledRequests.delete(id);
+  }
+}
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void removeManagedTab(tabId);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  void (async () => {
+    await loadState();
+    if (!managedTabs.has(tabId)) {
+      return;
+    }
+    const mergedTab = {
+      ...tab,
+      id: tabId,
+      windowId: Number.isInteger(tab.windowId) ? tab.windowId : getManagedTabEntry(tabId)?.windowId ?? null,
+      url: typeof changeInfo.url === "string" ? changeInfo.url : tab.url,
+      title: typeof tab.title === "string" ? tab.title : getManagedTabEntry(tabId)?.title ?? "",
+    };
+    await updateManagedTab(mergedTab);
+  })();
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === BRIDGE_RECONNECT_ALARM) {
+    connectBridge();
+  }
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  void loadState();
+  ensureReconnectAlarm();
+  connectBridge();
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  void loadState();
+  ensureReconnectAlarm();
+  connectBridge();
+});
+
+chrome.action.onClicked.addListener(() => {
+  connectBridge();
+});
+
+void loadState().finally(() => {
+  ensureReconnectAlarm();
+  connectBridge();
+});

--- a/src/browser/package-lock.json
+++ b/src/browser/package-lock.json
@@ -1,0 +1,607 @@
+{
+  "name": "browser-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "browser-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "browser": "bin/browser"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "@types/ws": "^8.5.14",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/src/browser/package.json
+++ b/src/browser/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "browser-cli",
+  "version": "0.1.0",
+  "description": "Browser CLI that controls Chrome through a local extension bridge",
+  "type": "module",
+  "bin": {
+    "browser": "./bin/browser"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "extension",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepare": "npm run build",
+    "prepack": "npm run build",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
+    "check:extension": "node --check extension/service-worker.js && node --check extension/browser-boundaries.js && node --check extension/close-idle.js && node --check extension/runtime-state.js",
+    "check": "npm run typecheck && npm run check:extension",
+    "test": "node --import tsx --test test/*.test.ts test/*.test.js",
+    "smoke": "node --import tsx --test test/smoke.test.ts",
+    "dev": "tsx src/client.ts",
+    "start:server": "tsx src/server.ts",
+    "prepublishOnly": "npm run check && npm test && npm run build"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "@types/ws": "^8.5.14",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/src/browser/src/client.ts
+++ b/src/browser/src/client.ts
@@ -1,0 +1,211 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { formatError, formatMetadata, formatSuccess } from "./lib/format.js";
+import { parseCliInput } from "./lib/parse.js";
+import { FALLBACK_PORT, SOCKET_PATH } from "./lib/types.js";
+import type { CommandRequest, CommandResponse } from "./lib/types.js";
+
+const HEALTH_REQUEST_TIMEOUT_MS = 2_000;
+const COMMAND_REQUEST_TIMEOUT_MS = 150_000;
+
+function requestTimeoutForPath(requestPath: string, body?: unknown): number {
+  if (requestPath === "/health") return HEALTH_REQUEST_TIMEOUT_MS;
+  if (
+    typeof body === "object" && body !== null &&
+    (body as { command?: unknown }).command === "wait"
+  ) {
+    const options = (body as { options?: Record<string, unknown> }).options ?? {};
+    const timeout = typeof options.timeout === "number" ? options.timeout : 15_000;
+    const ms = typeof options.ms === "string"
+      ? Number(options.ms.includes("-") ? options.ms.split("-")[1] : options.ms)
+      : 0;
+    const requested = Math.max(timeout, Number.isFinite(ms) ? ms : 0) + 15_000;
+    return Math.min(2_147_000_000, Math.max(COMMAND_REQUEST_TIMEOUT_MS, requested));
+  }
+  return COMMAND_REQUEST_TIMEOUT_MS;
+}
+
+function canTryFallback(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === "ENOENT" || code === "ECONNREFUSED" || code === "EACCES" || code === "ENOTSOCK";
+}
+
+function outputAndExit(ok: boolean, text: string, code = ok ? 0 : 1): never {
+  const body = `${text}\n${formatMetadata(ok, "unavailable", 0)}`;
+  process.stdout.write(`${body}\n`);
+  process.exit(code);
+}
+
+function sendRequestViaSocket<T>(method: string, requestPath: string, body?: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        method,
+        socketPath: SOCKET_PATH,
+        path: requestPath,
+        headers: body ? { "content-type": "application/json" } : undefined,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+        response.on("end", () => {
+          const payload = Buffer.concat(chunks).toString("utf8");
+          try {
+            resolve(JSON.parse(payload) as T);
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+
+    request.setTimeout(requestTimeoutForPath(requestPath, body), () => {
+      request.destroy(new Error(`Browser server request timed out (${requestPath}).`));
+    });
+    request.on("error", reject);
+    if (body) {
+      request.write(JSON.stringify(body));
+    }
+    request.end();
+  });
+}
+
+function sendRequestViaPort<T>(method: string, requestPath: string, body?: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        method,
+        host: "127.0.0.1",
+        port: FALLBACK_PORT,
+        path: requestPath,
+        headers: body ? { "content-type": "application/json" } : undefined,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+        response.on("end", () => {
+          const payload = Buffer.concat(chunks).toString("utf8");
+          try {
+            resolve(JSON.parse(payload) as T);
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+
+    request.setTimeout(requestTimeoutForPath(requestPath, body), () => {
+      request.destroy(new Error(`Browser server request timed out (${requestPath}).`));
+    });
+    request.on("error", reject);
+    if (body) {
+      request.write(JSON.stringify(body));
+    }
+    request.end();
+  });
+}
+
+async function sendRequest<T>(method: string, requestPath: string, body?: unknown): Promise<T> {
+  try {
+    return await sendRequestViaSocket<T>(method, requestPath, body);
+  } catch (error) {
+    if (!canTryFallback(error)) throw error;
+    return sendRequestViaPort<T>(method, requestPath, body);
+  }
+}
+
+function spawnServer() {
+  const modulePath = fileURLToPath(import.meta.url);
+  const moduleDir = path.dirname(modulePath);
+  const packageRoot = path.resolve(moduleDir, "..");
+  const distServer = path.resolve(packageRoot, "dist/server.js");
+  const srcServer = path.resolve(packageRoot, "src/server.ts");
+
+  if (modulePath.includes(`${path.sep}dist${path.sep}`)) {
+    const child = spawn(process.execPath, [distServer], {
+      cwd: packageRoot,
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    return;
+  }
+
+  const child = spawn("npx", ["tsx", srcServer], {
+    cwd: packageRoot,
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}
+
+async function serverIsReady(): Promise<boolean> {
+  const health = await sendRequest<{ ok?: unknown }>("GET", "/health");
+  return health.ok === true;
+}
+
+async function ensureServer() {
+  try {
+    if (await serverIsReady()) return;
+  } catch {
+    spawnServer();
+  }
+
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      if (await serverIsReady()) return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  }
+
+  outputAndExit(
+    false,
+    "[error] Server did not start within 10s. Try: npm run build (in src/browser) and then browser open <url>",
+  );
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<never> {
+  const parsed = parseCliInput(argv);
+  if (parsed.localOutput) {
+    outputAndExit(parsed.localOutput.ok, parsed.localOutput.text, parsed.localOutput.ok ? 0 : 1);
+  }
+
+  if (!parsed.command) {
+    outputAndExit(false, "[error] No command provided. Try: browser help");
+  }
+
+  const request: CommandRequest = {
+    command: parsed.command,
+    args: parsed.args,
+    options: parsed.options,
+  };
+
+  try {
+    if (parsed.allowAutoStart) {
+      await ensureServer();
+    }
+
+    const response = await sendRequest<CommandResponse>("POST", "/command", request);
+    const text = response.ok
+      ? formatSuccess(parsed.command, response.data, response.url, response.elapsed)
+      : formatError(response.error ?? "Unknown error", response.url, response.elapsed);
+    process.stdout.write(`${text}\n`);
+    process.exit(response.ok ? 0 : 1);
+  } catch {
+    const help =
+      parsed.command === "stop"
+        ? "Server not running. It will auto-start on next command, or run: browser open <url>"
+        : "Unable to reach browser server. It will auto-start on next command, or run: browser open <url>";
+    process.stdout.write(`${formatError(help, "unavailable", 0)}\n`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}

--- a/src/browser/src/lib/bridge.ts
+++ b/src/browser/src/lib/bridge.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
+import { BRIDGE_WS_PORT, DEFAULT_TIMEOUT_MS, FriendlyError } from "./types.js";
+import type { BridgeAction, BridgeCancelRequest, BridgeHelloMessage, BridgeRequest, BridgeResponse } from "./types.js";
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: NodeJS.Timeout;
+  cleanupAbort: () => void;
+}
+
+export interface ExtensionBridgeOptions {
+  host?: string;
+  port?: number;
+  handshakeTimeoutMs?: number;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isHelloMessage(value: unknown): value is BridgeHelloMessage {
+  return isObject(value) && value.type === "hello" && value.source === "browser-cli-v2-extension";
+}
+
+function isBridgeResponse(value: unknown): value is BridgeResponse {
+  return isObject(value) && typeof value.id === "string" && typeof value.ok === "boolean";
+}
+
+function parseMessage(payload: RawData): unknown {
+  try {
+    return JSON.parse(payload.toString()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export class ExtensionBridge {
+  private readonly wss: WebSocketServer;
+  private readonly readyPromise: Promise<void>;
+  private readonly handshakeTimeoutMs: number;
+  private readonly candidates = new Map<WebSocket, NodeJS.Timeout>();
+  private extensionSocket: WebSocket | null = null;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly requestPrefix = randomUUID();
+  private requestCounter = 0;
+  private lastSeenAt: number | null = null;
+
+  constructor(options: ExtensionBridgeOptions = {}) {
+    this.handshakeTimeoutMs = options.handshakeTimeoutMs ?? 3_000;
+    this.wss = new WebSocketServer({
+      host: options.host ?? "127.0.0.1",
+      port: options.port ?? BRIDGE_WS_PORT,
+      verifyClient: ({ origin }, done) => {
+        // A browser page must not be able to impersonate the unpacked extension.
+        // Chrome extension service workers send their chrome-extension:// origin.
+        done(typeof origin === "string" && origin.startsWith("chrome-extension://"), 403, "Extension origin required");
+      },
+    });
+
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.wss.once("listening", resolve);
+      this.wss.once("error", reject);
+    });
+    // Keep later server errors from becoming uncaught EventEmitter errors.
+    this.wss.on("error", () => undefined);
+    this.wss.on("connection", (socket) => this.attachCandidate(socket));
+  }
+
+  ready(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  isConnected(): boolean {
+    return this.extensionSocket?.readyState === WebSocket.OPEN;
+  }
+
+  getStatus() {
+    return { connected: this.isConnected(), lastSeenAt: this.lastSeenAt };
+  }
+
+  private attachCandidate(socket: WebSocket) {
+    const timer = setTimeout(() => {
+      this.candidates.delete(socket);
+      socket.close(1008, "Extension hello timed out");
+    }, this.handshakeTimeoutMs);
+    this.candidates.set(socket, timer);
+
+    socket.on("message", (message) => {
+      const parsed = parseMessage(message);
+      if (socket !== this.extensionSocket) {
+        if (isHelloMessage(parsed)) {
+          this.promoteCandidate(socket);
+        } else {
+          clearTimeout(timer);
+          this.candidates.delete(socket);
+          socket.close(1008, "Valid extension hello required");
+        }
+        return;
+      }
+      this.onAuthenticatedMessage(parsed);
+    });
+
+    socket.on("close", () => {
+      const candidateTimer = this.candidates.get(socket);
+      if (candidateTimer) clearTimeout(candidateTimer);
+      this.candidates.delete(socket);
+      if (this.extensionSocket === socket) {
+        this.extensionSocket = null;
+        this.rejectAllPending("Chrome extension bridge disconnected during command execution.");
+      }
+    });
+    socket.on("error", () => undefined);
+  }
+
+  private promoteCandidate(socket: WebSocket) {
+    const timer = this.candidates.get(socket);
+    if (timer) clearTimeout(timer);
+    this.candidates.delete(socket);
+
+    const previous = this.extensionSocket;
+    if (previous && previous !== socket && previous.readyState === WebSocket.OPEN) {
+      this.rejectAllPending("Chrome extension bridge reconnected during command execution. Retry the command.");
+      previous.close(1012, "Replaced by an authenticated extension connection");
+    }
+    this.extensionSocket = socket;
+    this.lastSeenAt = Date.now();
+  }
+
+  private onAuthenticatedMessage(parsed: unknown) {
+    this.lastSeenAt = Date.now();
+    if (isObject(parsed) && parsed.type === "keepalive") {
+      return;
+    }
+    if (!isBridgeResponse(parsed)) return;
+
+    const pending = this.pending.get(parsed.id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    pending.cleanupAbort();
+    this.pending.delete(parsed.id);
+    if (parsed.ok) pending.resolve(parsed.data);
+    else pending.reject(new FriendlyError(parsed.error ?? "Extension command failed."));
+  }
+
+  async call(
+    action: BridgeAction,
+    params: Record<string, unknown>,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    if (signal?.aborted) {
+      throw new FriendlyError(`Command cancelled before extension request (${action}).`);
+    }
+    if (!this.extensionSocket || this.extensionSocket.readyState !== WebSocket.OPEN) {
+      throw new FriendlyError(
+        "Chrome extension bridge is not connected. Load the extension from src/browser/extension and keep a Chrome tab open.",
+      );
+    }
+
+    const id = `${this.requestPrefix}:${this.requestCounter++}`;
+    const socket = this.extensionSocket;
+    const request: BridgeRequest = { id, action, params, deadline: Date.now() + timeoutMs };
+
+    return new Promise((resolve, reject) => {
+      const sendCancellation = () => {
+        if (socket.readyState === WebSocket.OPEN) {
+          const cancellation: BridgeCancelRequest = { type: "cancel", id };
+          try {
+            socket.send(JSON.stringify(cancellation), () => undefined);
+          } catch {
+            // The socket raced closed; disconnect is also treated as cancellation.
+          }
+        }
+      };
+      const onAbort = () => {
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        pending.cleanupAbort();
+        this.pending.delete(id);
+        sendCancellation();
+        reject(new FriendlyError(`Command cancelled while waiting for extension response (${action}).`));
+      };
+      const cleanupAbort = () => signal?.removeEventListener("abort", onAbort);
+      const timer = setTimeout(() => {
+        cleanupAbort();
+        this.pending.delete(id);
+        sendCancellation();
+        reject(new FriendlyError(`Timed out waiting for extension response (${action}).`));
+      }, timeoutMs);
+
+      this.pending.set(id, { resolve, reject, timer, cleanupAbort });
+      signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        socket.send(JSON.stringify(request));
+      } catch {
+        clearTimeout(timer);
+        cleanupAbort();
+        this.pending.delete(id);
+        reject(new FriendlyError("Failed to send command to Chrome extension bridge."));
+      }
+    });
+  }
+
+  private rejectAllPending(message: string) {
+    for (const [id, pending] of this.pending.entries()) {
+      clearTimeout(pending.timer);
+      pending.cleanupAbort();
+      pending.reject(new FriendlyError(message));
+      this.pending.delete(id);
+    }
+  }
+
+  async close(): Promise<void> {
+    this.rejectAllPending("Browser bridge server is shutting down.");
+    for (const [candidate, timer] of this.candidates) {
+      clearTimeout(timer);
+      candidate.close(1001, "Server shutting down");
+    }
+    this.candidates.clear();
+    if (this.extensionSocket?.readyState === WebSocket.OPEN) {
+      this.extensionSocket.close(1001, "Server shutting down");
+    }
+    this.extensionSocket = null;
+
+    await new Promise<void>((resolve) => {
+      try {
+        this.wss.close(() => resolve());
+      } catch {
+        resolve();
+      }
+    });
+  }
+}

--- a/src/browser/src/lib/format.ts
+++ b/src/browser/src/lib/format.ts
@@ -1,0 +1,307 @@
+import { OUTPUT_LINE_LIMIT } from "./types.js";
+import type { CommandName } from "./types.js";
+
+function truncateLines(text: string, maxLines = OUTPUT_LINE_LIMIT): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) {
+    return text;
+  }
+
+  const preview = lines.slice(0, maxLines).join("\n");
+  return `${preview}\n[truncated: showing ${maxLines}/${lines.length} lines. Use command-specific --limit or --scope options when available]`;
+}
+
+function stringifyData(data: unknown): string {
+  if (data == null) {
+    return "";
+  }
+  if (typeof data === "string") {
+    return data;
+  }
+  return JSON.stringify(data, null, 2);
+}
+
+function formatUptime(uptimeMs: number): string {
+  if (uptimeMs < 1_000) {
+    return `${uptimeMs}ms`;
+  }
+  if (uptimeMs < 60_000) {
+    return `${(uptimeMs / 1_000).toFixed(1)}s`;
+  }
+  return `${(uptimeMs / 60_000).toFixed(1)}m`;
+}
+
+function renderStateChanges(data: Record<string, unknown>): string {
+  const changes = data.stateChanges;
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return "";
+  }
+  return `State changes:\n${changes.map((c) => `  ${String(c)}`).join("\n")}`;
+}
+
+function renderTabsTable(data: unknown): string {
+  if (!Array.isArray(data) || data.length === 0) {
+    return "No managed tabs.";
+  }
+
+  return data
+    .map((item) => {
+      const record = item as { alias?: unknown; url?: unknown; title?: unknown; active?: unknown };
+      const marker = record.active ? "*" : " ";
+      const alias = String(record.alias ?? "?").padEnd(3);
+      const url = String(record.url ?? "about:blank").padEnd(32);
+      return `${marker} ${alias} ${url} "${String(record.title ?? "")}"`;
+    })
+    .join("\n");
+}
+
+function renderCommandData(command: CommandName, data: unknown): string {
+  if (command === "open" && typeof data === "object" && data !== null) {
+    const record = data as { title?: unknown; preview?: unknown };
+    return `Title: ${String(record.title ?? "(untitled)")}\nPreview: ${String(record.preview ?? "[blank]")}`;
+  }
+
+  if (command === "tabs") {
+    return renderTabsTable(data);
+  }
+
+  if ((command === "focus" || command === "close") && typeof data === "object" && data !== null) {
+    const record = data as { alias?: unknown; tabId?: unknown; url?: unknown; title?: unknown; active?: unknown };
+    const lines = [
+      `${command === "focus" ? "Focused" : "Closed"}: ${String(record.alias ?? record.tabId ?? "")}`,
+      `Tab id: ${String(record.tabId ?? "")}`,
+      `URL: ${String(record.url ?? "about:blank")}`,
+    ];
+    if (record.title) {
+      lines.push(`Title: ${String(record.title)}`);
+    }
+    if (command === "focus" && typeof record.active === "boolean") {
+      lines.push(`Active: ${record.active ? "yes" : "no"}`);
+    }
+    return lines.join("\n");
+  }
+
+  if (command === "close-idle" && typeof data === "object" && data !== null) {
+    const record = data as Record<string, unknown>;
+    const eligible = Array.isArray(record.eligible) ? record.eligible : [];
+    const closed = Array.isArray(record.closed) ? record.closed : [];
+    const skipped = Array.isArray(record.skipped) ? record.skipped : [];
+    const failed = Array.isArray(record.failed) ? record.failed : [];
+    const eligibleCount = Number(record.eligibleCount ?? eligible.length);
+    const closedCount = Number(record.closedCount ?? closed.length);
+    const skippedCount = Number(record.skippedCount ?? skipped.length);
+    const failedCount = Number(record.failedCount ?? failed.length);
+    const dryRun = Boolean(record.dryRun);
+    const lines = [
+      `Eligible: ${eligibleCount} tab(s) idle for at least ${String(record.hours ?? "?")} hour(s).`,
+      dryRun ? "Dry run: no tabs were closed." : `Closed: ${closedCount} tab(s).`,
+      `Skipped: ${skippedCount} tab(s).`,
+      `Failed: ${failedCount} tab(s).`,
+    ];
+
+    const displayed = dryRun ? eligible : closed;
+    if (displayed.length > 0) {
+      lines.push(dryRun ? "Eligible tabs:" : "Closed tabs:");
+      for (const item of displayed) {
+        const tab = item as Record<string, unknown>;
+        lines.push(`- ${String(tab.idleHours ?? "?")}h — ${String(tab.title ?? "(untitled)")} — ${String(tab.url ?? "about:blank")}`);
+      }
+    }
+
+    if (skipped.length > 0) {
+      const reasonCounts = new Map<string, number>();
+      for (const item of skipped) {
+        const reason = String((item as Record<string, unknown>).reason ?? "unknown");
+        reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
+      }
+      lines.push(`Skip reasons: ${Array.from(reasonCounts, ([reason, count]) => `${reason}=${count}`).join(", ")}`);
+    }
+
+    for (const item of failed) {
+      const tab = item as Record<string, unknown>;
+      lines.push(`Failure (${String(tab.stage ?? "unknown")}): ${String(tab.title ?? tab.url ?? tab.id ?? "tab")} — ${String(tab.error ?? "unknown error")}`);
+    }
+    return lines.join("\n");
+  }
+
+  if (command === "click" && typeof data === "object" && data !== null) {
+    const record = data as Record<string, unknown>;
+    const lines = [
+      `Clicked: ${String(record.clicked ?? "")}`,
+      `Resolved: ${String(record.target ?? "")}`,
+    ];
+    if (record.coords) {
+      lines.push(`Coords: ${JSON.stringify(record.coords)}`);
+    }
+    const sc = renderStateChanges(record);
+    if (sc) lines.push(sc);
+    lines.push(`Title: ${String(record.title ?? "(untitled)")}`);
+    lines.push(`Preview: ${String(record.preview ?? "[blank]")}`);
+    return lines.join("\n").trim();
+  }
+
+  if (command === "type" && typeof data === "object" && data !== null) {
+    const record = data as Record<string, unknown>;
+    const lines = [
+      `Filled: ${String(record.typedInto ?? "")}`,
+      `Resolved: ${String(record.target ?? "")}`,
+      `Text: ${String(record.text ?? "")}`,
+    ];
+    const sc = renderStateChanges(record);
+    if (sc) lines.push(sc);
+    return lines.join("\n").trim();
+  }
+
+  if (command === "fill" && typeof data === "object" && data !== null) {
+    const record = data as Record<string, unknown>;
+    const lines = [
+      `Filled: ${String(record.filledInto ?? "")}`,
+      `Resolved: ${String(record.target ?? "")}`,
+      `Intended: ${String(record.intended ?? "")}`,
+      `Actual: ${String(record.actual ?? "")}`,
+      `Match: ${String(record.match ?? false)}`,
+    ];
+    const sc = renderStateChanges(record);
+    if (sc) lines.push(sc);
+    return lines.join("\n").trim();
+  }
+
+  if (command === "upload" && typeof data === "object" && data !== null) {
+    const record = data as Record<string, unknown>;
+    const lines = [
+      `Uploaded: ${String(record.uploaded ?? "")}`,
+      `Target: ${String(record.target ?? "")}`,
+      `Resolved: ${String(record.selector ?? "")}`,
+    ];
+    const sc = renderStateChanges(record);
+    if (sc) lines.push(sc);
+    lines.push(`Title: ${String(record.title ?? "(untitled)")}`);
+    lines.push(`Preview: ${String(record.preview ?? "[blank]")}`);
+    return lines.join("\n").trim();
+  }
+
+  if (command === "wait" && typeof data === "object" && data !== null) {
+    const record = data as { condition?: unknown; waitedFor?: unknown; waitedMs?: unknown; title?: unknown; preview?: unknown };
+    const lines = [`Condition: ${String(record.condition ?? "")}`];
+    if (record.waitedFor != null) {
+      lines.push(`Waited for: ${String(record.waitedFor)}`);
+    }
+    if (record.waitedMs != null) {
+      lines.push(`Waited ms: ${String(record.waitedMs)}`);
+    }
+    if (record.title != null) {
+      lines.push(`Title: ${String(record.title)}`);
+    }
+    if (record.preview != null) {
+      lines.push(`Preview: ${String(record.preview)}`);
+    }
+    return lines.join("\n");
+  }
+
+  if ((command === "snapshot" || command === "diff") && typeof data === "object" && data !== null) {
+    const record = data as { snapshot?: unknown; diff?: unknown };
+    const text = typeof record.snapshot === "string" ? record.snapshot : typeof record.diff === "string" ? record.diff : "";
+    return text || stringifyData(data);
+  }
+
+  if (command === "describe" || command === "ask") {
+    return stringifyData(data);
+  }
+
+  if (command === "dialog" && typeof data === "object" && data !== null) {
+    const record = data as { open?: unknown; handled?: unknown; type?: unknown; message?: unknown; defaultPrompt?: unknown };
+    const lines: string[] = [];
+    if (record.handled) {
+      lines.push(`Handled: ${String(record.handled)}`);
+    } else {
+      lines.push(`Open: ${String(record.open ?? false)}`);
+    }
+    if (record.type) {
+      lines.push(`Type: ${String(record.type)}`);
+    }
+    if (record.message) {
+      lines.push(`Message: ${String(record.message)}`);
+    }
+    if (record.defaultPrompt) {
+      lines.push(`Default prompt: ${String(record.defaultPrompt)}`);
+    }
+    return lines.join("\n");
+  }
+
+  if ((command === "status" || command === "stop") && typeof data === "object" && data !== null) {
+    const record = data as {
+      message?: unknown;
+      url?: unknown;
+      title?: unknown;
+      uptimeMs?: unknown;
+      extensionConnected?: unknown;
+      managedTabId?: unknown;
+      managedAlias?: unknown;
+      managedWindowId?: unknown;
+      activeTabId?: unknown;
+      activeManagedTabId?: unknown;
+      activeManagedAlias?: unknown;
+      managedTabs?: unknown;
+      usingManagedTab?: unknown;
+    };
+    const lines: string[] = [];
+    if (record.message) {
+      lines.push(String(record.message));
+    }
+    lines.push(`URL: ${String(record.url ?? "about:blank")}`);
+    if (record.title) {
+      lines.push(`Title: ${String(record.title)}`);
+    }
+    if (typeof record.uptimeMs === "number") {
+      lines.push(`Uptime: ${formatUptime(record.uptimeMs)}`);
+    }
+    if (record.managedTabId != null) {
+      lines.push(`Managed tab id: ${String(record.managedTabId)}`);
+    }
+    if (record.managedAlias != null) {
+      lines.push(`Managed alias: ${String(record.managedAlias)}`);
+    }
+    if (record.managedWindowId != null) {
+      lines.push(`Managed window id: ${String(record.managedWindowId)}`);
+    }
+    if (record.activeTabId != null) {
+      lines.push(`Active tab id: ${String(record.activeTabId)}`);
+    }
+    if (record.activeManagedTabId != null) {
+      lines.push(`Active managed tab id: ${String(record.activeManagedTabId)}`);
+    }
+    if (record.activeManagedAlias != null) {
+      lines.push(`Active managed alias: ${String(record.activeManagedAlias)}`);
+    }
+    if (typeof record.usingManagedTab === "boolean") {
+      lines.push(`Using managed tab: ${record.usingManagedTab ? "yes" : "no"}`);
+    }
+    if (typeof record.extensionConnected === "boolean") {
+      lines.push(`Extension: ${record.extensionConnected ? "connected" : "disconnected"}`);
+    }
+    if (Array.isArray(record.managedTabs) && record.managedTabs.length > 0) {
+      lines.push("Tabs:");
+      lines.push(renderTabsTable(record.managedTabs));
+    }
+    return lines.join("\n");
+  }
+
+  return stringifyData(data);
+}
+
+export function formatMetadata(ok: boolean, url: string, elapsed: number): string {
+  return `[${ok ? "ok" : "error"} | url: ${url || "about:blank"} | ${Math.max(0, Math.round(elapsed))}ms]`;
+}
+
+export function formatSuccess(command: CommandName, data: unknown, url: string, elapsed: number): string {
+  const body = truncateLines(renderCommandData(command, data).trim());
+  if (!body) {
+    return formatMetadata(true, url, elapsed);
+  }
+  return `${body}\n${formatMetadata(true, url, elapsed)}`;
+}
+
+export function formatError(message: string, url: string, elapsed: number): string {
+  const body = truncateLines(`[error] ${message}`.trim());
+  return `${body}\n${formatMetadata(false, url || "unavailable", elapsed)}`;
+}

--- a/src/browser/src/lib/help.ts
+++ b/src/browser/src/lib/help.ts
@@ -1,0 +1,367 @@
+import type { CommandName } from "./types.js";
+
+interface HelpSpec {
+  name: CommandName;
+  summary: string;
+  usage: string;
+  description: string;
+  options: Array<{ flag: string; description: string }>;
+  examples: string[];
+  nextSteps: string[];
+}
+
+const HIDDEN_FROM_GENERAL_HELP = new Set<CommandName>(["html", "screenshot"]);
+
+const COMMANDS: HelpSpec[] = [
+  {
+    name: "open",
+    summary: "Navigate the managed Chrome tab and return a compact preview.",
+    usage: "browser open <url> [--new] [--window] [--tab <alias>] [--wait <selector>] [--no-delay]",
+    description:
+      "Updates the active managed tab in your real Chrome session by default. The first command creates a dedicated automation window and tab, and all subsequent commands stay there unless you use --new or target a different tab with --tab.",
+    options: [
+      { flag: "--new", description: "Open the URL in a new managed tab and make it active." },
+      { flag: "--window", description: "Used with --new: create a new Chrome window instead of a tab in the current window." },
+      { flag: "--tab <alias>", description: "Navigate a specific managed tab alias such as t1." },
+      { flag: "--wait <selector>", description: "Wait for a selector before returning." },
+      { flag: "--no-delay", description: "Skip the built-in randomized post-action delay." },
+    ],
+    examples: ['browser open "https://news.ycombinator.com"', 'browser open "https://example.com/login" --wait "form"', 'browser open "https://github.com" --new', 'browser open "https://example.com" --new --window'],
+    nextSteps: ["browser tabs", "browser snapshot", 'browser extract --scope "main"'],
+  },
+  {
+    name: "tabs",
+    summary: "List managed tabs and show which one is active.",
+    usage: "browser tabs",
+    description: "Shows every managed tab alias, its Chrome tab id, URL, title, and which tab receives commands by default.",
+    options: [],
+    examples: ["browser tabs"],
+    nextSteps: ["browser focus t1", "browser close t1"],
+  },
+  {
+    name: "focus",
+    summary: "Switch the active managed tab.",
+    usage: "browser focus <alias>",
+    description: "Makes the selected managed tab active for subsequent commands and focuses that tab in Chrome.",
+    options: [],
+    examples: ["browser focus t1"],
+    nextSteps: ['browser click "Continue"', "browser status"],
+  },
+  {
+    name: "close",
+    summary: "Close a managed tab and remove it from the registry.",
+    usage: "browser close <alias>",
+    description: "Closes the selected managed tab in Chrome. If it was active, another managed tab becomes active automatically.",
+    options: [],
+    examples: ["browser close t1"],
+    nextSteps: ["browser tabs", 'browser open "https://example.com" --new'],
+  },
+  {
+    name: "close-idle",
+    summary: "Safely close idle tabs across all normal Chrome windows.",
+    usage: "browser close-idle --hours <n> [--dry-run]",
+    description:
+      "Global cleanup for managed and unmanaged tabs in normal Chrome windows. Revalidates each candidate immediately before removal and always skips pinned, audible, active, non-normal-window, recently accessed, and timestamp-less tabs. Use --dry-run first.",
+    options: [
+      { flag: "--hours <n>", description: "Positive safe-integer hours of inactivity required for eligibility." },
+      { flag: "--dry-run", description: "Revalidate and report eligible tabs without closing anything." },
+    ],
+    examples: ["browser close-idle --hours 6 --dry-run", "browser close-idle --hours 6"],
+    nextSteps: ["browser tabs"],
+  },
+  {
+    name: "click",
+    summary: "Click an element by selector, visible text, or ref.",
+    usage: "browser click <target> [--tab <alias>] [--index <n>] [--text] [--coords] [--no-delay]",
+    description:
+      "Clicks the first matching element by default. Targets like .submit use selectors; plain text targets match visible text. After inspect, ref IDs like e2 can be used directly.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--index <n>", description: "Choose the nth match when multiple elements match." },
+      { flag: "--text", description: "Force a text-only search across visible elements." },
+      { flag: "--coords", description: "Return the clicked element's bounding box." },
+      { flag: "--no-delay", description: "Skip the built-in randomized post-action delay." },
+    ],
+    examples: ['browser click "More"', 'browser click "[data-e2e=post_button]"', 'browser click e2 --coords'],
+    nextSteps: ["browser diff", "browser wait --text \"Success\""],
+  },
+  {
+    name: "type",
+    summary: "Clear an input and type new text into it for simple fields.",
+    usage: "browser type <target> <text> [--tab <alias>] [--index <n>] [--no-delay]",
+    description:
+      "Finds an element, clears it, and fills it with DOM property updates. Prefer this for simple <input> and <textarea> elements. Use fill when framework state must update through trusted keyboard events.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--index <n>", description: "Choose the nth match when multiple elements match." },
+      { flag: "--no-delay", description: "Skip the built-in randomized post-action delay." },
+    ],
+    examples: ['browser type \'input[name="q"]\' "browser CLI"', 'browser type "Search" "browser automation"'],
+    nextSteps: ["browser click \"Search\"", "browser fill e3 \"replacement text\""],
+  },
+  {
+    name: "fill",
+    summary: "Type via real CDP keyboard events for React and rich-text editors.",
+    usage: "browser fill <target> [text] [--tab <alias>] [--clear] [--append] [--index <n>] [--no-delay]",
+    description:
+      "Focus an element, optionally clear it, and type text via trusted CDP keyboard events. React, Draft.js, Vue, and contenteditable regions update their internal state correctly with this command.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--clear", description: "Only clear the field and stop." },
+      { flag: "--append", description: "Skip the clear step and type at the current cursor position." },
+      { flag: "--index <n>", description: "Choose the nth match when multiple elements match." },
+      { flag: "--no-delay", description: "Skip the built-in randomized post-action delay." },
+    ],
+    examples: ['browser fill ".public-DraftEditor-content" "New caption"', 'browser fill e5 "Append this" --append', 'browser fill "Description" --clear'],
+    nextSteps: ["browser diff", "browser inspect"],
+  },
+  {
+    name: "upload",
+    summary: "Attach a local file to a file input via Chrome DevTools Protocol.",
+    usage: "browser upload <target> <filepath> [--tab <alias>] [--no-delay]",
+    description:
+      "Attach a local file to a file input element via Chrome DevTools Protocol. This is the reliable way to upload files because it avoids brittle OS dialog automation while still using Chrome's native file selection path.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--no-delay", description: "Skip the built-in randomized post-action delay." },
+    ],
+    examples: ['browser upload "input[type=file]" /path/to/video.mp4', "browser upload e4 /tmp/file.png"],
+    nextSteps: ["browser wait --text \"Uploaded\"", "browser diff"],
+  },
+  {
+    name: "wait",
+    summary: "Wait for page state, text, disappearance, stability, or a fixed/random delay.",
+    usage: "browser wait [selector] [--tab <alias>] [--text <text>] [--gone <selector>] [--stable <selector>] [--ms <n|min-max>] [--timeout <ms>]",
+    description:
+      "Wait for a condition on the page before continuing. Supports waiting for elements to appear, text to show up, elements to disappear, elements to stabilize, or a fixed/random time delay.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--text <text>", description: "Wait until the given text appears anywhere on the page." },
+      { flag: "--gone <selector>", description: "Wait until the selector disappears or becomes invisible." },
+      { flag: "--stable <selector>", description: "Wait until the selector stops mutating for 500ms." },
+      { flag: "--ms <n|min-max>", description: "Wait a fixed or random number of milliseconds." },
+      { flag: "--timeout <ms>", description: "Maximum wait time before failing. Default 15000." },
+    ],
+    examples: ['browser wait "main"', 'browser wait --text "Processing complete"', 'browser wait --ms 1000-3000'],
+    nextSteps: ["browser snapshot", "browser diff"],
+  },
+  {
+    name: "snapshot",
+    summary: "Return a compact accessibility-tree view of the page.",
+    usage: "browser snapshot [--tab <alias>] [--scope <selector>] [--depth <n>]",
+    description:
+      "Return Chrome's accessibility tree as a compact indented text representation. Use this as the primary page-understanding command when you need structure, labels, and interactive state.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--scope <selector>", description: "Limit the tree to a subtree rooted at the selector." },
+      { flag: "--depth <n>", description: "Limit the output tree depth." },
+    ],
+    examples: ["browser snapshot", 'browser snapshot --scope "main" --depth 4'],
+    nextSteps: ["browser diff", "browser inspect"],
+  },
+  {
+    name: "diff",
+    summary: "Show what changed since the last snapshot.",
+    usage: "browser diff [--tab <alias>] [--scope <selector>] [--depth <n>]",
+    description:
+      "Takes a fresh accessibility snapshot and compares it with the prior snapshot in this session. If no baseline exists yet, returns a full snapshot and stores it for the next diff.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--scope <selector>", description: "Limit the underlying snapshot to a subtree rooted at the selector." },
+      { flag: "--depth <n>", description: "Limit the underlying snapshot tree depth." },
+    ],
+    examples: ["browser diff", 'browser diff --scope "main"'],
+    nextSteps: ["browser inspect", "browser ask \"what changed visually?\""],
+  },
+  {
+    name: "inspect",
+    summary: "Return JSON for interactive elements, including stable refs.",
+    usage: "browser inspect [--tab <alias>] [--scope <selector>] [--all] [--coords]",
+    description:
+      "Return a JSON snapshot of interactive elements on the page: buttons, links, inputs, toggles, selects, and contenteditable regions. Each element gets a short ref ID like e1 for later targeting.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--scope <selector>", description: "Limit inspection to a subtree rooted at the selector." },
+      { flag: "--all", description: "Include hidden elements such as file inputs." },
+      { flag: "--coords", description: "Include bounding-box coordinates for each element." },
+    ],
+    examples: ["browser inspect", 'browser inspect --scope "main" --coords', "browser inspect --all"],
+    nextSteps: ["browser click e2", "browser fill e3 \"new text\""],
+  },
+  {
+    name: "describe",
+    summary: "Use a small vision model to describe the current page.",
+    usage: "browser describe [--tab <alias>] [--scope <selector>] [--model <name>]",
+    description:
+      "Take a screenshot and accessibility snapshot, send both to a fast vision model, and return a natural-language description. Use this when visual-only state matters more than structural page state.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--scope <selector>", description: "Scope the accessibility snapshot while keeping a full-page screenshot." },
+      { flag: "--model <name>", description: "Override the default model (google/gemini-3.1-flash-lite-preview)." },
+    ],
+    examples: ["browser describe", 'browser describe --scope "main"'],
+    nextSteps: ["browser ask \"what error message is visible?\"", "browser snapshot"],
+  },
+  {
+    name: "ask",
+    summary: "Ask a specific visual question about the current page.",
+    usage: "browser ask <question> [--tab <alias>] [--scope <selector>] [--model <name>]",
+    description:
+      "Take a screenshot and accessibility snapshot, send both to a fast vision model with your question, and return a concise factual answer. Use this when a targeted visual check is cheaper than a screenshot review.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--scope <selector>", description: "Scope the accessibility snapshot while keeping a full-page screenshot." },
+      { flag: "--model <name>", description: "Override the default model (google/gemini-3.1-flash-lite-preview)." },
+    ],
+    examples: ['browser ask "is the upload progress bar complete?"', 'browser ask "what text is in the error banner?" --scope "main"'],
+    nextSteps: ["browser click", "browser wait"],
+  },
+  {
+    name: "extract",
+    summary: "Extract visible text or structured link/text items.",
+    usage: "browser extract [selector] [--tab <alias>] [--scope <selector>] [--json] [--limit <n>]",
+    description:
+      "Without a selector, extracts visible page text. With --json, returns compact {text, href} objects from matching elements. Use --scope to avoid mixing navigation, footer, and sidebar content into one output.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--scope <selector>", description: "Use a root element before extracting text or matching the selector." },
+      { flag: "--json", description: "Return JSON instead of plain text." },
+      { flag: "--limit <n>", description: "Maximum number of items to return." },
+    ],
+    examples: ['browser extract --scope "main" --limit 40', 'browser extract ".titleline" --json --limit 5'],
+    nextSteps: ["browser snapshot", 'browser html "main" --limit 80'],
+  },
+  {
+    name: "screenshot",
+    summary: "Save a PNG screenshot of the managed Chrome tab.",
+    usage: "browser screenshot [path] [--tab <alias>]",
+    description:
+      "Attempts full-page capture through Chrome DevTools Protocol. If unavailable, it falls back to visible-viewport capture.",
+    options: [{ flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." }],
+    examples: ["browser screenshot", "browser screenshot ./artifacts/page.png"],
+    nextSteps: ["browser describe", "browser status"],
+  },
+  {
+    name: "html",
+    summary: "Return cleaned HTML for the full page or a selector.",
+    usage: "browser html [selector] [--tab <alias>] [--limit <n>]",
+    description: "Returns normalized markup without scripts/styles, truncated by line count for readability.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--limit <n>", description: "Maximum number of lines to show." },
+    ],
+    examples: ["browser html", 'browser html "main" --limit 80'],
+    nextSteps: ["browser snapshot", "browser extract"],
+  },
+  {
+    name: "eval",
+    summary: "Evaluate JavaScript in the active page context.",
+    usage: "browser eval <js> [--tab <alias>]",
+    description: "Runs JavaScript in the active tab and prints the result as JSON or text.",
+    options: [{ flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." }],
+    examples: ['browser eval "document.title"', 'browser eval "Array.from(document.links).length"'],
+    nextSteps: ["browser status", "browser inspect"],
+  },
+  {
+    name: "dialog",
+    summary: "Check for or handle browser-level dialogs that block automation.",
+    usage: "browser dialog [--tab <alias>] [--accept [text]] [--dismiss]",
+    description:
+      "Check for and handle browser-level dialogs such as alert, confirm, prompt, and beforeunload dialogs. These dialogs block other browser commands while open.",
+    options: [
+      { flag: "--tab <alias>", description: "Run the command against a specific managed tab alias." },
+      { flag: "--accept [text]", description: "Accept the dialog, optionally supplying prompt text." },
+      { flag: "--dismiss", description: "Dismiss the dialog." },
+    ],
+    examples: ["browser dialog", "browser dialog --accept", 'browser dialog --accept "yes"'],
+    nextSteps: ["browser click", "browser wait"],
+  },
+  {
+    name: "status",
+    summary: "Show managed automation tab URL, title, and bridge health.",
+    usage: "browser status [--tab <alias>]",
+    description: "Reports CLI server uptime plus extension connection and managed tab state. With --tab, shows status for a specific managed tab.",
+    options: [{ flag: "--tab <alias>", description: "Show status for a specific managed tab alias." }],
+    examples: ["browser status"],
+    nextSteps: ["browser open https://example.com", "browser stop"],
+  },
+  {
+    name: "stop",
+    summary: "Stop the local browser server.",
+    usage: "browser stop",
+    description: "Shuts down the background CLI server and websocket bridge.",
+    options: [],
+    examples: ["browser stop"],
+    nextSteps: ["browser open https://example.com"],
+  },
+];
+
+export function isCommandName(value: string): value is CommandName {
+  return COMMANDS.some((command) => command.name === value);
+}
+
+export function getHelpSpec(name: CommandName): HelpSpec {
+  const spec = COMMANDS.find((command) => command.name === name);
+  if (!spec) {
+    throw new Error(`Unknown command: ${name}`);
+  }
+  return spec;
+}
+
+export function renderGeneralHelp(): string {
+  const visibleCommands = COMMANDS.filter((command) => !HIDDEN_FROM_GENERAL_HELP.has(command.name));
+  const lines = [
+    "browser",
+    "",
+    "Control your real Chrome in a dedicated automation window through a local extension bridge.",
+    "",
+    "Commands:",
+    ...visibleCommands.map((command) => `  ${command.name.padEnd(10)} ${command.summary}`),
+    "",
+    "Common option (only on commands that list it):",
+    "  --tab <alias>   Target a specific managed tab.",
+    "",
+    "Example workflow:",
+    '  browser open "https://news.ycombinator.com"',
+    "  browser snapshot",
+    "  browser inspect",
+    '  browser click "More"',
+    "  browser stop",
+    "",
+    "Navigation:",
+    "  browser help",
+    "  browser <command> --help",
+    "  browser click           # usage + examples + next steps",
+  ];
+  return lines.join("\n");
+}
+
+export function renderCommandHelp(name: CommandName, issue?: string): string {
+  const spec = getHelpSpec(name);
+  const lines: string[] = [];
+
+  if (issue) {
+    lines.push(`[error] ${issue}`, "");
+  }
+
+  lines.push(spec.usage, "", spec.description);
+
+  if (spec.options.length > 0) {
+    lines.push("", "Options:");
+    for (const option of spec.options) {
+      lines.push(`  ${option.flag.padEnd(16)} ${option.description}`);
+    }
+  }
+
+  lines.push("", "Examples:");
+  for (const example of spec.examples) {
+    lines.push(`  ${example}`);
+  }
+
+  lines.push("", "Next steps:");
+  for (const nextStep of spec.nextSteps) {
+    lines.push(`  ${nextStep}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/browser/src/lib/listener.ts
+++ b/src/browser/src/lib/listener.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import process from "node:process";
+
+export type ListenTransport = "socket" | "port" | "existing";
+export interface ListenResult {
+  transport: ListenTransport;
+  ownsSocket: boolean;
+}
+
+interface ListenOptions {
+  socketPath: string;
+  fallbackPort: number;
+  host?: string;
+  startupTimeoutMs?: number;
+  probeTimeoutMs?: number;
+}
+
+type ProbeResult = "browser" | "stale" | "occupied";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function attemptListen(server: http.Server, target: string | { port: number; host: string }): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onListening = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      server.off("listening", onListening);
+      server.off("error", onError);
+    };
+    server.once("listening", onListening);
+    server.once("error", onError);
+    if (typeof target === "string") server.listen(target);
+    else server.listen(target.port, target.host);
+  });
+}
+
+async function probeHealth(
+  target: { socketPath: string } | { host: string; port: number },
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: ProbeResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const request = http.request({ ...target, method: "GET", path: "/health" }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      response.on("end", () => {
+        try {
+          const payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { ok?: unknown; service?: unknown };
+          finish(response.statusCode === 200 && payload.service === "browser-cli" ? "browser" : "occupied");
+        } catch {
+          finish("occupied");
+        }
+      });
+    });
+    request.setTimeout(timeoutMs, () => {
+      request.destroy();
+      finish("occupied");
+    });
+    request.on("error", (error: NodeJS.ErrnoException) => {
+      finish(error.code === "ENOENT" || error.code === "ECONNREFUSED" ? "stale" : "occupied");
+    });
+    request.end();
+  });
+}
+
+async function processIsAlive(pid: number): Promise<boolean> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function acquireLock(lockPath: string): Promise<null | (() => Promise<void>)> {
+  try {
+    const handle = await fs.open(lockPath, "wx", 0o600);
+    await handle.writeFile(`${process.pid}\n`);
+    await handle.close();
+    return async () => fs.rm(lockPath, { force: true }).catch(() => undefined);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+
+  try {
+    const stat = await fs.lstat(lockPath);
+    if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+      throw new Error(`Startup lock is owned by another user: ${lockPath}`);
+    }
+    const raw = await fs.readFile(lockPath, "utf8");
+    const pid = Number.parseInt(raw.trim(), 10);
+    if (await processIsAlive(pid)) return null;
+    // Invalid, freshly-created contents may just be between open() and write().
+    if (!Number.isSafeInteger(pid) && Date.now() - stat.mtimeMs < 10_000) return null;
+    await fs.rm(lockPath, { force: true });
+    return acquireLock(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function removeStaleSocket(socketPath: string): Promise<void> {
+  try {
+    const stat = await fs.lstat(socketPath);
+    if (!stat.isSocket()) {
+      throw new Error(`Refusing to remove non-socket path: ${socketPath}`);
+    }
+    if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+      throw new Error(`Refusing to remove socket owned by another user: ${socketPath}`);
+    }
+    await fs.unlink(socketPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+export async function listenForCommands(server: http.Server, options: ListenOptions): Promise<ListenResult> {
+  const host = options.host ?? "127.0.0.1";
+  const timeoutMs = options.startupTimeoutMs ?? 10_000;
+  const probeTimeoutMs = options.probeTimeoutMs ?? 500;
+  const lockPath = `${options.socketPath}.startup.lock`;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // A lock closes the unlink-to-bind race: non-winners wait rather than bind
+    // the just-unlinked path before the lock holder can do so.
+    const lockExists = await fs.access(lockPath).then(() => true, () => false);
+    if (lockExists) {
+      const release = await acquireLock(lockPath);
+      if (!release) {
+        await delay(20);
+        continue;
+      }
+      await release();
+    }
+
+    try {
+      await attemptListen(server, options.socketPath);
+      return { transport: "socket", ownsSocket: true };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EACCES" || code === "EPERM") break;
+      if (code !== "EADDRINUSE") throw error;
+    }
+
+    const probe = await probeHealth({ socketPath: options.socketPath }, probeTimeoutMs);
+    if (probe === "browser") return { transport: "existing", ownsSocket: false };
+    if (probe === "occupied") throw new Error(`Command socket is occupied by another live service: ${options.socketPath}`);
+
+    const release = await acquireLock(lockPath);
+    if (!release) {
+      await delay(20);
+      continue;
+    }
+    try {
+      const recheck = await probeHealth({ socketPath: options.socketPath }, probeTimeoutMs);
+      if (recheck === "browser") return { transport: "existing", ownsSocket: false };
+      if (recheck === "occupied") throw new Error(`Command socket is occupied by another live service: ${options.socketPath}`);
+      await removeStaleSocket(options.socketPath);
+      try {
+        await attemptListen(server, options.socketPath);
+        return { transport: "socket", ownsSocket: true };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EADDRINUSE") throw error;
+      }
+    } finally {
+      await release();
+    }
+  }
+
+  try {
+    await attemptListen(server, { host, port: options.fallbackPort });
+    return { transport: "port", ownsSocket: false };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EADDRINUSE") throw error;
+    const probe = await probeHealth({ host, port: options.fallbackPort }, probeTimeoutMs);
+    if (probe === "browser") return { transport: "existing", ownsSocket: false };
+    throw new Error(`Fallback command port ${options.fallbackPort} is unavailable.`);
+  }
+}

--- a/src/browser/src/lib/parse.ts
+++ b/src/browser/src/lib/parse.ts
@@ -1,0 +1,474 @@
+import path from "node:path";
+import { isCommandName, renderCommandHelp, renderGeneralHelp } from "./help.js";
+import type { CommandName } from "./types.js";
+
+export interface ParsedInput {
+  command?: CommandName;
+  args: string[];
+  options: Record<string, unknown>;
+  localOutput?: { ok: boolean; text: string };
+  allowAutoStart: boolean;
+}
+
+type OptionKind = "boolean" | "string" | "optional-string" | "non-negative-integer" | "positive-integer";
+
+interface OptionRule {
+  key: string;
+  kind: OptionKind;
+  maximum?: number;
+}
+
+interface CommandSchema {
+  minArgs: number;
+  maxArgs: number;
+  options: Record<string, OptionRule>;
+}
+
+const booleanOption = (key: string): OptionRule => ({ key, kind: "boolean" });
+const stringOption = (key: string): OptionRule => ({ key, kind: "string" });
+const optionalStringOption = (key: string): OptionRule => ({ key, kind: "optional-string" });
+const nonNegativeIntegerOption = (key: string, maximum?: number): OptionRule => ({ key, kind: "non-negative-integer", maximum });
+const positiveIntegerOption = (key: string): OptionRule => ({ key, kind: "positive-integer" });
+
+const TAB = stringOption("tab");
+const NO_DELAY = booleanOption("noDelay");
+const MAX_WAIT_MS = 2_147_000_000;
+
+const COMMAND_SCHEMAS: Record<CommandName, CommandSchema> = {
+  open: {
+    minArgs: 1,
+    maxArgs: 1,
+    options: {
+      "--new": booleanOption("new"),
+      "--window": booleanOption("window"),
+      "--tab": TAB,
+      "--wait": stringOption("wait"),
+      "--no-delay": NO_DELAY,
+    },
+  },
+  tabs: { minArgs: 0, maxArgs: 0, options: {} },
+  focus: { minArgs: 1, maxArgs: 1, options: {} },
+  close: { minArgs: 1, maxArgs: 1, options: {} },
+  "close-idle": {
+    minArgs: 0,
+    maxArgs: 0,
+    options: {
+      "--hours": positiveIntegerOption("hours"),
+      "--dry-run": booleanOption("dryRun"),
+    },
+  },
+  click: {
+    minArgs: 1,
+    maxArgs: 1,
+    options: {
+      "--tab": TAB,
+      "--index": nonNegativeIntegerOption("index"),
+      "--text": booleanOption("text"),
+      "--coords": booleanOption("coords"),
+      "--no-delay": NO_DELAY,
+    },
+  },
+  type: {
+    minArgs: 2,
+    maxArgs: 2,
+    options: {
+      "--tab": TAB,
+      "--index": nonNegativeIntegerOption("index"),
+      "--no-delay": NO_DELAY,
+    },
+  },
+  fill: {
+    minArgs: 1,
+    maxArgs: 2,
+    options: {
+      "--tab": TAB,
+      "--clear": booleanOption("clear"),
+      "--append": booleanOption("append"),
+      "--index": nonNegativeIntegerOption("index"),
+      "--no-delay": NO_DELAY,
+    },
+  },
+  upload: {
+    minArgs: 2,
+    maxArgs: 2,
+    options: {
+      "--tab": TAB,
+      "--no-delay": NO_DELAY,
+    },
+  },
+  wait: {
+    minArgs: 0,
+    maxArgs: 1,
+    options: {
+      "--tab": TAB,
+      "--text": stringOption("text"),
+      "--gone": stringOption("gone"),
+      "--stable": stringOption("stable"),
+      "--ms": stringOption("ms"),
+      "--timeout": nonNegativeIntegerOption("timeout", MAX_WAIT_MS),
+    },
+  },
+  snapshot: {
+    minArgs: 0,
+    maxArgs: 0,
+    options: {
+      "--tab": TAB,
+      "--scope": stringOption("scope"),
+      "--depth": nonNegativeIntegerOption("depth"),
+    },
+  },
+  diff: {
+    minArgs: 0,
+    maxArgs: 0,
+    options: {
+      "--tab": TAB,
+      "--scope": stringOption("scope"),
+      "--depth": nonNegativeIntegerOption("depth"),
+    },
+  },
+  inspect: {
+    minArgs: 0,
+    maxArgs: 0,
+    options: {
+      "--tab": TAB,
+      "--scope": stringOption("scope"),
+      "--all": booleanOption("all"),
+      "--coords": booleanOption("coords"),
+    },
+  },
+  describe: {
+    minArgs: 0,
+    maxArgs: 0,
+    options: {
+      "--tab": TAB,
+      "--scope": stringOption("scope"),
+      "--model": stringOption("model"),
+    },
+  },
+  ask: {
+    minArgs: 1,
+    maxArgs: 1,
+    options: {
+      "--tab": TAB,
+      "--scope": stringOption("scope"),
+      "--model": stringOption("model"),
+    },
+  },
+  extract: {
+    minArgs: 0,
+    maxArgs: 1,
+    options: {
+      "--tab": TAB,
+      "--scope": stringOption("scope"),
+      "--json": booleanOption("json"),
+      "--limit": positiveIntegerOption("limit"),
+    },
+  },
+  screenshot: {
+    minArgs: 0,
+    maxArgs: 1,
+    options: { "--tab": TAB },
+  },
+  html: {
+    minArgs: 0,
+    maxArgs: 1,
+    options: {
+      "--tab": TAB,
+      "--limit": positiveIntegerOption("limit"),
+    },
+  },
+  eval: {
+    minArgs: 1,
+    maxArgs: 1,
+    options: { "--tab": TAB },
+  },
+  dialog: {
+    minArgs: 0,
+    maxArgs: 0,
+    options: {
+      "--tab": TAB,
+      "--accept": optionalStringOption("accept"),
+      "--dismiss": booleanOption("dismiss"),
+    },
+  },
+  status: {
+    minArgs: 0,
+    maxArgs: 0,
+    options: { "--tab": TAB },
+  },
+  stop: { minArgs: 0, maxArgs: 0, options: {} },
+};
+
+function commandFailure(command: CommandName, issue: string): ParsedInput {
+  return {
+    command,
+    args: [],
+    options: {},
+    localOutput: { ok: false, text: renderCommandHelp(command, issue) },
+    allowAutoStart: false,
+  };
+}
+
+function parseInteger(flag: string, raw: string, positive: boolean): number | string {
+  const pattern = positive ? /^[1-9]\d*$/ : /^(?:0|[1-9]\d*)$/;
+  if (!pattern.test(raw)) {
+    return `${flag} requires a ${positive ? "positive" : "non-negative"} whole number.`;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) {
+    return `${flag} must be a safe integer.`;
+  }
+  return parsed;
+}
+
+function validateDelay(value: string): string | null {
+  const match = /^(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/.exec(value);
+  if (!match) {
+    return `Invalid --ms value "${value}". Use a non-negative integer or min-max range.`;
+  }
+
+  const minimum = Number(match[1]);
+  const maximum = match[2] == null ? minimum : Number(match[2]);
+  if (!Number.isSafeInteger(minimum) || !Number.isSafeInteger(maximum)) {
+    return "--ms values must be safe integers.";
+  }
+  if (minimum > MAX_WAIT_MS || maximum > MAX_WAIT_MS) {
+    return `--ms values must not exceed ${MAX_WAIT_MS}.`;
+  }
+  if (maximum < minimum) {
+    return "--ms range maximum must be greater than or equal to its minimum.";
+  }
+  return null;
+}
+
+function argumentIssue(command: CommandName, args: string[], options: Record<string, unknown>): string | null {
+  const schema = COMMAND_SCHEMAS[command];
+  if (args.length < schema.minArgs) {
+    switch (command) {
+      case "open":
+        return "Missing required argument <url>.";
+      case "focus":
+      case "close":
+        return "Missing required argument <alias>.";
+      case "click":
+        return "Missing required argument <target>.";
+      case "type":
+        return "Missing required arguments <target> <text>.";
+      case "fill":
+        return "Missing required argument <target>.";
+      case "upload":
+        return "Missing required arguments <target> <filepath>.";
+      case "ask":
+        return "Missing required argument <question>.";
+      case "eval":
+        return "Missing required argument <js>.";
+      default:
+        return "Missing required argument.";
+    }
+  }
+
+  if (args.length > schema.maxArgs) {
+    return `Too many positional arguments (expected at most ${schema.maxArgs}). Quote arguments that contain spaces.`;
+  }
+
+  if (command === "close-idle" && options.hours == null) {
+    return "Missing required option --hours <n>.";
+  }
+
+  if (command === "open" && options.window && options.tab) {
+    return "--window creates an independent window and cannot be combined with --tab.";
+  }
+
+  if (command === "fill") {
+    if (options.clear && options.append) {
+      return "Use either --clear or --append, not both.";
+    }
+    if (options.clear && args.length > 1) {
+      return "Do not provide <text> with --clear.";
+    }
+    if (!options.clear && args.length < 2) {
+      return "Missing required argument <text> unless --clear is used.";
+    }
+  }
+
+  if (command === "dialog" && options.accept && options.dismiss) {
+    return "Use either --accept or --dismiss, not both.";
+  }
+
+  if (command === "wait") {
+    const conditions = [args.length === 1, typeof options.text === "string", typeof options.gone === "string", typeof options.stable === "string", typeof options.ms === "string"].filter(Boolean).length;
+    if (conditions !== 1) {
+      return "Specify exactly one wait condition: [selector], --text, --gone, --stable, or --ms.";
+    }
+    if (typeof options.ms === "string") {
+      return validateDelay(options.ms);
+    }
+  }
+
+  return null;
+}
+
+function validateOptionValue(rule: OptionRule, value: unknown): boolean {
+  switch (rule.kind) {
+    case "boolean":
+      return typeof value === "boolean";
+    case "string":
+      return typeof value === "string" && value.length > 0;
+    case "optional-string":
+      return value === true || (typeof value === "string" && value.length > 0);
+    case "non-negative-integer":
+      return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+    case "positive-integer":
+      return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+  }
+}
+
+/** Validate already-normalized input, including requests sent directly to the local server. */
+export function validateCommandInput(command: CommandName, args: unknown, options: unknown): string | null {
+  if (!Array.isArray(args) || !args.every((argument) => typeof argument === "string")) {
+    return "Command arguments must be strings.";
+  }
+  if (typeof options !== "object" || options === null || Array.isArray(options)) {
+    return "Command options must be an object.";
+  }
+
+  const normalizedOptions = options as Record<string, unknown>;
+  const rulesByKey = new Map(Object.values(COMMAND_SCHEMAS[command].options).map((rule) => [rule.key, rule]));
+  for (const [key, value] of Object.entries(normalizedOptions)) {
+    const rule = rulesByKey.get(key);
+    if (!rule) {
+      return `Unsupported option "${key}" for browser ${command}.`;
+    }
+    if (!validateOptionValue(rule, value) || (rule.maximum != null && typeof value === "number" && value > rule.maximum)) {
+      return `Invalid value for option "${key}".`;
+    }
+  }
+
+  return argumentIssue(command, args, normalizedOptions);
+}
+
+export function parseCliInput(argv: string[], cwd = process.cwd()): ParsedInput {
+  if (argv.length === 0 || (argv.length === 1 && ["help", "--help", "-h"].includes(argv[0]))) {
+    return {
+      args: [],
+      options: {},
+      localOutput: { ok: true, text: renderGeneralHelp() },
+      allowAutoStart: false,
+    };
+  }
+
+  if (["help", "--help", "-h"].includes(argv[0])) {
+    return {
+      args: [],
+      options: {},
+      localOutput: { ok: false, text: `[error] Help does not accept arguments.\n\n${renderGeneralHelp()}` },
+      allowAutoStart: false,
+    };
+  }
+
+  const [rawCommand, ...rest] = argv;
+  if (!isCommandName(rawCommand)) {
+    return {
+      args: [],
+      options: {},
+      localOutput: { ok: false, text: `[error] Unknown command "${rawCommand}".\n\n${renderGeneralHelp()}` },
+      allowAutoStart: false,
+    };
+  }
+
+  if (rest.length === 1 && ["--help", "-h"].includes(rest[0])) {
+    return {
+      command: rawCommand,
+      args: [],
+      options: {},
+      localOutput: { ok: true, text: renderCommandHelp(rawCommand) },
+      allowAutoStart: false,
+    };
+  }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    return commandFailure(rawCommand, "--help must be used by itself after the command.");
+  }
+
+  const schema = COMMAND_SCHEMAS[rawCommand];
+  const args: string[] = [];
+  const options: Record<string, unknown> = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith("--")) {
+      args.push(token);
+      continue;
+    }
+
+    const rule = schema.options[token];
+    if (!rule) {
+      return commandFailure(rawCommand, `Unsupported option "${token}".`);
+    }
+    if (Object.prototype.hasOwnProperty.call(options, rule.key)) {
+      return commandFailure(rawCommand, `Option "${token}" may only be specified once.`);
+    }
+
+    if (rule.kind === "boolean") {
+      options[rule.key] = true;
+      continue;
+    }
+
+    if (rule.kind === "optional-string") {
+      const candidate = rest[index + 1];
+      if (candidate != null && !candidate.startsWith("--")) {
+        options[rule.key] = candidate;
+        index += 1;
+      } else {
+        options[rule.key] = true;
+      }
+      continue;
+    }
+
+    const value = rest[index + 1];
+    if (value == null || value.startsWith("--")) {
+      return commandFailure(rawCommand, `${token} requires a value.`);
+    }
+    index += 1;
+
+    if (rule.kind === "string") {
+      if (!value) {
+        return commandFailure(rawCommand, `${token} requires a non-empty value.`);
+      }
+      options[rule.key] = value;
+      continue;
+    }
+
+    const parsed = parseInteger(token, value, rule.kind === "positive-integer");
+    if (typeof parsed === "string") {
+      return commandFailure(rawCommand, parsed);
+    }
+    if (rule.maximum != null && parsed > rule.maximum) {
+      return commandFailure(rawCommand, `${token} must not exceed ${rule.maximum}.`);
+    }
+    options[rule.key] = parsed;
+  }
+
+  if (options.window) {
+    options.new = true;
+  }
+
+  const issue = argumentIssue(rawCommand, args, options);
+  if (issue) {
+    return commandFailure(rawCommand, issue);
+  }
+
+  if (rawCommand === "screenshot" && args[0]) {
+    args[0] = path.resolve(cwd, args[0]);
+  }
+  if (rawCommand === "upload" && args[1]) {
+    args[1] = path.resolve(cwd, args[1]);
+  }
+
+  return {
+    command: rawCommand,
+    args,
+    options,
+    allowAutoStart: rawCommand !== "stop",
+  };
+}

--- a/src/browser/src/lib/types.ts
+++ b/src/browser/src/lib/types.ts
@@ -1,0 +1,105 @@
+export const SOCKET_PATH = "/tmp/browser-cli-v2.sock";
+export const FALLBACK_PORT = 19223;
+export const BRIDGE_WS_PORT = 19224;
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const BRIDGE_TIMEOUT_GRACE_MS = 5_000;
+export const CLOSE_IDLE_TIMEOUT_MS = 120_000;
+export const OUTPUT_LINE_LIMIT = 200;
+export const OPEN_PREVIEW_CHARS = 500;
+export const DEFAULT_EXTRACT_LIMIT = 20;
+export const DEFAULT_HTML_LIMIT = 120;
+
+export type CommandName =
+  | "open"
+  | "tabs"
+  | "focus"
+  | "close"
+  | "close-idle"
+  | "click"
+  | "type"
+  | "fill"
+  | "upload"
+  | "wait"
+  | "snapshot"
+  | "diff"
+  | "inspect"
+  | "describe"
+  | "ask"
+  | "extract"
+  | "screenshot"
+  | "html"
+  | "eval"
+  | "dialog"
+  | "status"
+  | "stop";
+
+export interface CommandRequest {
+  command: CommandName;
+  args: string[];
+  options: Record<string, unknown>;
+}
+
+export interface CommandResponse {
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+  url: string;
+  title: string;
+  elapsed: number;
+}
+
+export interface BrowserState {
+  startedAt: number;
+}
+
+export type BridgeAction =
+  | "open"
+  | "tabs"
+  | "focus"
+  | "close"
+  | "close-idle"
+  | "click"
+  | "type"
+  | "fill"
+  | "upload"
+  | "wait"
+  | "snapshot"
+  | "diff"
+  | "inspect"
+  | "extract"
+  | "screenshot"
+  | "html"
+  | "eval"
+  | "dialog"
+  | "status";
+
+export interface BridgeRequest {
+  id: string;
+  action: BridgeAction;
+  params: Record<string, unknown>;
+  deadline: number;
+}
+
+export interface BridgeCancelRequest {
+  type: "cancel";
+  id: string;
+}
+
+export interface BridgeResponse {
+  id: string;
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+export interface BridgeHelloMessage {
+  type: "hello";
+  source?: string;
+}
+
+export class FriendlyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FriendlyError";
+  }
+}

--- a/src/browser/src/server.ts
+++ b/src/browser/src/server.ts
@@ -1,0 +1,808 @@
+import http from "node:http";
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { ExtensionBridge } from "./lib/bridge.js";
+import { listenForCommands } from "./lib/listener.js";
+import { validateCommandInput } from "./lib/parse.js";
+import { BRIDGE_TIMEOUT_GRACE_MS, BRIDGE_WS_PORT, CLOSE_IDLE_TIMEOUT_MS, DEFAULT_EXTRACT_LIMIT, DEFAULT_HTML_LIMIT, FALLBACK_PORT, FriendlyError, SOCKET_PATH } from "./lib/types.js";
+import type { BridgeAction, BrowserState, CommandName, CommandRequest, CommandResponse } from "./lib/types.js";
+
+const DEFAULT_ORACLE_MODEL = "google/gemini-3.1-flash-lite-preview";
+const LOCATION_TIMEOUT_MS = 1_000;
+const OPENROUTER_TIMEOUT_MS = 60_000;
+
+const DESCRIBE_SYSTEM_PROMPT = `You are a browser state oracle inside a browser automation tool.
+You receive a screenshot and an accessibility tree of a web page.
+
+Describe everything you observe on this page. Be thorough - anything a
+human would notice when looking at this page should be mentioned. Include:
+
+- What the page is showing (main content, current view or section)
+- Any modal, dialog, banner, toast, or overlay that is visible
+- State of interactive elements if relevant (toggles, inputs, selections)
+- Any error messages, warnings, or loading states
+- Anything unusual or unexpected
+
+Report what you see verbatim. Quote exact text from the page - do not
+paraphrase error messages, labels, button text, or status indicators.
+If a banner says "Content under review", write exactly that, not a summary.
+
+Be concise but never omit observations to save space. If the page is
+complex, a longer response is correct. If it's simple, a short one is fine.
+Plain text, no markdown formatting.`;
+
+const ASK_SYSTEM_PROMPT = `You are a browser state oracle inside a browser automation tool.
+You receive a screenshot, an accessibility tree of a web page, and a
+specific question.
+
+Answer the question precisely and factually based on what you can observe
+in the screenshot and accessibility tree.
+
+Report what you see verbatim. Quote exact text from the page - do not
+paraphrase or summarize labels, messages, values, or button text.
+If the page says "144/4000", report exactly "144/4000", not "about 144
+characters."
+
+Never guess. If you cannot determine the answer from what's visible,
+say "unclear from current view" and explain what you can see instead.
+
+Plain text, 1-5 sentences. Be concise but precise.`;
+
+const COMMAND_NAMES: ReadonlySet<CommandName> = new Set([
+  "open",
+  "tabs",
+  "focus",
+  "close",
+  "close-idle",
+  "click",
+  "type",
+  "fill",
+  "upload",
+  "wait",
+  "snapshot",
+  "diff",
+  "inspect",
+  "describe",
+  "ask",
+  "extract",
+  "screenshot",
+  "html",
+  "eval",
+  "dialog",
+  "status",
+  "stop",
+]);
+
+const state: BrowserState = {
+  startedAt: Date.now(),
+};
+
+export interface CommandBridge {
+  call(action: BridgeAction, params: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal): Promise<unknown>;
+  getStatus(): { connected: boolean; lastSeenAt?: number | null };
+}
+
+type OracleParams = { prompt: string; question?: string; scope?: string; model?: string; tabId?: string };
+export type OracleRunner = (params: OracleParams, commandBridge: CommandBridge) => Promise<string>;
+
+let bridge: ExtensionBridge | null = null;
+let server: http.Server | null = null;
+let ownsSocket = false;
+let shuttingDown = false;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function parseNumberOption(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function buildTabParams(options: Record<string, unknown>): Record<string, unknown> {
+  return typeof options.tab === "string" && options.tab.trim() ? { tabId: options.tab.trim() } : {};
+}
+
+function extractLocation(value: unknown): { url: string; title: string } | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const url = parseString(value.url);
+  if (!url) {
+    return null;
+  }
+
+  return {
+    url,
+    title: parseString(value.title),
+  };
+}
+
+function requireBridge(): ExtensionBridge {
+  if (!bridge) {
+    throw new FriendlyError("Browser server has not started its extension bridge.");
+  }
+  return bridge;
+}
+
+async function getCurrentLocation(commandBridge: CommandBridge): Promise<{ url: string; title: string }> {
+  try {
+    const status = await commandBridge.call("status", {}, LOCATION_TIMEOUT_MS);
+    const location = extractLocation(status);
+    if (location) {
+      return location;
+    }
+  } catch {
+    // fall through
+  }
+
+  return { url: "about:blank", title: "" };
+}
+
+function parseEnvValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+async function readEnvFile(envPath: string): Promise<Record<string, string>> {
+  try {
+    const content = await fs.readFile(envPath, "utf8");
+    const entries: Record<string, string> = {};
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) {
+        continue;
+      }
+      const separatorIndex = trimmed.indexOf("=");
+      if (separatorIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, separatorIndex).trim();
+      const value = trimmed.slice(separatorIndex + 1);
+      if (key) {
+        entries[key] = parseEnvValue(value);
+      }
+    }
+    return entries;
+  } catch {
+    return {};
+  }
+}
+
+async function loadApiKey(): Promise<string> {
+  if (process.env.OPENROUTER_API_KEY) {
+    return process.env.OPENROUTER_API_KEY;
+  }
+
+  const candidatePaths = [
+    path.resolve(process.cwd(), ".env"),
+    path.resolve(process.cwd(), "..", ".env"),
+    path.resolve(process.cwd(), "..", "..", ".env"),
+  ];
+
+  for (const envPath of candidatePaths) {
+    const values = await readEnvFile(envPath);
+    if (values.OPENROUTER_API_KEY) {
+      return values.OPENROUTER_API_KEY;
+    }
+  }
+
+  throw new FriendlyError("OPENROUTER_API_KEY is not set. Set it in the environment or in the .env file.");
+}
+
+function extractChatText(payload: unknown): string {
+  if (!isObject(payload) || !Array.isArray(payload.choices) || payload.choices.length === 0) {
+    throw new FriendlyError("API response did not include any choices.");
+  }
+
+  const firstChoice = payload.choices[0];
+  if (!isObject(firstChoice) || !isObject(firstChoice.message)) {
+    throw new FriendlyError("API response did not include a message.");
+  }
+
+  const content = firstChoice.message.content;
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (Array.isArray(content)) {
+    const text = content
+      .map((part) => {
+        if (!isObject(part)) {
+          return "";
+        }
+        if (typeof part.text === "string") {
+          return part.text;
+        }
+        return "";
+      })
+      .join("\n")
+      .trim();
+    if (text) {
+      return text;
+    }
+  }
+
+  throw new FriendlyError("API response did not include text content.");
+}
+
+async function runOracle(params: OracleParams, commandBridge: CommandBridge): Promise<string> {
+  try {
+    // Extension requests are intentionally serialized, so capture these in
+    // sequence and give each operation its own full timeout budget.
+    const screenshotResult = await commandBridge.call(
+      "screenshot",
+      { maxWidth: 1280, quality: 70, format: "jpeg", ...(params.tabId ? { tabId: params.tabId } : {}) },
+      30_000,
+    );
+    const capturedTabId = isObject(screenshotResult) && Number.isInteger(screenshotResult.tabId)
+      ? screenshotResult.tabId
+      : params.tabId;
+    const snapshotResult = await commandBridge.call(
+      "snapshot",
+      { scope: params.scope ?? null, ...(capturedTabId != null ? { tabId: capturedTabId } : {}) },
+      30_000,
+    );
+
+    if (!isObject(screenshotResult) || typeof screenshotResult.dataUrl !== "string") {
+      throw new FriendlyError("Extension did not return screenshot data.");
+    }
+    if (!isObject(snapshotResult) || typeof snapshotResult.snapshot !== "string") {
+      throw new FriendlyError("Extension did not return snapshot data.");
+    }
+
+    const apiKey = await loadApiKey();
+    const model = params.model || DEFAULT_ORACLE_MODEL;
+    const userText = params.question
+      ? `Accessibility tree:\n${snapshotResult.snapshot}\n\nQuestion:\n${params.question}`
+      : `Accessibility tree:\n${snapshotResult.snapshot}`;
+
+    const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+      method: "POST",
+      signal: AbortSignal.timeout(OPENROUTER_TIMEOUT_MS),
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: params.prompt },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: userText },
+              { type: "image_url", image_url: { url: screenshotResult.dataUrl } },
+            ],
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const details = (await response.text().catch(() => "")).slice(0, 500);
+      throw new FriendlyError(`OpenRouter request failed (${response.status} ${response.statusText})${details ? `: ${details}` : ""}`);
+    }
+
+    const payload = (await response.json()) as unknown;
+    return extractChatText(payload);
+  } catch (error) {
+    if (error instanceof FriendlyError) {
+      throw error;
+    }
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new FriendlyError(`OpenRouter request timed out after ${OPENROUTER_TIMEOUT_MS / 1000}s.`);
+    }
+    if (error instanceof TypeError) {
+      throw new FriendlyError(`Oracle request failed (network error: ${error.message}). Check connectivity and OPENROUTER_API_KEY.`);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new FriendlyError(`Oracle failed unexpectedly: ${message}`);
+  }
+}
+
+async function closeResources() {
+  await bridge?.close().catch(() => undefined);
+  bridge = null;
+}
+
+async function shutdown() {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  await closeResources();
+
+  if (server) {
+    await new Promise<void>((resolve) => {
+      server?.close(() => resolve());
+    });
+  }
+
+  if (ownsSocket) {
+    await fs.rm(SOCKET_PATH, { force: true }).catch(() => undefined);
+    ownsSocket = false;
+  }
+}
+
+async function parseJsonBody(request: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const payload = Buffer.concat(chunks).toString("utf8");
+  return payload ? JSON.parse(payload) : {};
+}
+
+export async function runCommand(
+  body: CommandRequest,
+  commandBridge: CommandBridge,
+  oracleRunner: OracleRunner = runOracle,
+): Promise<unknown> {
+  const { command, args, options } = body;
+  const validationIssue = validateCommandInput(command, args, options);
+  if (validationIssue) {
+    throw new FriendlyError(validationIssue);
+  }
+
+  switch (command) {
+    case "open": {
+      const [url] = args;
+      if (!url) {
+        throw new FriendlyError('Missing required argument <url>. Try: browser open "https://example.com"');
+      }
+      const wait = typeof options.wait === "string" ? options.wait : undefined;
+      return commandBridge.call("open", {
+        url,
+        wait,
+        newTab: Boolean(options.new || options.window),
+        newWindow: Boolean(options.window),
+        noDelay: Boolean(options.noDelay),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "tabs": {
+      return commandBridge.call("tabs", {});
+    }
+
+    case "focus": {
+      if (!args[0]) {
+        throw new FriendlyError('Missing required argument <alias>. Try: browser focus t0');
+      }
+      return commandBridge.call("focus", { alias: args[0] });
+    }
+
+    case "close": {
+      if (!args[0]) {
+        throw new FriendlyError('Missing required argument <alias>. Try: browser close t0');
+      }
+      return commandBridge.call("close", { alias: args[0] });
+    }
+
+    case "close-idle": {
+      const hours = parseNumberOption(options.hours, 0);
+      if (hours <= 0) {
+        throw new FriendlyError("--hours must be greater than zero.");
+      }
+      return commandBridge.call("close-idle", { hours, dryRun: Boolean(options.dryRun) }, CLOSE_IDLE_TIMEOUT_MS);
+    }
+
+    case "click": {
+      const [target] = args;
+      if (!target) {
+        throw new FriendlyError('Missing required argument <target>. Try: browser click "More"');
+      }
+      const index = parseNumberOption(options.index, 0);
+      return commandBridge.call("click", {
+        target,
+        index,
+        text: Boolean(options.text),
+        coords: Boolean(options.coords),
+        noDelay: Boolean(options.noDelay),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "type": {
+      const [target, text] = args;
+      if (!target || typeof text !== "string") {
+        throw new FriendlyError('Missing required arguments <target> <text>. Try: browser type "Search" "browser CLI"');
+      }
+      const index = parseNumberOption(options.index, 0);
+      return commandBridge.call("type", { target, text, index, noDelay: Boolean(options.noDelay), ...buildTabParams(options) });
+    }
+
+    case "fill": {
+      const [target, text = ""] = args;
+      if (!target) {
+        throw new FriendlyError('Missing required argument <target>. Try: browser fill "Description" "New text"');
+      }
+      const clear = Boolean(options.clear);
+      if (!clear && typeof text !== "string") {
+        throw new FriendlyError('Missing required argument <text>. Try: browser fill "Description" "New text"');
+      }
+      const index = parseNumberOption(options.index, 0);
+      return commandBridge.call("fill", {
+        target,
+        text,
+        index,
+        clear,
+        append: Boolean(options.append),
+        noDelay: Boolean(options.noDelay),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "upload": {
+      const [target, requestedPath] = args;
+      if (!target || !requestedPath) {
+        throw new FriendlyError('Missing required arguments <target> <filepath>. Try: browser upload "input[type=file]" /path/to/file');
+      }
+
+      const resolvedPath = path.resolve(requestedPath);
+      try {
+        await fs.access(resolvedPath);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new FriendlyError(`File does not exist or is not readable: ${resolvedPath} (${message})`);
+      }
+
+      return commandBridge.call("upload", { target, filepath: resolvedPath, noDelay: Boolean(options.noDelay), ...buildTabParams(options) });
+    }
+
+    case "wait": {
+      const [selector] = args;
+      const timeout = parseNumberOption(options.timeout, 15_000);
+      const delayMaximum =
+        typeof options.ms === "string"
+          ? Number(options.ms.includes("-") ? options.ms.split("-")[1] : options.ms)
+          : 0;
+      const bridgeTimeout = Math.max(timeout, delayMaximum) + BRIDGE_TIMEOUT_GRACE_MS;
+      return commandBridge.call("wait", {
+        selector: selector ?? null,
+        text: typeof options.text === "string" ? options.text : null,
+        gone: typeof options.gone === "string" ? options.gone : null,
+        stable: typeof options.stable === "string" ? options.stable : null,
+        ms: typeof options.ms === "string" ? options.ms : null,
+        timeout,
+        ...buildTabParams(options),
+      }, bridgeTimeout);
+    }
+
+    case "snapshot": {
+      return commandBridge.call("snapshot", {
+        scope: typeof options.scope === "string" ? options.scope : null,
+        depth: parseNumberOption(options.depth, -1),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "diff": {
+      return commandBridge.call("diff", {
+        scope: typeof options.scope === "string" ? options.scope : null,
+        depth: parseNumberOption(options.depth, -1),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "inspect": {
+      return commandBridge.call("inspect", {
+        scope: typeof options.scope === "string" ? options.scope : null,
+        all: Boolean(options.all),
+        coords: Boolean(options.coords),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "describe": {
+      return oracleRunner({
+        prompt: DESCRIBE_SYSTEM_PROMPT,
+        scope: typeof options.scope === "string" ? options.scope : undefined,
+        model: typeof options.model === "string" ? options.model : undefined,
+        tabId: typeof options.tab === "string" ? options.tab : undefined,
+      }, commandBridge);
+    }
+
+    case "ask": {
+      const [question] = args;
+      if (!question) {
+        throw new FriendlyError('Missing required argument <question>. Try: browser ask "what error message is showing?"');
+      }
+      return oracleRunner({
+        prompt: ASK_SYSTEM_PROMPT,
+        question,
+        scope: typeof options.scope === "string" ? options.scope : undefined,
+        model: typeof options.model === "string" ? options.model : undefined,
+        tabId: typeof options.tab === "string" ? options.tab : undefined,
+      }, commandBridge);
+    }
+
+    case "extract": {
+      const [selector] = args;
+      return commandBridge.call("extract", {
+        selector: selector ?? null,
+        scope: typeof options.scope === "string" ? options.scope : null,
+        json: Boolean(options.json),
+        limit: parseNumberOption(options.limit, DEFAULT_EXTRACT_LIMIT),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "screenshot": {
+      const [requestedPath] = args;
+      const targetPath = requestedPath ? path.resolve(requestedPath) : path.resolve(process.cwd(), "screenshot.png");
+      if (!targetPath.endsWith(".png")) {
+        throw new FriendlyError(`Screenshot path must end with .png. Try: browser screenshot ${targetPath}.png`);
+      }
+
+      const result = await commandBridge.call("screenshot", buildTabParams(options));
+      if (!isObject(result) || typeof result.dataUrl !== "string") {
+        throw new FriendlyError("Extension did not return screenshot data.");
+      }
+
+      const base64 = result.dataUrl.replace(/^data:image\/png;base64,/, "");
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, Buffer.from(base64, "base64"));
+      const mode = parseString(result.mode, "viewport");
+      const warning = parseString(result.warning);
+      const warningSuffix = warning ? ` (${warning})` : "";
+      return `Saved ${mode} screenshot to ${targetPath}${warningSuffix}`;
+    }
+
+    case "html": {
+      const [selector] = args;
+      return commandBridge.call("html", {
+        selector: selector ?? null,
+        limit: parseNumberOption(options.limit, DEFAULT_HTML_LIMIT),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "eval": {
+      const expression = args.join(" ").trim();
+      if (!expression) {
+        throw new FriendlyError('Missing required argument <js>. Try: browser eval "document.title"');
+      }
+      return commandBridge.call("eval", { expression, ...buildTabParams(options) });
+    }
+
+    case "dialog": {
+      return commandBridge.call("dialog", {
+        accept: options.accept,
+        dismiss: Boolean(options.dismiss),
+        ...buildTabParams(options),
+      });
+    }
+
+    case "status": {
+      try {
+        const status = await commandBridge.call("status", buildTabParams(options));
+        if (isObject(status)) {
+          return {
+            ...status,
+            uptimeMs: Date.now() - state.startedAt,
+            extensionConnected: commandBridge.getStatus().connected,
+          };
+        }
+      } catch (error) {
+        if (typeof options.tab === "string" && options.tab.trim()) {
+          throw error;
+        }
+        return {
+          message:
+            error instanceof Error
+              ? error.message
+              : "Chrome extension bridge is disconnected. Load the extension from src/browser/extension.",
+          url: "about:blank",
+          title: "",
+          uptimeMs: Date.now() - state.startedAt,
+          extensionConnected: commandBridge.getStatus().connected,
+        };
+      }
+      return {
+        url: "about:blank",
+        title: "",
+        uptimeMs: Date.now() - state.startedAt,
+        extensionConnected: commandBridge.getStatus().connected,
+      };
+    }
+
+    case "stop": {
+      const location = await getCurrentLocation(commandBridge);
+      return {
+        message: "Browser server stopping.",
+        ...location,
+        uptimeMs: Date.now() - state.startedAt,
+        extensionConnected: commandBridge.getStatus().connected,
+        shouldStop: true,
+      };
+    }
+
+    default:
+      throw new FriendlyError("Unknown command. Try: browser help");
+  }
+}
+
+export type CommandExecutor = (body: CommandRequest, signal?: AbortSignal) => Promise<CommandResponse>;
+
+async function executeCommand(body: CommandRequest, signal?: AbortSignal): Promise<CommandResponse> {
+  const started = Date.now();
+  const commandBridge = requireBridge();
+  const scopedBridge: CommandBridge = {
+    getStatus: () => commandBridge.getStatus(),
+    call: (action, params, timeoutMs) => commandBridge.call(action, params, timeoutMs, signal),
+  };
+
+  try {
+    const data = await runCommand(body, scopedBridge);
+    const shouldStop = isObject(data) && Boolean(data.shouldStop);
+    const responseData =
+      shouldStop && isObject(data) ? Object.fromEntries(Object.entries(data).filter(([key]) => key !== "shouldStop")) : data;
+
+    const location = extractLocation(responseData) ?? (signal?.aborted ? { url: "about:blank", title: "" } : await getCurrentLocation(commandBridge));
+    const response: CommandResponse = {
+      ok: true,
+      data: responseData,
+      url: location.url,
+      title: location.title,
+      elapsed: Date.now() - started,
+    };
+
+    if (shouldStop) {
+      setTimeout(() => {
+        void shutdown().finally(() => process.exit(0));
+      }, 50);
+    }
+
+    return response;
+  } catch (error) {
+    const location = signal?.aborted ? { url: "about:blank", title: "" } : await getCurrentLocation(commandBridge);
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      url: location.url,
+      title: location.title,
+      elapsed: Date.now() - started,
+    };
+  }
+}
+
+function writeJson(response: http.ServerResponse, statusCode: number, body: unknown) {
+  response.writeHead(statusCode, { "content-type": "application/json; charset=utf-8" });
+  response.end(JSON.stringify(body));
+}
+
+function writeCommandError(response: http.ServerResponse, statusCode: number, error: string) {
+  writeJson(response, statusCode, {
+    ok: false,
+    error,
+    url: "about:blank",
+    title: "",
+    elapsed: 0,
+  } satisfies CommandResponse);
+}
+
+async function requestHandler(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  commandExecutor: CommandExecutor,
+) {
+  if (request.method === "GET" && request.url === "/health") {
+    writeJson(response, 200, {
+      service: "browser-cli",
+      ok: bridge !== null,
+      uptimeMs: Date.now() - state.startedAt,
+      extensionConnected: bridge?.getStatus().connected ?? false,
+    });
+    return;
+  }
+
+  if (request.method === "POST" && request.url === "/command") {
+    // This endpoint may be reachable over loopback when Unix sockets are not
+    // available. Reject browser-origin and simple/no-CORS requests before
+    // consuming their bodies; CORS response headers are not a security check.
+    if (request.headers.origin !== undefined) {
+      writeCommandError(response, 403, "Browser-origin command requests are forbidden.");
+      return;
+    }
+
+    const contentType = request.headers["content-type"];
+    const mediaType = typeof contentType === "string" ? contentType.split(";", 1)[0]?.trim().toLowerCase() : "";
+    if (mediaType !== "application/json") {
+      writeCommandError(response, 415, "Command requests require Content-Type: application/json.");
+      return;
+    }
+
+    const cancellation = new AbortController();
+    request.once("aborted", () => cancellation.abort());
+    response.once("close", () => {
+      if (!response.writableEnded) cancellation.abort();
+    });
+    try {
+      const body = (await parseJsonBody(request)) as CommandRequest;
+      if (!body?.command || !COMMAND_NAMES.has(body.command)) {
+        throw new FriendlyError("Invalid command payload. Try: browser help");
+      }
+      const result = await commandExecutor(body, cancellation.signal);
+      writeJson(response, 200, result);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeCommandError(response, 400, message);
+      return;
+    }
+  }
+
+  writeJson(response, 404, { ok: false, error: "Not found" });
+}
+
+export function createRequestHandler(commandExecutor: CommandExecutor = executeCommand): http.RequestListener {
+  return (request, response) => {
+    void requestHandler(request, response, commandExecutor);
+  };
+}
+
+export async function startServer(): Promise<boolean> {
+  if (server || bridge) {
+    throw new Error("Browser server is already running in this process.");
+  }
+
+  const candidateServer = http.createServer(createRequestHandler());
+  const listener = await listenForCommands(candidateServer, {
+    socketPath: SOCKET_PATH,
+    fallbackPort: FALLBACK_PORT,
+  });
+  if (listener.transport === "existing") {
+    return false;
+  }
+
+  server = candidateServer;
+  ownsSocket = listener.ownsSocket;
+  if (ownsSocket) {
+    await fs.chmod(SOCKET_PATH, 0o600).catch(() => undefined);
+  }
+
+  const candidateBridge = new ExtensionBridge();
+  try {
+    await candidateBridge.ready();
+    bridge = candidateBridge;
+  } catch (error) {
+    await candidateBridge.close().catch(() => undefined);
+    await new Promise<void>((resolve) => candidateServer.close(() => resolve()));
+    server = null;
+    if (ownsSocket) {
+      await fs.rm(SOCKET_PATH, { force: true }).catch(() => undefined);
+      ownsSocket = false;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new FriendlyError(`Cannot start extension bridge on 127.0.0.1:${BRIDGE_WS_PORT}: ${message}`);
+  }
+  return true;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void startServer().catch((error) => {
+    process.stderr.write(`[browser-server] ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+  process.on("SIGINT", () => {
+    void shutdown().finally(() => process.exit(0));
+  });
+  process.on("SIGTERM", () => {
+    void shutdown().finally(() => process.exit(0));
+  });
+}

--- a/src/browser/test/bridge.test.ts
+++ b/src/browser/test/bridge.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import { test } from "node:test";
+import { WebSocket } from "ws";
+import { ExtensionBridge } from "../src/lib/bridge.js";
+
+async function unusedPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+function openSocket(port: number, origin = "chrome-extension://test-extension"): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${port}`, { origin });
+    socket.once("open", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function closeSocket(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.CLOSED) return Promise.resolve();
+  return new Promise((resolve) => {
+    socket.once("close", () => resolve());
+    socket.close();
+  });
+}
+
+test("bridge promotes only a valid extension hello and ignores unauthenticated replacements", async () => {
+  const port = await unusedPort();
+  const bridge = new ExtensionBridge({ port, handshakeTimeoutMs: 100 });
+  await bridge.ready();
+  const first = await openSocket(port);
+  const candidate = await openSocket(port);
+
+  try {
+    assert.equal(bridge.getStatus().connected, false);
+    first.send(JSON.stringify({ type: "hello", source: "browser-cli-v2-extension" }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(bridge.getStatus().connected, true);
+
+    await new Promise((resolve) => setTimeout(resolve, 130));
+    assert.equal(candidate.readyState, WebSocket.CLOSED);
+    assert.equal(bridge.getStatus().connected, true, "timed-out candidate must not replace the real extension");
+
+    first.once("message", (raw) => {
+      const request = JSON.parse(raw.toString()) as { id: string };
+      first.send(JSON.stringify({ id: request.id, ok: true, data: "ok" }));
+    });
+    assert.equal(await bridge.call("tabs", {}, 500), "ok");
+  } finally {
+    await Promise.all([closeSocket(first), closeSocket(candidate)]);
+    await bridge.close();
+  }
+});
+
+test("aborting a bridge call sends extension cancellation immediately", async () => {
+  const port = await unusedPort();
+  const bridge = new ExtensionBridge({ port });
+  await bridge.ready();
+  const extension = await openSocket(port);
+  extension.send(JSON.stringify({ type: "hello", source: "browser-cli-v2-extension" }));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const cancellationSeen = new Promise<{ type: string; id: string }>((resolve) => {
+    extension.on("message", (raw) => {
+      const payload = JSON.parse(raw.toString()) as { type?: string; id: string };
+      if (payload.type === "cancel") resolve({ type: payload.type, id: payload.id });
+    });
+  });
+  const controller = new AbortController();
+  const call = bridge.call("wait", {}, 10_000, controller.signal);
+  controller.abort();
+  try {
+    await assert.rejects(call, /cancelled/);
+    assert.equal((await cancellationSeen).type, "cancel");
+  } finally {
+    await closeSocket(extension);
+    await bridge.close();
+  }
+});
+
+test("fixed bridge-port conflicts reject cleanly", async () => {
+  const port = await unusedPort();
+  const winner = new ExtensionBridge({ port });
+  await winner.ready();
+  const loser = new ExtensionBridge({ port });
+  try {
+    await assert.rejects(loser.ready(), (error: NodeJS.ErrnoException) => error.code === "EADDRINUSE");
+  } finally {
+    await loser.close();
+    await winner.close();
+  }
+});
+
+test("bridge rejects normal web-page websocket origins", async () => {
+  const port = await unusedPort();
+  const bridge = new ExtensionBridge({ port });
+  await bridge.ready();
+  try {
+    await assert.rejects(openSocket(port, "https://example.test"), /403|Unexpected server response/);
+    assert.equal(bridge.getStatus().connected, false);
+  } finally {
+    await bridge.close();
+  }
+});

--- a/src/browser/test/browser-boundaries.test.js
+++ b/src/browser/test/browser-boundaries.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  assertManagedTabRegistered,
+  captureTargetViaCdp,
+  resolveManagedTabIdentifier,
+} from "../extension/browser-boundaries.js";
+
+const managed = [
+  { tabId: 41, alias: "t0" },
+  { tabId: 99, alias: "123" },
+];
+
+test("tab resolution never treats numeric strings as raw Chrome tab ids", () => {
+  assert.equal(resolveManagedTabIdentifier(managed, 41, { tabId: "t0" }), 41);
+  assert.equal(resolveManagedTabIdentifier(managed, 41, { tabId: "123" }), 99, "an exact registered alias remains valid");
+  assert.throws(() => resolveManagedTabIdentifier(managed, 41, { tabId: "41" }), /Unknown managed tab alias/);
+  assert.throws(() => resolveManagedTabIdentifier(managed, 41, { alias: "99" }), /Unknown managed tab alias/);
+});
+
+test("raw integer ids must already be registered", () => {
+  assert.equal(resolveManagedTabIdentifier(managed, 41, { tabId: 41 }), 41);
+  assert.equal(assertManagedTabRegistered(managed, 99), 99);
+  assert.throws(() => resolveManagedTabIdentifier(managed, 41, { tabId: 777 }), /Unknown managed tab id/);
+  assert.throws(() => assertManagedTabRegistered(managed, 777), /not a registered managed tab/);
+});
+
+test("compressed screenshots use only target-specific CDP viewport capture", async () => {
+  const calls = [];
+  const result = await captureTargetViaCdp({
+    tabId: 41,
+    fullPage: false,
+    format: "jpeg",
+    quality: 70,
+    captureFullPage: async () => {
+      throw new Error("full-page must not run");
+    },
+    captureViewport: async (...args) => {
+      calls.push(args);
+      return "data:image/jpeg;base64,target";
+    },
+  });
+
+  assert.deepEqual(calls, [[41, "jpeg", 70]]);
+  assert.deepEqual(result, { dataUrl: "data:image/jpeg;base64,target", mode: "viewport" });
+});
+
+test("full-page CDP failure falls back to the same target's CDP viewport", async () => {
+  const calls = [];
+  const result = await captureTargetViaCdp({
+    tabId: 99,
+    fullPage: true,
+    captureFullPage: async (tabId) => {
+      calls.push(["full", tabId]);
+      throw new Error("layout too large");
+    },
+    captureViewport: async (tabId, format) => {
+      calls.push(["viewport", tabId, format]);
+      return "data:image/png;base64,target";
+    },
+  });
+
+  assert.deepEqual(calls, [["full", 99], ["viewport", 99, "png"]]);
+  assert.equal(result.dataUrl, "data:image/png;base64,target");
+  assert.equal(result.mode, "viewport");
+  assert.match(result.warning, /layout too large/);
+});
+
+test("CDP screenshot failure reports both full-page and viewport errors", async () => {
+  await assert.rejects(
+    captureTargetViaCdp({
+      tabId: 41,
+      fullPage: true,
+      captureFullPage: async () => {
+        throw new Error("full failure");
+      },
+      captureViewport: async () => {
+        throw new Error("viewport failure");
+      },
+    }),
+    (error) => {
+      assert.match(error.message, /full-page CDP capture failed \(full failure\)/);
+      assert.match(error.message, /target-specific CDP viewport capture failed \(viewport failure\)/);
+      return true;
+    },
+  );
+});

--- a/src/browser/test/close-idle.test.js
+++ b/src/browser/test/close-idle.test.js
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { assertValidIdleHours, closeIdleTabs } from "../extension/close-idle.js";
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 2_000_000_000_000;
+
+function oldTab(id, overrides = {}) {
+  return {
+    id,
+    windowId: 1,
+    url: `https://example.com/${id}`,
+    title: `Tab ${id}`,
+    active: false,
+    pinned: false,
+    audible: false,
+    lastAccessed: NOW - 10 * HOUR,
+    ...overrides,
+  };
+}
+
+describe("close-idle safety", () => {
+  test("requires positive safe-integer hours at the extension boundary", () => {
+    for (const value of [1, 6, Number.MAX_SAFE_INTEGER]) {
+      assert.doesNotThrow(() => assertValidIdleHours(value));
+    }
+    for (const value of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, "6", null]) {
+      assert.throws(() => assertValidIdleHours(value), /positive safe integer/);
+    }
+  });
+
+  test("selects globally but skips protected tabs and revalidates every candidate", async () => {
+    const normalTabs = [
+      oldTab(1, { active: true }),
+      oldTab(2, { pinned: true }),
+      oldTab(3, { audible: true }),
+      oldTab(4, { lastAccessed: undefined }),
+      oldTab(5, { lastAccessed: NOW - HOUR }),
+      oldTab(6),
+      oldTab(7),
+      oldTab(8),
+      oldTab(9),
+      oldTab(10),
+      oldTab(11),
+    ];
+    const popupTab = oldTab(13, { windowId: 3 });
+    const byId = new Map(normalTabs.map((tab) => [tab.id, tab]));
+    const removed = [];
+    const revalidated = [];
+
+    const chromeApi = {
+      windows: {
+        async getAll(options) {
+          assert.deepEqual(options, { populate: true });
+          return [
+            { id: 1, type: "normal", tabs: normalTabs },
+            { id: 3, type: "popup", tabs: [popupTab] },
+          ];
+        },
+        async get(windowId, options) {
+          assert.deepEqual(options, { populate: false });
+          return { id: windowId, type: windowId === 2 ? "popup" : "normal" };
+        },
+      },
+      tabs: {
+        async get(id) {
+          revalidated.push(id);
+          if (id === 8) throw new Error(`No tab with id: ${id}`);
+          if (id === 10) throw new Error("tabs permission temporarily unavailable");
+          const tab = { ...byId.get(id) };
+          if (id === 7) tab.active = true;
+          if (id === 11) tab.windowId = 2;
+          return tab;
+        },
+        async remove(id) {
+          if (id === 9) throw new Error("Chrome refused removal");
+          removed.push(id);
+        },
+      },
+    };
+
+    const result = await closeIdleTabs({ chromeApi, hours: 6, now: () => NOW });
+
+    assert.deepEqual(revalidated, [6, 6, 7, 7, 8, 9, 9, 10, 11, 11]);
+    assert.deepEqual(removed, [6]);
+    assert.deepEqual(result.closed.map((tab) => tab.id), [6]);
+    assert.deepEqual(result.eligible.map((tab) => tab.id), [6, 9]);
+    assert.equal(result.eligibleCount, 2);
+    assert.equal(result.closedCount, 1);
+    assert.equal(result.skippedCount, 9);
+    assert.equal(result.failedCount, 2);
+    assert.deepEqual(
+      new Map(result.skipped.map((tab) => [tab.id, tab.reason])),
+      new Map([
+        [1, "active"],
+        [2, "pinned"],
+        [3, "audible"],
+        [4, "missing-last-accessed"],
+        [5, "not-idle"],
+        [7, "revalidated-active"],
+        [8, "vanished"],
+        [11, "revalidated-non-normal-window"],
+        [13, "non-normal-window"],
+      ]),
+    );
+    assert.deepEqual(result.failed.map(({ id, stage }) => [id, stage]), [[9, "close"], [10, "revalidate"]]);
+  });
+
+  test("uses a final tab fetch after windows.get to catch protection changes and moves", async () => {
+    const tabs = [oldTab(40), oldTab(41), oldTab(42), oldTab(43)];
+    const byId = new Map(tabs.map((tab) => [tab.id, { ...tab }]));
+    const finalStates = new Map([
+      [40, { active: true }],
+      [41, { pinned: true }],
+      [42, { audible: true }],
+      [43, { windowId: 2 }],
+    ]);
+    const fetchCounts = new Map();
+    const removed = [];
+    const chromeApi = {
+      windows: {
+        getAll: async () => [{ id: 1, type: "normal", tabs }],
+        get: async (windowId) => {
+          assert.equal(windowId, 1);
+          // Model the state changing while the asynchronous window lookup is
+          // pending. Only the subsequent tabs.get can observe this state.
+          await Promise.resolve();
+          return { id: 1, type: "normal" };
+        },
+      },
+      tabs: {
+        get: async (id) => {
+          const count = (fetchCounts.get(id) || 0) + 1;
+          fetchCounts.set(id, count);
+          return count === 1 ? { ...byId.get(id) } : { ...byId.get(id), ...finalStates.get(id) };
+        },
+        remove: async (id) => removed.push(id),
+      },
+    };
+
+    const result = await closeIdleTabs({ chromeApi, hours: 6, now: () => NOW });
+
+    assert.deepEqual(removed, []);
+    assert.deepEqual(Array.from(fetchCounts.entries()), [[40, 2], [41, 2], [42, 2], [43, 2]]);
+    assert.deepEqual(
+      new Map(result.skipped.map(({ id, reason }) => [id, reason])),
+      new Map([
+        [40, "revalidated-active"],
+        [41, "revalidated-pinned"],
+        [42, "revalidated-audible"],
+        [43, "revalidated-window-changed"],
+      ]),
+    );
+    assert.equal(result.eligibleCount, 0);
+    assert.equal(result.failedCount, 0);
+  });
+
+  test("dry-run revalidates and reports without removing anything", async () => {
+    const tab = oldTab(20);
+    let removeCalls = 0;
+    const chromeApi = {
+      windows: {
+        getAll: async () => [{ id: 1, type: "normal", tabs: [tab] }],
+        get: async () => ({ id: 1, type: "normal" }),
+      },
+      tabs: {
+        get: async () => ({ ...tab }),
+        remove: async () => {
+          removeCalls += 1;
+        },
+      },
+    };
+
+    const result = await closeIdleTabs({ chromeApi, hours: 6, dryRun: true, now: () => NOW });
+    assert.equal(removeCalls, 0);
+    assert.equal(result.dryRun, true);
+    assert.equal(result.eligibleCount, 1);
+    assert.equal(result.closedCount, 0);
+    assert.deepEqual(result.eligible.map(({ id }) => id), [20]);
+  });
+
+  test("cancellation is checked again immediately before destructive removal", async () => {
+    const tab = oldTab(25);
+    let checks = 0;
+    let removeCalls = 0;
+    const chromeApi = {
+      windows: {
+        getAll: async () => [{ id: 1, type: "normal", tabs: [tab] }],
+        get: async () => ({ id: 1, type: "normal" }),
+      },
+      tabs: {
+        get: async () => ({ ...tab }),
+        remove: async () => {
+          removeCalls += 1;
+        },
+      },
+    };
+
+    const result = await closeIdleTabs({
+      chromeApi,
+      hours: 1,
+      now: () => NOW,
+      shouldContinue: () => {
+        checks += 1;
+        return checks < 3;
+      },
+    });
+    assert.equal(result.eligibleCount, 1);
+    assert.equal(removeCalls, 0);
+  });
+
+  test("a tab that vanishes during removal does not abort later candidates", async () => {
+    const tabs = [oldTab(30), oldTab(31)];
+    const removed = [];
+    const chromeApi = {
+      windows: {
+        getAll: async () => [{ id: 1, type: "normal", tabs }],
+        get: async () => ({ id: 1, type: "normal" }),
+      },
+      tabs: {
+        get: async (id) => ({ ...tabs.find((tab) => tab.id === id) }),
+        remove: async (id) => {
+          if (id === 30) throw new Error("No tab with id: 30");
+          removed.push(id);
+        },
+      },
+    };
+
+    const result = await closeIdleTabs({ chromeApi, hours: 1, now: () => NOW });
+    assert.deepEqual(removed, [31]);
+    assert.deepEqual(result.closed.map(({ id }) => id), [31]);
+    assert.equal(result.skipped.find(({ id }) => id === 30)?.reason, "vanished-before-close");
+    assert.equal(result.failedCount, 0);
+  });
+});

--- a/src/browser/test/format.test.ts
+++ b/src/browser/test/format.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { formatError, formatMetadata, formatSuccess } from "../src/lib/format.js";
+
+test("metadata is stable and sanitizes elapsed time", () => {
+  assert.equal(formatMetadata(true, "https://example.com", 1.6), "[ok | url: https://example.com | 2ms]");
+  assert.equal(formatMetadata(false, "", -10), "[error | url: about:blank | 0ms]");
+});
+
+test("close-idle formatting distinguishes eligible, closed, skipped, and failed", () => {
+  const output = formatSuccess(
+    "close-idle",
+    {
+      dryRun: false,
+      hours: 6,
+      eligibleCount: 2,
+      closedCount: 1,
+      skippedCount: 3,
+      failedCount: 1,
+      eligible: [],
+      closed: [{ id: 1, idleHours: 9.5, title: "Old tab", url: "https://old.example" }],
+      skipped: [
+        { id: 2, reason: "pinned" },
+        { id: 3, reason: "active" },
+        { id: 4, reason: "active" },
+      ],
+      failed: [{ id: 5, title: "Failed tab", stage: "close", error: "denied" }],
+    },
+    "about:blank",
+    12,
+  );
+
+  assert.match(output, /^Eligible: 2 tab\(s\)/);
+  assert.match(output, /Closed: 1 tab\(s\)\./);
+  assert.match(output, /Skipped: 3 tab\(s\)\./);
+  assert.match(output, /Failed: 1 tab\(s\)\./);
+  assert.match(output, /Closed tabs:\n- 9\.5h — Old tab — https:\/\/old\.example/);
+  assert.match(output, /Skip reasons: pinned=1, active=2/);
+  assert.match(output, /Failure \(close\): Failed tab — denied/);
+  assert.match(output, /\[ok \| url: about:blank \| 12ms\]$/);
+});
+
+test("close-idle dry-run formatting explicitly says nothing was closed", () => {
+  const output = formatSuccess(
+    "close-idle",
+    {
+      dryRun: true,
+      hours: 12,
+      eligibleCount: 1,
+      closedCount: 0,
+      skippedCount: 0,
+      failedCount: 0,
+      eligible: [{ idleHours: 14, title: "Candidate", url: "https://candidate.example" }],
+      closed: [],
+      skipped: [],
+      failed: [],
+    },
+    "https://current.example",
+    2,
+  );
+  assert.match(output, /Dry run: no tabs were closed\./);
+  assert.match(output, /Eligible tabs:/);
+  assert.doesNotMatch(output, /Closed tabs:/);
+});
+
+test("tabs and errors render concise human-readable output", () => {
+  const tabs = formatSuccess(
+    "tabs",
+    [{ alias: "t0", url: "https://example.com", title: "Example", active: true }],
+    "https://example.com",
+    1,
+  );
+  assert.match(tabs, /^\* t0/);
+  assert.match(tabs, /"Example"/);
+
+  const error = formatError("bad input", "unavailable", 3);
+  assert.equal(error, "[error] bad input\n[error | url: unavailable | 3ms]");
+});
+
+test("long output is truncated to the configured line limit", () => {
+  const body = Array.from({ length: 205 }, (_, index) => `line ${index}`).join("\n");
+  const output = formatSuccess("extract", body, "about:blank", 1);
+  assert.match(output, /\[truncated: showing 200\/205 lines/);
+  assert.doesNotMatch(output, /line 204/);
+});

--- a/src/browser/test/listener.test.ts
+++ b/src/browser/test/listener.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { listenForCommands } from "../src/lib/listener.js";
+
+async function unusedPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+function commandServer(): http.Server {
+  return http.createServer((request, response) => {
+    if (request.url === "/health") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ service: "browser-cli", ok: true }));
+      return;
+    }
+    response.writeHead(404).end();
+  });
+}
+
+test("simultaneous cold starts converge on one Unix command listener", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-listener-"));
+  const socketPath = path.join(directory, "command.sock");
+  const fallbackPort = await unusedPort();
+  const first = commandServer();
+  const second = commandServer();
+
+  try {
+    const results = await Promise.all([
+      listenForCommands(first, { socketPath, fallbackPort }),
+      listenForCommands(second, { socketPath, fallbackPort }),
+    ]);
+    assert.deepEqual(results.map((result) => result.transport).sort(), ["existing", "socket"]);
+    assert.equal([first, second].filter((candidate) => candidate.listening).length, 1);
+  } finally {
+    await Promise.all(
+      [first, second].map((candidate) =>
+        candidate.listening ? new Promise<void>((resolve) => candidate.close(() => resolve())) : Promise.resolve(),
+      ),
+    );
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a live non-Browser service at the socket path is never unlinked", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-listener-"));
+  const socketPath = path.join(directory, "command.sock");
+  const fallbackPort = await unusedPort();
+  const occupant = http.createServer((_request, response) => response.writeHead(200).end("not browser"));
+  const candidate = commandServer();
+  await new Promise<void>((resolve, reject) => {
+    occupant.once("error", reject);
+    occupant.listen(socketPath, resolve);
+  });
+
+  try {
+    await assert.rejects(
+      listenForCommands(candidate, { socketPath, fallbackPort }),
+      /occupied by another live service/,
+    );
+    assert.equal(occupant.listening, true);
+    assert.equal((await fs.lstat(socketPath)).isSocket(), true);
+  } finally {
+    await new Promise<void>((resolve) => occupant.close(() => resolve()));
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});

--- a/src/browser/test/parse.test.ts
+++ b/src/browser/test/parse.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { parseCliInput, validateCommandInput } from "../src/lib/parse.js";
+import type { CommandName } from "../src/lib/types.js";
+
+function parseOk(argv: string[]) {
+  const parsed = parseCliInput(argv, "/tmp/browser-parse-test");
+  assert.equal(parsed.localOutput, undefined, parsed.localOutput?.text);
+  assert.ok(parsed.command);
+  return parsed;
+}
+
+function parseError(argv: string[], pattern: RegExp) {
+  const parsed = parseCliInput(argv);
+  assert.equal(parsed.localOutput?.ok, false);
+  assert.match(parsed.localOutput?.text ?? "", pattern);
+}
+
+describe("command-specific CLI parsing", () => {
+  const validCommands: Array<[CommandName, string[]]> = [
+    ["open", ["https://example.com", "--new", "--window", "--wait", "main", "--no-delay"]],
+    ["tabs", []],
+    ["focus", ["t0"]],
+    ["close", ["t0"]],
+    ["close-idle", ["--hours", "6", "--dry-run"]],
+    ["click", ["button", "--tab", "t0", "--index", "0", "--text", "--coords", "--no-delay"]],
+    ["type", ["input", "hello", "--tab", "t0", "--index", "1", "--no-delay"]],
+    ["fill", ["input", "hello", "--tab", "t0", "--append", "--index", "1", "--no-delay"]],
+    ["upload", ["input", "./file.txt", "--tab", "t0", "--no-delay"]],
+    ["wait", ["--text", "ready", "--tab", "t0", "--timeout", "1000"]],
+    ["snapshot", ["--tab", "t0", "--scope", "main", "--depth", "3"]],
+    ["diff", ["--tab", "t0", "--scope", "main", "--depth", "3"]],
+    ["inspect", ["--tab", "t0", "--scope", "main", "--all", "--coords"]],
+    ["describe", ["--tab", "t0", "--scope", "main", "--model", "model/name"]],
+    ["ask", ["what is visible?", "--tab", "t0", "--scope", "main", "--model", "model/name"]],
+    ["extract", ["a", "--tab", "t0", "--scope", "main", "--json", "--limit", "5"]],
+    ["screenshot", ["./shot.png", "--tab", "t0"]],
+    ["html", ["main", "--tab", "t0", "--limit", "80"]],
+    ["eval", ["document.title", "--tab", "t0"]],
+    ["dialog", ["--tab", "t0", "--accept", "yes"]],
+    ["status", ["--tab", "t0"]],
+    ["stop", []],
+  ];
+
+  for (const [command, argv] of validCommands) {
+    test(`accepts the documented ${command} form`, () => {
+      const parsed = parseOk([command, ...argv]);
+      assert.equal(parsed.command, command);
+    });
+  }
+
+  test("normalizes paths and --window semantics", () => {
+    const upload = parseOk(["upload", "input", "relative.txt"]);
+    assert.equal(upload.args[1], "/tmp/browser-parse-test/relative.txt");
+
+    const screenshot = parseOk(["screenshot", "shot.png"]);
+    assert.equal(screenshot.args[0], "/tmp/browser-parse-test/shot.png");
+
+    const open = parseOk(["open", "example.com", "--window"]);
+    assert.deepEqual(open.options, { window: true, new: true });
+    assert.deepEqual(parseOk(["open", "example.com", "--tab", "t0"]).options, { tab: "t0" });
+  });
+
+  test("supports all wait modes and fill --clear", () => {
+    for (const argv of [["wait", "main"], ["wait", "--gone", ".spinner"], ["wait", "--stable", "main"], ["wait", "--ms", "10-20"]]) {
+      parseOk(argv);
+    }
+    parseOk(["fill", "input", "--clear"]);
+    parseOk(["dialog", "--accept"]);
+    parseOk(["dialog", "--dismiss"]);
+  });
+
+  test("rejects unsupported options per command, including --tab on global cleanup", () => {
+    parseError(["close-idle", "--hours", "6", "--tab", "t0"], /Unsupported option "--tab"/);
+    parseError(["tabs", "--json"], /Unsupported option "--json"/);
+    parseError(["click", "button", "--dry-run"], /Unsupported option "--dry-run"/);
+    parseError(["status", "--all"], /Unsupported option "--all"/);
+  });
+
+  test("rejects surplus positional arguments rather than ignoring them", () => {
+    parseError(["tabs", "extra"], /Too many positional arguments/);
+    parseError(["focus", "t0", "extra"], /Too many positional arguments/);
+    parseError(["click", "one", "two"], /Too many positional arguments/);
+    parseError(["ask", "unquoted", "question"], /Too many positional arguments/);
+    parseError(["status", "extra"], /Too many positional arguments/);
+  });
+
+  test("rejects duplicate and ambiguous options", () => {
+    parseError(["click", "button", "--index", "1", "--index", "2"], /only be specified once/);
+    parseError(["dialog", "--accept", "--dismiss"], /either --accept or --dismiss/);
+    parseError(["fill", "input", "text", "--clear"], /Do not provide <text>/);
+    parseError(["fill", "input", "text", "--clear", "--append"], /either --clear or --append/);
+    parseError(["wait", "main", "--text", "ready"], /exactly one wait condition/);
+    parseError(["wait"], /exactly one wait condition/);
+    parseError(["open", "example.com", "--window", "--tab", "t0"], /cannot be combined/);
+  });
+
+  test("does not let --help hide invalid trailing input", () => {
+    parseError(["click", "button", "--help"], /--help must be used by itself/);
+    parseError(["help", "click"], /Help does not accept arguments/);
+    assert.equal(parseCliInput(["click", "--help"]).localOutput?.ok, true);
+  });
+});
+
+describe("strict numeric parsing", () => {
+  test("accepts positive safe-integer hours", () => {
+    assert.equal(parseOk(["close-idle", "--hours", "1"]).options.hours, 1);
+    assert.equal(parseOk(["close-idle", "--hours", String(Number.MAX_SAFE_INTEGER)]).options.hours, Number.MAX_SAFE_INTEGER);
+  });
+
+  test("rejects malformed, non-positive, fractional, and unsafe hours", () => {
+    for (const value of ["", "0", "-1", "1.5", "6hours", "+6", " 6", "9007199254740992", "Infinity", "1e3"]) {
+      parseError(["close-idle", "--hours", value], /(?:requires a value|positive whole number|safe integer)/);
+    }
+  });
+
+  test("applies strict integer parsing to other integer options", () => {
+    parseError(["click", "button", "--index", "2x"], /non-negative whole number/);
+    parseError(["extract", "--limit", "1.5"], /positive whole number/);
+    parseError(["wait", "--ms", "1", "--timeout", "10ms"], /non-negative whole number/);
+    parseError(["snapshot", "--depth", "-1"], /non-negative whole number/);
+    parseError(["wait", "--ms", "20-10"], /maximum must be greater/);
+    parseError(["wait", "--ms", "1x"], /Invalid --ms/);
+    parseError(["wait", "--ms", "2147000001"], /must not exceed/);
+    parseError(["wait", "--text", "ready", "--timeout", "2147000001"], /must not exceed/);
+  });
+});
+
+test("direct command requests receive the same option and argument validation", () => {
+  assert.match(validateCommandInput("close-idle", [], { hours: 1, tab: "t0" }) ?? "", /Unsupported option/);
+  assert.match(validateCommandInput("close-idle", [], { hours: 1.5 }) ?? "", /Invalid value/);
+  assert.match(validateCommandInput("tabs", ["extra"], {}) ?? "", /Too many positional/);
+  assert.equal(validateCommandInput("close-idle", [], { hours: 1, dryRun: true }), null);
+});

--- a/src/browser/test/runtime-state.test.js
+++ b/src/browser/test/runtime-state.test.js
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { SerialTaskQueue, SerializedStateStore } from "../extension/runtime-state.js";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+test("state loading is shared and callers cannot observe half-loaded state", async () => {
+  const gate = deferred();
+  let getCalls = 0;
+  let applied = null;
+  const store = new SerializedStateStore({
+    storage: {
+      async get(keys) {
+        getCalls += 1;
+        assert.deepEqual(keys, ["managedTabs", "activeTabId"]);
+        return gate.promise;
+      },
+      async set() {},
+    },
+    keys: ["managedTabs", "activeTabId"],
+    read: () => applied,
+    apply: (value) => {
+      applied = value;
+    },
+    empty: () => ({ managedTabs: [], activeTabId: null }),
+  });
+
+  let firstFinished = false;
+  let secondFinished = false;
+  const first = store.load().then(() => {
+    firstFinished = true;
+  });
+  const second = store.load().then(() => {
+    secondFinished = true;
+  });
+
+  await Promise.resolve();
+  assert.equal(getCalls, 1);
+  assert.equal(firstFinished, false);
+  assert.equal(secondFinished, false);
+
+  const state = { managedTabs: [{ tabId: 1, alias: "t0" }], activeTabId: 1 };
+  gate.resolve(state);
+  await Promise.all([first, second]);
+  assert.deepEqual(applied, state);
+});
+
+test("state writes use mutation-time snapshots and cannot overtake each other", async () => {
+  const firstWrite = deferred();
+  const writes = [];
+  let state = { value: 0 };
+  const store = new SerializedStateStore({
+    storage: {
+      async get() {
+        return { value: 0 };
+      },
+      async set(snapshot) {
+        writes.push(snapshot);
+        if (writes.length === 1) {
+          await firstWrite.promise;
+        }
+      },
+    },
+    keys: ["value"],
+    read: () => state,
+    apply: (value) => {
+      state = value;
+    },
+    empty: () => ({ value: 0 }),
+  });
+
+  await store.load();
+  state = { value: 1 };
+  const first = store.save();
+  state = { value: 2 };
+  const second = store.save();
+
+  await Promise.resolve();
+  assert.deepEqual(writes, [{ value: 1 }]);
+  firstWrite.resolve();
+  await Promise.all([first, second]);
+  assert.deepEqual(writes, [{ value: 1 }, { value: 2 }]);
+});
+
+test("failed storage operations preserve runtime state and do not block later writes", async () => {
+  let calls = 0;
+  let state = { value: 0 };
+  const writes = [];
+  const store = new SerializedStateStore({
+    storage: {
+      get: async () => ({ value: 0 }),
+      async set(snapshot) {
+        calls += 1;
+        if (calls === 1) throw new Error("storage unavailable");
+        writes.push(snapshot);
+      },
+    },
+    keys: ["value"],
+    read: () => state,
+    apply: (value) => {
+      state = value;
+    },
+    empty: () => ({ value: 0 }),
+  });
+
+  await store.load();
+  state = { value: 1 };
+  await store.save();
+  state = { value: 2 };
+  await store.save();
+  assert.deepEqual(state, { value: 2 });
+  assert.deepEqual(writes, [{ value: 2 }]);
+});
+
+test("request queue serializes tasks and recovers after a rejection", async () => {
+  const queue = new SerialTaskQueue();
+  const gate = deferred();
+  const events = [];
+
+  const first = queue.enqueue(async () => {
+    events.push("first:start");
+    await gate.promise;
+    events.push("first:end");
+    throw new Error("expected");
+  });
+  const second = queue.enqueue(async () => {
+    events.push("second:start");
+    events.push("second:end");
+    return 42;
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(events, ["first:start"]);
+  gate.resolve();
+  await assert.rejects(first, /expected/);
+  assert.equal(await second, 42);
+  assert.deepEqual(events, ["first:start", "first:end", "second:start", "second:end"]);
+});

--- a/src/browser/test/server-http.test.ts
+++ b/src/browser/test/server-http.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { test } from "node:test";
+import { createRequestHandler, type CommandExecutor } from "../src/server.js";
+import type { CommandResponse } from "../src/lib/types.js";
+
+interface TestResponse {
+  statusCode: number;
+  body: CommandResponse;
+}
+
+function postCommand(port: number, headers: http.OutgoingHttpHeaders, body: string): Promise<TestResponse> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        method: "POST",
+        host: "127.0.0.1",
+        port,
+        path: "/command",
+        headers: {
+          "content-length": Buffer.byteLength(body),
+          ...headers,
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+        response.on("end", () => {
+          try {
+            resolve({
+              statusCode: response.statusCode ?? 0,
+              body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as CommandResponse,
+            });
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+    request.on("error", reject);
+    request.end(body);
+  });
+}
+
+test("loopback command endpoint rejects browser-compatible requests before dispatch", async () => {
+  const dispatched: string[] = [];
+  const executor: CommandExecutor = async (body) => {
+    dispatched.push(body.command);
+    return {
+      ok: true,
+      data: [],
+      url: "about:blank",
+      title: "",
+      elapsed: 0,
+    };
+  };
+  const server = http.createServer(createRequestHandler(executor));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    const noCorsStyle = await postCommand(address.port, { "content-type": "text/plain" }, "not json");
+    assert.equal(noCorsStyle.statusCode, 415);
+    assert.match(noCorsStyle.body.error ?? "", /application\/json/);
+    assert.deepEqual(dispatched, []);
+
+    const originBearing = await postCommand(
+      address.port,
+      { "content-type": "application/json", origin: "https://attacker.example" },
+      "not json",
+    );
+    assert.equal(originBearing.statusCode, 403);
+    assert.match(originBearing.body.error ?? "", /Browser-origin/);
+    assert.deepEqual(dispatched, []);
+
+    const cliStyle = await postCommand(
+      address.port,
+      { "content-type": "application/json" },
+      JSON.stringify({ command: "tabs", args: [], options: {} }),
+    );
+    assert.equal(cliStyle.statusCode, 200);
+    assert.equal(cliStyle.body.ok, true);
+    assert.deepEqual(dispatched, ["tabs"]);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/src/browser/test/smoke.test.ts
+++ b/src/browser/test/smoke.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { parseCliInput } from "../src/lib/parse.js";
+import { runCommand, type CommandBridge, type OracleRunner } from "../src/server.js";
+import { CLOSE_IDLE_TIMEOUT_MS, type BridgeAction, type CommandName, type CommandRequest } from "../src/lib/types.js";
+
+class FakeBridge implements CommandBridge {
+  readonly calls: Array<{ action: BridgeAction; params: Record<string, unknown>; timeoutMs?: number }> = [];
+
+  getStatus() {
+    return { connected: false, lastSeenAt: null };
+  }
+
+  async call(action: BridgeAction, params: Record<string, unknown>, timeoutMs?: number): Promise<unknown> {
+    this.calls.push({ action, params, timeoutMs });
+    switch (action) {
+      case "open":
+        return { url: "https://example.test", title: "Example", preview: "ready" };
+      case "tabs":
+        return [];
+      case "focus":
+      case "close":
+        return { alias: "t0", tabId: 1, url: "https://example.test", title: "Example", active: action === "focus" };
+      case "close-idle":
+        return {
+          dryRun: true,
+          hours: params.hours,
+          eligibleCount: 0,
+          closedCount: 0,
+          skippedCount: 0,
+          failedCount: 0,
+          eligible: [],
+          closed: [],
+          skipped: [],
+          failed: [],
+        };
+      case "click":
+        return { clicked: params.target, target: params.target, title: "Example", preview: "ready" };
+      case "type":
+        return { typedInto: params.target, target: params.target, text: params.text };
+      case "fill":
+        return { filledInto: params.target, target: params.target, intended: params.text, actual: params.text, match: true };
+      case "upload":
+        return { uploaded: params.filepath, target: params.target, selector: "input", title: "Example", preview: "ready" };
+      case "wait":
+        return { condition: "delay", waitedMs: 0, url: "https://example.test", title: "Example" };
+      case "snapshot":
+        return { snapshot: "page \"Example\"", url: "https://example.test", title: "Example" };
+      case "diff":
+        return { diff: "No changes since last snapshot.", url: "https://example.test", title: "Example" };
+      case "inspect":
+        return { elements: [], url: "https://example.test", title: "Example" };
+      case "extract":
+        return "Example text";
+      case "screenshot":
+        return { dataUrl: "data:image/png;base64,iVBORw0KGgo=", mode: "viewport", url: "https://example.test", title: "Example" };
+      case "html":
+        return "<html></html>";
+      case "eval":
+        return "Example";
+      case "dialog":
+        return { open: false, url: "https://example.test", title: "Example" };
+      case "status":
+        return { url: "https://example.test", title: "Example", managedTabs: [] };
+    }
+  }
+}
+
+function requestFromArgv(argv: string[], cwd: string): CommandRequest {
+  const parsed = parseCliInput(argv, cwd);
+  assert.equal(parsed.localOutput, undefined, parsed.localOutput?.text);
+  assert.ok(parsed.command);
+  return { command: parsed.command, args: parsed.args, options: parsed.options };
+}
+
+test("every Browser CLI command runs through parsing and dispatch without live services", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "browser-smoke-"));
+  const uploadPath = path.join(tempDir, "upload.txt");
+  const screenshotPath = path.join(tempDir, "shot.png");
+  await fs.writeFile(uploadPath, "fixture");
+
+  const commands: Array<[CommandName, string[]]> = [
+    ["open", ["open", "https://example.test"]],
+    ["tabs", ["tabs"]],
+    ["focus", ["focus", "t0"]],
+    ["close", ["close", "t0"]],
+    ["close-idle", ["close-idle", "--hours", "6", "--dry-run"]],
+    ["click", ["click", "Continue"]],
+    ["type", ["type", "Search", "browser"]],
+    ["fill", ["fill", "Editor", "text"]],
+    ["upload", ["upload", "input", uploadPath]],
+    ["wait", ["wait", "--ms", "0"]],
+    ["snapshot", ["snapshot"]],
+    ["diff", ["diff"]],
+    ["inspect", ["inspect"]],
+    ["describe", ["describe"]],
+    ["ask", ["ask", "what is visible?"]],
+    ["extract", ["extract"]],
+    ["screenshot", ["screenshot", screenshotPath]],
+    ["html", ["html"]],
+    ["eval", ["eval", "document.title"]],
+    ["dialog", ["dialog"]],
+    ["status", ["status"]],
+    ["stop", ["stop"]],
+  ];
+
+  const bridge = new FakeBridge();
+  let oracleCalls = 0;
+  const fakeOracle: OracleRunner = async () => {
+    oracleCalls += 1;
+    return "offline oracle fixture";
+  };
+
+  try {
+    for (const [expectedCommand, argv] of commands) {
+      const request = requestFromArgv(argv, tempDir);
+      assert.equal(request.command, expectedCommand);
+      await assert.doesNotReject(runCommand(request, bridge, fakeOracle), `failed smoke command: ${expectedCommand}`);
+    }
+
+    assert.equal(oracleCalls, 2);
+    assert.equal((await fs.readFile(screenshotPath)).length > 0, true);
+
+    await runCommand({ command: "open", args: ["https://window.example"], options: { window: true } }, bridge, fakeOracle);
+    const directWindowOpen = bridge.calls.filter(({ action }) => action === "open").at(-1);
+    assert.equal(directWindowOpen?.params.newTab, true);
+    assert.equal(directWindowOpen?.params.newWindow, true);
+    const closeIdleCall = bridge.calls.find(({ action }) => action === "close-idle");
+    assert.equal(closeIdleCall?.timeoutMs, CLOSE_IDLE_TIMEOUT_MS);
+    const waitCall = bridge.calls.find(({ action }) => action === "wait");
+    assert.equal(waitCall?.timeoutMs, 20_000);
+    assert.equal(bridge.calls.some(({ action, timeoutMs }) => action === "status" && timeoutMs === 1_000), true);
+
+    const dispatched = new Set(bridge.calls.map(({ action }) => action));
+    for (const action of [
+      "open", "tabs", "focus", "close", "close-idle", "click", "type", "fill", "upload", "wait", "snapshot", "diff",
+      "inspect", "extract", "screenshot", "html", "eval", "dialog", "status",
+    ] satisfies BridgeAction[]) {
+      assert.equal(dispatched.has(action), true, `bridge action was not exercised: ${action}`);
+    }
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/src/browser/test/status.test.ts
+++ b/src/browser/test/status.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { runCommand, type CommandBridge } from "../src/server.js";
+import type { BridgeAction } from "../src/lib/types.js";
+
+class StatusBridge implements CommandBridge {
+  getStatus() {
+    return { connected: true, lastSeenAt: null };
+  }
+
+  async call(action: BridgeAction, params: Record<string, unknown>): Promise<unknown> {
+    assert.equal(action, "status");
+    if (params.tabId === "missing") throw new Error('Unknown managed tab alias "missing".');
+    if (params.tabId === "stale") throw new Error("Managed tab is no longer available.");
+    throw new Error("extension temporarily unavailable");
+  }
+}
+
+test("status --tab propagates invalid and stale managed-tab errors", async () => {
+  const bridge = new StatusBridge();
+  await assert.rejects(
+    runCommand({ command: "status", args: [], options: { tab: "missing" } }, bridge),
+    /Unknown managed tab alias/,
+  );
+  await assert.rejects(
+    runCommand({ command: "status", args: [], options: { tab: "stale" } }, bridge),
+    /no longer available/,
+  );
+});
+
+test("plain status remains diagnostic when the extension is unavailable", async () => {
+  const result = await runCommand({ command: "status", args: [], options: {} }, new StatusBridge());
+  assert.equal(typeof result, "object");
+  assert.match((result as { message: string }).message, /temporarily unavailable/);
+});

--- a/src/browser/tsconfig.json
+++ b/src/browser/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noEmitOnError": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/src/browser/tsconfig.test.json
+++ b/src/browser/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the standalone Browser CLI and MV3 extension under `src/browser`
- harden `close-idle` with strict parsing, dry-run support, protected-tab defaults, per-tab revalidation, cancellation, and accurate result accounting
- enforce the managed-tab boundary so numeric IDs cannot adopt or mutate personal tabs
- make screenshots target-specific through CDP and remove unsafe `captureVisibleTab` fallbacks
- serialize extension work, harden state persistence/cold starts, authenticate the extension handshake, and protect the loopback command endpoint from browser-origin requests
- add command-specific validation, packaging/build lifecycle, and documentation

## Verification
- `npm --prefix src/browser run check`
- `npm --prefix src/browser test` — 62 passing
- `npm --prefix src/browser run build`
- `npm --prefix src/browser run smoke` — every command parsed and dispatched through offline fakes
- `npm --prefix src/browser audit` — 0 vulnerabilities
- `npm pack --dry-run`
- installed the generated tarball in a clean temporary project and exercised the packaged binary plus all 22 command help paths
- `uv run pytest` — 407 passing, 2 skipped
- `git diff --check`

## Testing boundary
The automated suite intentionally does not load the unpacked extension into the user’s live Chrome profile, close real tabs, or call OpenRouter. Live extension behavior therefore still requires a manual isolated-profile smoke test.
