### PR TITLE
fix: reject stale browser extensions

### DIFF
--- a/src/browser/README.md
+++ b/src/browser/README.md
@@ -22,7 +22,7 @@ Requirements: Node.js 20 or newer and Chrome/Chromium 121 or newer. Chrome 121 i
 cd src/browser
 npm install
 npm run build
-npm link                    # optional: installs the `browser` command
+npm install -g .            # installs the `browser` command and extension globally
 ```
 
 Load the extension:
@@ -30,12 +30,12 @@ Load the extension:
 1. Open `chrome://extensions`.
 2. Enable **Developer mode**.
 3. Click **Load unpacked**.
-4. Select `src/browser/extension`.
+4. Select `src/browser/extension`, or `$(npm root -g)/browser-cli/extension` after a global install.
 5. Keep Chrome running, then check the connection with `browser status`.
 
 The CLI starts its local server on the first command. Concurrent cold starts elect one command-server winner without unlinking a live socket; only that winner binds the extension bridge. Run `browser stop` to stop it. The local Unix socket is owner-only where supported; the TCP and WebSocket fallbacks bind to `127.0.0.1`. The loopback HTTP command endpoint rejects every request carrying an `Origin` header and accepts only `application/json`, preventing browser pages and no-CORS requests from dispatching commands without relying on CORS response policy.
 
-The WebSocket server accepts only `chrome-extension://` origins and promotes a connection only after the expected extension hello handshake; unauthenticated candidates time out. This prevents ordinary web pages from replacing the extension. It is not a shared-secret pairing protocol: another process running as the same local user can still connect to loopback while impersonating an extension origin, so the same-user local-process trust boundary remains.
+The WebSocket server accepts only `chrome-extension://` origins and promotes a connection only after the expected versioned extension hello handshake; stale or unauthenticated candidates are rejected. This prevents ordinary web pages and outdated extension code from replacing the current extension. It is not a shared-secret pairing protocol: another process running as the same local user can still connect to loopback while impersonating an extension origin, so the same-user local-process trust boundary remains.
 
 ## Usage
 

--- a/src/browser/extension/service-worker.js
+++ b/src/browser/extension/service-worker.js
@@ -7,6 +7,7 @@ import {
 import { SerializedStateStore, SerialTaskQueue } from "./runtime-state.js";
 
 const BRIDGE_URL = "ws://127.0.0.1:19224";
+const BRIDGE_PROTOCOL_VERSION = 1;
 const PREVIEW_CHARS = 500;
 const MAX_FULL_PAGE_DIMENSION = 16384;
 const BRIDGE_RECONNECT_ALARM = "browser-v2-bridge-reconnect";
@@ -278,12 +279,20 @@ function connectBridge() {
 
   connection.addEventListener("open", () => {
     reconnectDelayMs = 1000;
-    sendTo(connection, { type: "hello", source: "browser-cli-v2-extension" });
+    sendTo(connection, {
+      type: "hello",
+      source: "browser-cli-extension",
+      protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    });
     if (keepaliveTimer) {
       clearInterval(keepaliveTimer);
     }
     keepaliveTimer = setInterval(() => {
-      sendTo(connection, { type: "keepalive", source: "browser-cli-v2-extension" });
+      sendTo(connection, {
+        type: "keepalive",
+        source: "browser-cli-extension",
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+      });
     }, 20_000);
     log("Connected to bridge");
   });

--- a/src/browser/src/lib/bridge.ts
+++ b/src/browser/src/lib/bridge.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
-import { BRIDGE_WS_PORT, DEFAULT_TIMEOUT_MS, FriendlyError } from "./types.js";
+import { BRIDGE_PROTOCOL_VERSION, BRIDGE_WS_PORT, DEFAULT_TIMEOUT_MS, FriendlyError } from "./types.js";
 import type { BridgeAction, BridgeCancelRequest, BridgeHelloMessage, BridgeRequest, BridgeResponse } from "./types.js";
 
 interface PendingRequest {
@@ -21,8 +22,15 @@ function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 function isHelloMessage(value: unknown): value is BridgeHelloMessage {
-  return isObject(value) && value.type === "hello" && value.source === "browser-cli-v2-extension";
+  return (
+    isObject(value) &&
+    value.type === "hello" &&
+    value.source === "browser-cli-extension" &&
+    value.protocolVersion === BRIDGE_PROTOCOL_VERSION
+  );
 }
+
+const EXTENSION_DIR = fileURLToPath(new URL("../../extension", import.meta.url));
 
 function isBridgeResponse(value: unknown): value is BridgeResponse {
   return isObject(value) && typeof value.id === "string" && typeof value.ok === "boolean";
@@ -155,7 +163,7 @@ export class ExtensionBridge {
     }
     if (!this.extensionSocket || this.extensionSocket.readyState !== WebSocket.OPEN) {
       throw new FriendlyError(
-        "Chrome extension bridge is not connected. Load the extension from src/browser/extension and keep a Chrome tab open.",
+        `Chrome extension bridge is not connected. Load the extension from ${EXTENSION_DIR} and keep Chrome open.`,
       );
     }
 

--- a/src/browser/src/lib/types.ts
+++ b/src/browser/src/lib/types.ts
@@ -1,6 +1,7 @@
 export const SOCKET_PATH = "/tmp/browser-cli-v2.sock";
 export const FALLBACK_PORT = 19223;
 export const BRIDGE_WS_PORT = 19224;
+export const BRIDGE_PROTOCOL_VERSION = 1;
 export const DEFAULT_TIMEOUT_MS = 30_000;
 export const BRIDGE_TIMEOUT_GRACE_MS = 5_000;
 export const CLOSE_IDLE_TIMEOUT_MS = 120_000;
@@ -94,7 +95,8 @@ export interface BridgeResponse {
 
 export interface BridgeHelloMessage {
   type: "hello";
-  source?: string;
+  source: "browser-cli-extension";
+  protocolVersion: number;
 }
 
 export class FriendlyError extends Error {

--- a/src/browser/test/bridge.test.ts
+++ b/src/browser/test/bridge.test.ts
@@ -32,6 +32,12 @@ function closeSocket(socket: WebSocket): Promise<void> {
   });
 }
 
+const validHello = {
+  type: "hello",
+  source: "browser-cli-extension",
+  protocolVersion: 1,
+};
+
 test("bridge promotes only a valid extension hello and ignores unauthenticated replacements", async () => {
   const port = await unusedPort();
   const bridge = new ExtensionBridge({ port, handshakeTimeoutMs: 100 });
@@ -41,7 +47,7 @@ test("bridge promotes only a valid extension hello and ignores unauthenticated r
 
   try {
     assert.equal(bridge.getStatus().connected, false);
-    first.send(JSON.stringify({ type: "hello", source: "browser-cli-v2-extension" }));
+    first.send(JSON.stringify(validHello));
     await new Promise((resolve) => setTimeout(resolve, 10));
     assert.equal(bridge.getStatus().connected, true);
 
@@ -65,7 +71,7 @@ test("aborting a bridge call sends extension cancellation immediately", async ()
   const bridge = new ExtensionBridge({ port });
   await bridge.ready();
   const extension = await openSocket(port);
-  extension.send(JSON.stringify({ type: "hello", source: "browser-cli-v2-extension" }));
+  extension.send(JSON.stringify(validHello));
   await new Promise((resolve) => setTimeout(resolve, 10));
   const cancellationSeen = new Promise<{ type: string; id: string }>((resolve) => {
     extension.on("message", (raw) => {
@@ -104,6 +110,24 @@ test("bridge rejects normal web-page websocket origins", async () => {
   await bridge.ready();
   try {
     await assert.rejects(openSocket(port, "https://example.test"), /403|Unexpected server response/);
+    assert.equal(bridge.getStatus().connected, false);
+  } finally {
+    await bridge.close();
+  }
+});
+
+test("bridge rejects stale extension protocol handshakes", async () => {
+  const port = await unusedPort();
+  const bridge = new ExtensionBridge({ port });
+  await bridge.ready();
+  const staleExtension = await openSocket(port);
+  staleExtension.send(JSON.stringify({
+    type: "hello",
+    source: "browser-cli-v2-extension",
+  }));
+
+  try {
+    await new Promise<void>((resolve) => staleExtension.once("close", () => resolve()));
     assert.equal(bridge.getStatus().connected, false);
   } finally {
     await bridge.close();


### PR DESCRIPTION
## Summary
- version the Browser CLI extension handshake
- reject stale unpacked extension code instead of silently accepting it
- report the exact packaged extension path when disconnected
- document global installation and extension loading

## Verification
- `npm --prefix src/browser run check`
- `npm --prefix src/browser test` — 63 passing
- `npm --prefix src/browser run build`
- `npm --prefix src/browser run smoke`
- `npm --prefix src/browser audit` — 0 vulnerabilities
- `git diff --check`