### PR TITLE
feat(news): merge validated agent-driven news pipeline

### DIFF
--- a/scripts/prompts/news_e2e_collector.md
+++ b/scripts/prompts/news_e2e_collector.md
@@ -1,0 +1,36 @@
+# Controlled news E2E collector
+
+You are the only collector in a deliberately isolated end-to-end test.
+
+- Article URL: `{{ARTICLE_URL}}`
+- Scratch database: `{{DB}}`
+- Run date: `{{DATE}}`
+- Fixed source ID: `e2e-collector`
+
+Fetch exactly the public article URL above. Extract the article into normalized
+Markdown or plain text: preserve the substantive body, remove navigation,
+advertising, cookie text, and other page chrome. Do not send raw HTML.
+
+Construct exactly one JSON object with these fields:
+
+- `title`: the article's real, non-empty title
+- `source_id`: exactly `e2e-collector`
+- `url`: exactly `{{ARTICLE_URL}}`
+- `published_at`: the article's publication date/time when available; if the
+  page has no publication value, use `{{DATE}}`
+- `content`: the normalized non-empty Markdown/text body
+- optional `section`: `e2e-controlled-article`
+- optional `collected_at`: current ISO-8601 UTC timestamp
+
+Pipe the JSON object directly on stdin to this exact command:
+
+```bash
+cd {{ROOT_Q}} && printf '%s\n' "$article_json" | {{MINERVA}} news ingest --input - --db {{DB_Q}}
+```
+
+You may use a different safe JSON-producing shell construct, but it must end in
+the same direct pipe to `news ingest --input -`. Do not create an intermediate
+article, JSON, Markdown, or text file. The scratch SQLite DB is the only
+persistent collector output. Confirm the ingest command returns `inserted`,
+`updated`, or `duplicate`; otherwise fail. Do not access any other database.
+Do not invoke Slack or any messaging tool.

--- a/scripts/prompts/news_e2e_sol.md
+++ b/scripts/prompts/news_e2e_sol.md
@@ -1,0 +1,42 @@
+# Sol news E2E summarizer and dry-run brief writer
+
+You are the sole synthesis agent in an isolated end-to-end test.
+
+- Scratch database: `{{DB}}`
+- Brief artifact: `{{BRIEF}}`
+- Run date: `{{DATE}}`
+- Focus symbol: `{{SYMBOL}}`
+- Market index: `{{INDEX}}`
+
+Work only with the scratch DB and brief path above. Never open or modify the
+canonical `invest.db` or any other database. Do not invoke Slack, webhooks, or
+any messaging/posting command; this run is artifact-only.
+
+1. Read rows from `news` whose `summary IS NULL OR trim(summary) = ''`, ordered
+   deterministically by `published_at, article_key`.
+2. For every such row, pass the row's normalized article `content` to the
+   general command below through stdin (one invocation per row). Do not write
+   temporary article files:
+
+   ```bash
+   cd {{ROOT_Q}} && printf '%s' "$content" | {{MINERVA}} summarize --model {{SUMMARY_MODEL_Q}}
+   ```
+
+3. Treat an empty summary or non-zero summarizer exit as a hard failure. Keep
+   generated summaries in memory until all calls succeed. Then use Python's
+   `sqlite3` parameter binding in one `BEGIN IMMEDIATE` transaction to persist
+   them. Update by exact `article_key` and include
+   `AND (summary IS NULL OR trim(summary) = '')`; verify each expected row was
+   updated, commit only after every update succeeds, and roll back on error.
+   Never interpolate article text or summaries into SQL.
+4. Re-read the summarized news plus the `prices` rows for `{{SYMBOL}}` and
+   `{{INDEX}}`. Write a concise investor-oriented Markdown brief directly to
+   `{{BRIEF}}`. Include a heading, the important news, and both close-to-close
+   market moves (current, previous close, and change percent). The brief must
+   be non-empty and must clearly say `Dry run — not posted to Slack`.
+5. Verify in read-only mode that no news row has a NULL/blank summary and the
+   brief is non-empty. Exit non-zero if either check fails.
+
+Do not merely describe these steps: execute them. The only allowed persistent
+changes are parameterized summary updates in `{{DB}}` and the brief artifact at
+`{{BRIEF}}`.

--- a/scripts/run_news_pipeline_e2e.sh
+++ b/scripts/run_news_pipeline_e2e.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+
+# API keys used by the live providers and `minerva summarize` normally live in
+# the operator's shell profile. Source it only when --live was explicitly
+# requested; the safe default and stubbed tests must not execute profile code.
+# Keep this before strict mode because .zshrc may contain zsh-only commands.
+for e2e_arg in "$@"; do
+  if [[ "${e2e_arg}" == "--live" ]]; then
+    source ~/.zshrc >/dev/null 2>&1 || true
+    break
+  fi
+done
+unset e2e_arg
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+RUN_DATE="${MINERVA_E2E_DATE:-$(date +%F)}"
+ARTICLE_URL="${MINERVA_E2E_ARTICLE_URL:-}"
+SYMBOL="${MINERVA_E2E_SYMBOL:-NVDA}"
+MARKET_INDEX="${MINERVA_E2E_INDEX:-^GSPC}"
+COLLECTOR_AGENT="${MINERVA_E2E_COLLECTOR_AGENT:-main}"
+COLLECTOR_MODEL="${MINERVA_E2E_COLLECTOR_MODEL:-fireworks/accounts/fireworks/routers/glm-5p2-fast}"
+SOL_AGENT="${MINERVA_E2E_SOL_AGENT:-main}"
+SOL_MODEL="${MINERVA_E2E_SOL_MODEL:-openai/gpt-5.6-sol}"
+SUMMARY_MODEL="${MINERVA_E2E_SUMMARY_MODEL:-gemini-3.6-flash}"
+AGENT_TIMEOUT="${MINERVA_E2E_AGENT_TIMEOUT:-900}"
+RUN_ROOT="${MINERVA_E2E_RUN_ROOT:-${TMPDIR:-/tmp}/minerva-news-e2e-runs}"
+OPENCLAW_COMMAND="${MINERVA_E2E_OPENCLAW:-openclaw}"
+MINERVA_RUNNER="${MINERVA_RUNNER:-uv run minerva}"
+MODE=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run_news_pipeline_e2e.sh (--live | --stubbed) [options]
+
+Runs the agent-driven news pipeline only against a newly created scratch DB.
+The run directory is always preserved and Slack is never invoked.
+
+Modes:
+  --live                    Allow real OpenClaw, Finnhub, Yahoo, and LLM calls.
+  --stubbed                 Require injected OpenClaw and Minerva test doubles.
+
+Options:
+  --date YYYY-MM-DD         Provider date (default: today).
+  --article-url URL         One controlled public article URL (required).
+  --symbol SYMBOL           Finnhub/Yahoo symbol (default: NVDA).
+  --index SYMBOL            Yahoo index (default: ^GSPC).
+  --collector-agent ID      Collector OpenClaw agent (default: main).
+  --collector-model MODEL   Collector OpenClaw model.
+  --sol-agent ID            Summarizer OpenClaw agent (default: main).
+  --sol-model MODEL         Summarizer OpenClaw model (default: Sol).
+  --summary-model MODEL     Model passed to `minerva summarize`.
+  --run-root DIR            Parent for preserved run directories.
+  -h, --help                Show this help.
+
+Stubbed mode safety contract:
+  Set MINERVA_E2E_OPENCLAW to a test double and MINERVA_RUNNER to a provider
+  test double. The same production command arguments and prompts are built,
+  but no real provider or agent is reachable accidentally.
+EOF
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --live|--stubbed)
+      if [[ -n "${MODE}" ]]; then
+        echo "error: choose exactly one of --live or --stubbed" >&2
+        exit 2
+      fi
+      MODE="${1#--}"
+      shift
+      ;;
+    --date) RUN_DATE="${2:?--date requires a value}"; shift 2 ;;
+    --article-url) ARTICLE_URL="${2:?--article-url requires a value}"; shift 2 ;;
+    --symbol) SYMBOL="${2:?--symbol requires a value}"; shift 2 ;;
+    --index) MARKET_INDEX="${2:?--index requires a value}"; shift 2 ;;
+    --collector-agent) COLLECTOR_AGENT="${2:?--collector-agent requires a value}"; shift 2 ;;
+    --collector-model) COLLECTOR_MODEL="${2:?--collector-model requires a value}"; shift 2 ;;
+    --sol-agent) SOL_AGENT="${2:?--sol-agent requires a value}"; shift 2 ;;
+    --sol-model) SOL_MODEL="${2:?--sol-model requires a value}"; shift 2 ;;
+    --summary-model) SUMMARY_MODEL="${2:?--summary-model requires a value}"; shift 2 ;;
+    --run-root) RUN_ROOT="${2:?--run-root requires a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "${MODE}" ]]; then
+  echo "error: network and agent execution are disabled by default; choose --live or --stubbed" >&2
+  exit 2
+fi
+if [[ -z "${ARTICLE_URL}" ]]; then
+  echo "error: --article-url is required" >&2
+  exit 2
+fi
+if ! [[ "${RUN_DATE}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || \
+   ! python3 - "${RUN_DATE}" <<'PY'
+from datetime import date
+import sys
+try:
+    date.fromisoformat(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+PY
+then
+  echo "error: --date must be a valid YYYY-MM-DD date" >&2
+  exit 2
+fi
+if ! [[ "${AGENT_TIMEOUT}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: MINERVA_E2E_AGENT_TIMEOUT must be a positive integer" >&2
+  exit 2
+fi
+if [[ "$(printf '%s' "${SYMBOL}" | tr '[:lower:]' '[:upper:]')" == \
+      "$(printf '%s' "${MARKET_INDEX}" | tr '[:lower:]' '[:upper:]')" ]]; then
+  echo "error: --symbol and --index must identify different instruments" >&2
+  exit 2
+fi
+if [[ "${MODE}" == "stubbed" ]]; then
+  if [[ "${OPENCLAW_COMMAND}" == "openclaw" || "${MINERVA_RUNNER}" == "uv run minerva" ]]; then
+    echo "error: --stubbed requires MINERVA_E2E_OPENCLAW and MINERVA_RUNNER test doubles" >&2
+    exit 2
+  fi
+fi
+
+mkdir -p "${RUN_ROOT}"
+RUN_DIR="$(mktemp -d "${RUN_ROOT%/}/news-e2e-${RUN_DATE}-XXXXXX")"
+DB_PATH="${RUN_DIR}/scratch.db"
+BRIEF_PATH="${RUN_DIR}/dry-run-brief.md"
+LOG_DIR="${RUN_DIR}/logs"
+PROMPT_DIR="${RUN_DIR}/prompts"
+mkdir -p "${LOG_DIR}" "${PROMPT_DIR}"
+
+# A newly allocated path beneath RUN_DIR is the only DB this workflow accepts.
+if [[ -e "${DB_PATH}" ]]; then
+  echo "error[setup]: scratch DB unexpectedly exists: ${DB_PATH}" >&2
+  exit 1
+fi
+
+IFS=' ' read -r -a MINERVA_RUNNER_ARR <<< "${MINERVA_RUNNER}"
+run_minerva() { "${MINERVA_RUNNER_ARR[@]}" "$@"; }
+printf -v MINERVA_COMMAND '%q ' "${MINERVA_RUNNER_ARR[@]}"
+MINERVA_COMMAND="${MINERVA_COMMAND% }"
+printf -v ROOT_Q '%q' "${ROOT_DIR}"
+printf -v DB_Q '%q' "${DB_PATH}"
+printf -v BRIEF_Q '%q' "${BRIEF_PATH}"
+printf -v SUMMARY_MODEL_Q '%q' "${SUMMARY_MODEL}"
+
+render_prompt() {
+  local template="$1" destination="$2"
+  python3 - "$template" "$destination" "$RUN_DATE" "$ARTICLE_URL" \
+    "$SYMBOL" "$MARKET_INDEX" "$ROOT_DIR" "$DB_PATH" "$BRIEF_PATH" \
+    "$MINERVA_COMMAND" "$ROOT_Q" "$DB_Q" "$BRIEF_Q" "$SUMMARY_MODEL_Q" <<'PY'
+import sys
+from pathlib import Path
+
+(template, destination, run_date, article_url, symbol, market_index,
+ root, db, brief, minerva, root_q, db_q, brief_q, summary_model_q) = sys.argv[1:]
+text = Path(template).read_text(encoding="utf-8")
+values = {
+    "DATE": run_date,
+    "ARTICLE_URL": article_url,
+    "SYMBOL": symbol,
+    "INDEX": market_index,
+    "ROOT": root,
+    "DB": db,
+    "BRIEF": brief,
+    "MINERVA": minerva,
+    "ROOT_Q": root_q,
+    "DB_Q": db_q,
+    "BRIEF_Q": brief_q,
+    "SUMMARY_MODEL_Q": summary_model_q,
+}
+for key, value in values.items():
+    text = text.replace("{{" + key + "}}", value)
+Path(destination).write_text(text, encoding="utf-8")
+PY
+}
+
+fail_phase() {
+  local phase="$1" status="$2" log_file="$3"
+  echo "error[${phase}]: failed with status ${status}" >&2
+  echo "error[${phase}]: log: ${log_file}" >&2
+  echo "error[${phase}]: preserved run directory: ${RUN_DIR}" >&2
+  exit "${status}"
+}
+
+invoke_agent() {
+  local phase="$1" agent="$2" model="$3" prompt_file="$4" log_file="$5"
+  local session_id="news-e2e-${phase}-${RUN_DATE}-$$-${RANDOM}"
+  local prompt
+  prompt="$(<"${prompt_file}")"
+  if "${OPENCLAW_COMMAND}" agent \
+      --agent "${agent}" \
+      --timeout "${AGENT_TIMEOUT}" \
+      --model "${model}" \
+      --thinking high \
+      --session-id "${session_id}" \
+      --message "${prompt}" >"${log_file}" 2>&1; then
+    return 0
+  else
+    local status=$?
+    fail_phase "${phase}" "${status}" "${log_file}"
+  fi
+}
+
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${ROOT_DIR}/.uv-cache}"
+export MINERVA_WORKSPACE_ROOT="${RUN_DIR}/workspace"
+
+# Progress belongs on stderr so successful stdout remains one machine-readable
+# JSON result.
+echo "news-e2e: run_dir=${RUN_DIR}" >&2
+echo "news-e2e: mode=${MODE} db=${DB_PATH}" >&2
+
+COLLECTOR_PROMPT="${PROMPT_DIR}/collector.md"
+render_prompt "${ROOT_DIR}/scripts/prompts/news_e2e_collector.md" "${COLLECTOR_PROMPT}"
+echo "news-e2e: phase=collector" >&2
+invoke_agent "collector" "${COLLECTOR_AGENT}" "${COLLECTOR_MODEL}" \
+  "${COLLECTOR_PROMPT}" "${LOG_DIR}/collector.log"
+
+# These are the exact live command surfaces. In stubbed mode MINERVA_RUNNER is
+# an explicit test double that receives the same argument vectors.
+echo "news-e2e: phase=finnhub" >&2
+if run_minerva news download-finnhub \
+    --date "${RUN_DATE}" --db "${DB_PATH}" --symbol "${SYMBOL}" \
+    >"${LOG_DIR}/finnhub.json" 2>"${LOG_DIR}/finnhub.stderr"; then
+  :
+else
+  status=$?
+  fail_phase "finnhub" "${status}" "${LOG_DIR}/finnhub.stderr"
+fi
+
+echo "news-e2e: phase=market-data" >&2
+if run_minerva news download-market-data \
+    --date "${RUN_DATE}" --db "${DB_PATH}" --index "${MARKET_INDEX}" \
+    --symbol "${SYMBOL}" >"${LOG_DIR}/market-data.json" \
+    2>"${LOG_DIR}/market-data.stderr"; then
+  :
+else
+  status=$?
+  fail_phase "market-data" "${status}" "${LOG_DIR}/market-data.stderr"
+fi
+
+SOL_PROMPT="${PROMPT_DIR}/sol.md"
+render_prompt "${ROOT_DIR}/scripts/prompts/news_e2e_sol.md" "${SOL_PROMPT}"
+echo "news-e2e: phase=sol" >&2
+invoke_agent "sol" "${SOL_AGENT}" "${SOL_MODEL}" \
+  "${SOL_PROMPT}" "${LOG_DIR}/sol.log"
+
+echo "news-e2e: phase=verify" >&2
+if python3 - "${DB_PATH}" "${BRIEF_PATH}" "${ARTICLE_URL}" "${SYMBOL}" \
+    "${MARKET_INDEX}" "${RUN_DIR}" >"${RUN_DIR}/result.json" \
+    2>"${LOG_DIR}/verify.stderr" <<'PY'
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+(db_raw, brief_raw, article_url, symbol, market_index, run_dir) = sys.argv[1:]
+db = Path(db_raw)
+brief = Path(brief_raw)
+errors: list[str] = []
+counts = {"collector_rows": 0, "finnhub_rows": 0, "market_rows": 0, "null_summaries": 0}
+
+if not db.is_file():
+    errors.append("scratch DB does not exist")
+else:
+    try:
+        uri = f"{db.resolve().as_uri()}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as conn:
+            conn.execute("PRAGMA query_only = ON")
+            tables = {row[0] for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )}
+            if "news" not in tables:
+                errors.append("news table does not exist")
+            else:
+                counts["collector_rows"] = conn.execute(
+                    "SELECT COUNT(*) FROM news WHERE source=? AND url=?",
+                    ("e2e-collector", article_url),
+                ).fetchone()[0]
+                counts["finnhub_rows"] = conn.execute(
+                    "SELECT COUNT(*) FROM news WHERE section IN (?, ?)",
+                    ("finnhub-general", "finnhub-company"),
+                ).fetchone()[0]
+                counts["null_summaries"] = conn.execute(
+                    "SELECT COUNT(*) FROM news "
+                    "WHERE summary IS NULL OR trim(summary) = ''"
+                ).fetchone()[0]
+            if "prices" not in tables:
+                errors.append("prices table does not exist")
+            else:
+                expected_prices = (
+                    (symbol.upper(), "security"),
+                    (market_index.upper(), "index"),
+                )
+                missing_prices = []
+                for ticker, instrument_type in expected_prices:
+                    found = conn.execute(
+                        "SELECT 1 FROM prices WHERE ticker=? AND instrument_type=? "
+                        "AND previous_close IS NOT NULL AND change_pct IS NOT NULL "
+                        "LIMIT 1",
+                        (ticker, instrument_type),
+                    ).fetchone()
+                    if found is None:
+                        missing_prices.append(f"{ticker} ({instrument_type})")
+                    else:
+                        counts["market_rows"] += 1
+                if missing_prices:
+                    errors.append(
+                        "market rows missing type/previous_close/change_pct: "
+                        + ", ".join(missing_prices)
+                    )
+    except sqlite3.Error as exc:
+        errors.append(f"SQLite verification failed: {exc}")
+
+if counts["collector_rows"] < 1:
+    errors.append("collector row was not found")
+if counts["finnhub_rows"] < 1:
+    errors.append("no Finnhub rows were found")
+if counts["null_summaries"]:
+    errors.append(f"{counts['null_summaries']} news row(s) still lack summaries")
+try:
+    brief_nonempty = bool(brief.read_text(encoding="utf-8").strip())
+except OSError:
+    brief_nonempty = False
+if not brief_nonempty:
+    errors.append("dry-run brief is missing or empty")
+
+if errors:
+    for error in errors:
+        print(f"verification: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+result = {
+    "brief_nonempty": True,
+    **counts,
+    "ok": True,
+    "run_dir": run_dir,
+}
+print(json.dumps(result, separators=(",", ":"), sort_keys=True))
+PY
+then
+  cat "${RUN_DIR}/result.json"
+else
+  status=$?
+  fail_phase "verify" "${status}" "${LOG_DIR}/verify.stderr"
+fi

--- a/src/harness/cli.py
+++ b/src/harness/cli.py
@@ -39,6 +39,7 @@ app = typer.Typer(
         "Examples:\n"
         "  minerva sec 10k AAPL --items 7\n"
         "  minerva extract -f apple-10k.md \"What are the key risks?\"\n"
+        "  minerva summarize -f earnings-call.txt\n"
         "  minerva extract-files -q questions.md -F selected-files.txt -o data/extractions/summary\n"
         "  minerva run \"sec 10k AAPL --items 1A | extract 'What are the top 3 risk factors?'\"\n"
     ),

--- a/src/harness/commands/__init__.py
+++ b/src/harness/commands/__init__.py
@@ -31,5 +31,6 @@ def register_commands(app: typer.Typer) -> None:
     app.add_typer(plot.app, name="plot")
     app.add_typer(extract.app, name="extract")
     app.add_typer(extract.extract_files_app, name="extract-files")
+    app.add_typer(extract.summarize_app, name="summarize")
     app.add_typer(fileinfo.app, name="fileinfo")
     app.add_typer(research.app, name="research")

--- a/src/harness/commands/extract.py
+++ b/src/harness/commands/extract.py
@@ -1,4 +1,4 @@
-"""LLM extraction commands backed by Gemini or OpenAI."""
+"""LLM extraction and summarization commands backed by Gemini or OpenAI."""
 
 from __future__ import annotations
 
@@ -31,6 +31,14 @@ EXTRACT_HELP = (
     "  minerva run \"sec 10k AAPL --items 1A | extract 'What are the top 3 risk factors?'\"\n"
 )
 
+SUMMARIZE_HELP = (
+    "Summarize UTF-8 text from a file or stdin.\n\n"
+    "Examples:\n"
+    "  minerva summarize --file earnings-call.txt\n"
+    "  cat filing.md | minerva summarize --max-tokens 2000\n"
+    "  minerva summarize -f notes.md --model gemini-3.6-flash --thinking high\n"
+)
+
 EXTRACT_FILES_HELP = (
     "Apply one extraction prompt or question pack across many UTF-8 text/markdown files.\n\n"
     "Examples:\n"
@@ -44,15 +52,16 @@ EXTRACT_FILES_HELP = (
     "    -o data/extractions/summary\n"
     "  minerva extract-files --questions-file questions.md \\\n"
     "    --files 'data/sources/**/*.md' --out data/extractions/summary \\\n"
-    "    --model gemini-3-flash --thinking minimal --concurrency 4\n"
+    "    --model gemini-3.6-flash --thinking minimal --concurrency 4\n"
     "  minerva extract-files -q questions.md -f 'data/**/*.md' -o out \\\n"
     "    --model gpt-5.5 --concurrency 2\n"
 )
 
-DEFAULT_MODEL = "gemini-3-flash"
+DEFAULT_MODEL = "gemini-3.6-flash"
 DEFAULT_MAX_TOKENS = 16384
 DEFAULT_CONCURRENCY = 4
 MODEL_ALIASES: dict[str, str] = {
+    # Gemini 3.6 Flash already uses Google's stable provider model code; no alias needed.
     # OpenClaw/user-facing shorthand; Google GenAI expects the preview model id today.
     "gemini-3-flash": "gemini-3-flash-preview",
     # Accept provider-qualified OpenClaw-style names while sending OpenAI its model id.
@@ -84,10 +93,17 @@ SYSTEM_PROMPT = (
     "Cite section/page numbers when possible. If the prompt contains multiple "
     "questions, answer each under a clearly labeled markdown heading."
 )
+SUMMARY_PROMPT = (
+    "Summarize the document below concisely and accurately. Preserve material facts, "
+    "figures, qualifications, and conclusions. Return only the summary without a preamble."
+)
 
 VALID_THINKING_LEVELS: frozenset[str] = frozenset({"off", "minimal", "low", "medium", "high", "adaptive"})
 
 app = typer.Typer(help=EXTRACT_HELP, no_args_is_help=False, invoke_without_command=True)
+summarize_app = typer.Typer(
+    help=SUMMARIZE_HELP, no_args_is_help=False, invoke_without_command=True
+)
 extract_files_app = typer.Typer(help=EXTRACT_FILES_HELP, no_args_is_help=False, invoke_without_command=True)
 # ---------------------------------------------------------------------------
 # `extract`
@@ -227,6 +243,100 @@ def extract_cli_command(
             settings=settings,
         )
     )
+# ---------------------------------------------------------------------------
+# `summarize`
+# ---------------------------------------------------------------------------
+
+
+def summarize_command(
+    *,
+    file_path: str | None = None,
+    model: str = DEFAULT_MODEL,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    thinking: str | None = None,
+    stdin: bytes = b"",
+    settings: HarnessSettings,
+) -> CommandResult:
+    """Summarize one UTF-8 text input using the shared extraction model backend."""
+    start = time.perf_counter()
+    try:
+        document_text = _read_summary_text(file_path=file_path, stdin=stdin)
+        resolved_thinking = _resolve_default_thinking(model, thinking)
+        _build_thinking_config(model, resolved_thinking)
+        api_key = _api_key_for_model(settings, model)
+        if not api_key:
+            return _missing_api_key_result(model, start)
+        prompt = f"{SUMMARY_PROMPT}\n\nDocument:\n{document_text}"
+        answer = _generate_answer(
+            prompt=prompt,
+            document_text=document_text,
+            model=model,
+            max_tokens=max_tokens,
+            thinking=resolved_thinking,
+            api_key=api_key,
+        )
+    except _UsageError as exc:
+        return error_result(exc.what, exc.what_to_do, exc.alternatives, start)
+    except ValueError as exc:
+        return error_result(
+            f"invalid summarization configuration: {exc}",
+            "use a supported model/thinking combination, or omit `--thinking`",
+            [
+                "`--thinking minimal` for gemini-3-*",
+                "`--thinking adaptive` for gemini-2.5-*",
+            ],
+            start,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return error_result(
+            f"summarization failed: {exc}",
+            "verify the input, API key, and model name, then retry",
+            [
+                "`minerva summarize --file document.txt`",
+                "`cat document.txt | minerva summarize`",
+            ],
+            start,
+        )
+    return CommandResult.from_text(answer.strip(), duration_ms=elapsed_ms(start))
+
+
+@summarize_app.callback()
+def summarize_cli_command(
+    ctx: typer.Context,
+    file_path: str | None = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Path to a UTF-8 text file. Omit to read from stdin.",
+    ),
+    model: str = typer.Option(
+        DEFAULT_MODEL, "--model", help="Model to use (Gemini or OpenAI)."
+    ),
+    max_tokens: int = typer.Option(
+        DEFAULT_MAX_TOKENS, "--max-tokens", help="Maximum summary output tokens."
+    ),
+    thinking: str | None = typer.Option(
+        None,
+        "--thinking",
+        help="Thinking level: off|minimal|low|medium|high|adaptive (model-aware).",
+    ),
+) -> None:
+    """Summarize one UTF-8 text input and print only the summary."""
+    stdin = b"" if file_path else typer.get_binary_stream("stdin").read()
+    if not file_path and not stdin:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
+    result = summarize_command(
+        file_path=file_path,
+        model=model,
+        max_tokens=max_tokens,
+        thinking=thinking,
+        stdin=stdin,
+        settings=get_settings(),
+    )
+    _print_summary(result)
+
+
 # ---------------------------------------------------------------------------
 # `extract-files`
 # ---------------------------------------------------------------------------
@@ -623,6 +733,46 @@ def _build_prompt_pack(*, question: str | None, questions_file: str | None) -> s
         ]
     )
 
+
+def _read_summary_text(*, file_path: str | None, stdin: bytes) -> str:
+    if file_path:
+        path = resolve_path(file_path)
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            raise _UsageError(
+                f"could not read input file `{file_path}`: {exc}",
+                "pass a readable UTF-8 text file",
+                ["`minerva summarize --file path/to/document.txt`"],
+            ) from exc
+    elif stdin:
+        raw = stdin
+    else:
+        raise _UsageError(
+            "no input text was provided for `summarize`",
+            "pass `--file PATH` or pipe UTF-8 text into the command",
+            [
+                "`minerva summarize --file document.txt`",
+                "`cat document.txt | minerva summarize`",
+            ],
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _UsageError(
+            "input is not valid UTF-8 text",
+            "convert the input to UTF-8 text before summarizing it",
+            ["`iconv -f <source-encoding> -t UTF-8 input.txt > input-utf8.txt`"],
+        ) from exc
+    if not text.strip():
+        raise _UsageError(
+            "input text is empty",
+            "provide non-empty UTF-8 text to summarize",
+            ["`minerva summarize --file document.txt`"],
+        )
+    return text
+
+
 def _read_document_text(*, file_path: str | None, stdin: bytes) -> str:
     if file_path:
         return resolve_path(file_path).read_text(encoding="utf-8")
@@ -702,7 +852,7 @@ def _is_gemini_3(model: str) -> bool:
     return model.startswith("gemini-3")
 
 def _is_gemini_3_flash(model: str) -> bool:
-    return model.startswith("gemini-3-flash")
+    return model.startswith(("gemini-3-flash", "gemini-3.6-flash"))
 
 def _is_gemini_25(model: str) -> bool:
     return model.startswith("gemini-2.5")
@@ -724,7 +874,7 @@ def _missing_api_key_result(model: str, start: float) -> CommandResult:
         return error_result(
             "OPENAI_API_KEY is not set",
             "set OPENAI_API_KEY and retry, or choose a Gemini model with GEMINI_API_KEY configured",
-            ["`export OPENAI_API_KEY=...`", "`--model gemini-3-flash`"],
+            ["`export OPENAI_API_KEY=...`", "`--model gemini-3.6-flash`"],
             start,
         )
     return error_result(
@@ -982,6 +1132,17 @@ async def _run_extractions(
 # ---------------------------------------------------------------------------
 # CLI plumbing
 # ---------------------------------------------------------------------------
+def _print_summary(result: CommandResult) -> None:
+    if result.exit_code == 0:
+        typer.echo(result.stdout.decode("utf-8"))
+        return
+    envelope = OutputEnvelope.from_result(
+        result, workspace_root=get_settings().ensure_workspace_root()
+    )
+    typer.echo(envelope.render())
+    raise typer.Exit(result.exit_code)
+
+
 def _print(result: CommandResult) -> None:
     envelope = OutputEnvelope.from_result(result, workspace_root=get_settings().ensure_workspace_root())
     typer.echo(envelope.render())

--- a/src/harness/commands/news.py
+++ b/src/harness/commands/news.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import date
 from pathlib import Path
 from typing import NoReturn
 
@@ -11,14 +12,19 @@ import typer
 
 from harness import news
 from harness.config import get_settings
+from harness.portfolio_state import NON_SECURITY_TICKERS, load_json, portfolio_paths
+from minerva import prices as prices_mod
 
 NEWS_HELP = (
-    "Ingest collected news and check candidate article existence.\n\n"
+    "Ingest collected news, check article existence, and download market data.\n\n"
     "Examples:\n"
     "  minerva news ingest --raw-dir ./raw --summaries-dir ./summaries\n"
     "  minerva news ingest --date 2026-07-19\n"
     "  minerva news exist --db invest.db --source-id example --input candidates.json\n"
+    "  minerva news download-market-data --date 2026-07-19\n"
 )
+
+DEFAULT_MARKET_INDEXES = ("^GSPC", "^IXIC", "^DJI", "^RUT", "^VIX")
 
 app = typer.Typer(help=NEWS_HELP, no_args_is_help=True)
 
@@ -130,6 +136,90 @@ def ingest_cli(
 
     # Preserve the ingestion script's one-line, sorted JSON stdout contract.
     typer.echo(json.dumps(result.stats, sort_keys=True))
+
+
+def market_instruments(
+    workspace_root: Path,
+    *,
+    indexes: list[str] | None,
+    symbols: list[str],
+) -> list[tuple[str, str | None, str]]:
+    """Return a deterministic holdings/watchlist, index, and explicit universe."""
+    universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+    instruments: list[tuple[str, str | None, str]] = []
+    positions: dict[str, int] = {}
+
+    def add(symbol: str, exchange: str | None, instrument_type: str) -> None:
+        normalized = symbol.strip().upper()
+        if not normalized or normalized in NON_SECURITY_TICKERS:
+            return
+        existing = positions.get(normalized)
+        if existing is not None:
+            if instrument_type == "index":
+                instruments[existing] = (normalized, exchange, instrument_type)
+            return
+        positions[normalized] = len(instruments)
+        instruments.append((normalized, exchange, instrument_type))
+
+    portfolio_rows = universe if isinstance(universe, list) else []
+    for item in sorted(
+        (row for row in portfolio_rows if isinstance(row, dict)),
+        key=lambda row: str(row.get("ticker") or "").upper(),
+    ):
+        add(
+            str(item.get("ticker") or ""),
+            str(item["exchange"]) if item.get("exchange") else None,
+            "security",
+        )
+    for symbol in DEFAULT_MARKET_INDEXES if indexes is None else indexes:
+        add(symbol, None, "index")
+    for symbol in symbols:
+        add(symbol, None, "security")
+    return instruments
+
+
+@app.command("download-market-data")
+def download_market_data_cli(
+    single_date: str = typer.Option(
+        ...,
+        "--date",
+        metavar="YYYY-MM-DD",
+        help="Use the latest completed trading session on or before this date.",
+    ),
+    db_path: Path | None = typer.Option(
+        None,
+        "--db",
+        help="SQLite database (default: <workspace>/data/04-database/invest.db).",
+    ),
+    indexes: list[str] = typer.Option(
+        [],
+        "--index",
+        help="Index symbol; repeat to replace the default index set.",
+    ),
+    symbols: list[str] = typer.Option(
+        [],
+        "--symbol",
+        help="Additional Yahoo symbol; may be repeated.",
+    ),
+) -> None:
+    """Store completed daily market movements in the existing prices table."""
+    try:
+        target_date = date.fromisoformat(single_date)
+    except ValueError:
+        _fail(f"invalid --date: {single_date!r}; expected YYYY-MM-DD", exit_code=2)
+
+    workspace_root = get_settings().resolved_workspace_root
+    resolved_db = db_path or prices_mod.default_db_path(workspace_root)
+    instruments = market_instruments(
+        workspace_root,
+        indexes=list(indexes) if indexes else None,
+        symbols=list(symbols or []),
+    )
+    try:
+        result = prices_mod.download_market_data(resolved_db, instruments, target_date)
+    except (OSError, sqlite3.Error) as exc:
+        _fail(str(exc), exit_code=1)
+    typer.echo(json.dumps(result, sort_keys=True, separators=(",", ":")))
 
 
 @app.command("exist")

--- a/src/harness/commands/news.py
+++ b/src/harness/commands/news.py
@@ -20,6 +20,7 @@ NEWS_HELP = (
     "candidate existence.\n\n"
     "Examples:\n"
     "  minerva news download-finnhub --date 2026-07-19\n"
+    "  minerva news ingest --input article.json\n"
     "  minerva news ingest --raw-dir ./raw --summaries-dir ./summaries\n"
     "  minerva news ingest --date 2026-07-19\n"
     "  minerva news exist --db invest.db --source-id example --input candidates.json\n"
@@ -105,6 +106,15 @@ def ingest_cli(
         "--raw-dir",
         help="Explicit raw directory (bypasses --news-root).",
     ),
+    input_path: str | None = typer.Option(
+        None,
+        "--input",
+        metavar="FILE",
+        help=(
+            "One normalized article JSON object with title, source_id, url, "
+            "published_at, and content (use - for stdin)."
+        ),
+    ),
     summaries_dir: Path | None = typer.Option(
         None,
         "--summaries-dir",
@@ -144,14 +154,41 @@ def ingest_cli(
         help="Optional file to write per-file decisions.",
     ),
 ) -> None:
-    """Ingest raw markdown and matching summaries into the news table."""
-    selected_modes = (
-        int(all_dates) + int(single_date is not None) + int(raw_dir is not None)
+    """Ingest one normalized article or a file-based news batch."""
+    selected_modes = sum(
+        (
+            int(input_path is not None),
+            int(all_dates),
+            int(single_date is not None),
+            int(raw_dir is not None),
+        )
     )
     if selected_modes != 1:
-        _fail("exactly one of --all, --date, or --raw-dir is required", exit_code=2)
+        _fail(
+            "exactly one of --input, --all, --date, or --raw-dir is required",
+            exit_code=2,
+        )
     if summaries_dir is not None and raw_dir is None:
         _fail("--summaries-dir requires --raw-dir", exit_code=2)
+    if input_path is not None:
+        incompatible = [
+            flag
+            for flag, selected in (
+                ("--summaries-dir", summaries_dir is not None),
+                ("--news-root", news_root is not None),
+                ("--news-sources", news_sources is not None),
+                ("--ir-registry", ir_registry is not None),
+                ("--enrich", bool(enrich)),
+                ("--report", report is not None),
+            )
+            if selected
+        ]
+        if incompatible:
+            _fail(
+                "--input cannot be combined with batch option(s): "
+                + ", ".join(incompatible),
+                exit_code=2,
+            )
 
     workspace_root = get_settings().resolved_workspace_root
     resolved_news_root = news_root or workspace_root / "data" / "02-news"
@@ -171,6 +208,19 @@ def ingest_cli(
     )
 
     try:
+        if input_path is not None:
+            article = news.parse_article_input(_read_json_input(input_path))
+            article_result = news.ingest_article(resolved_db_path, article)
+            typer.echo(
+                json.dumps(
+                    article_result,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            return
+
         result = news.ingest(
             db_path=resolved_db_path,
             news_root=resolved_news_root,
@@ -187,6 +237,8 @@ def ingest_cli(
             report.write_text(
                 "\n".join(result.report_lines) + "\n", encoding="utf-8"
             )
+    except news.ArticleInputError as exc:
+        _fail(str(exc), exit_code=2)
     except news.NewsError as exc:
         _fail(str(exc), exit_code=1)
     except (OSError, sqlite3.Error) as exc:
@@ -297,7 +349,7 @@ def exist_cli(
 ) -> None:
     """Return which candidate news items already exist in SQLite."""
     try:
-        raw = _read_candidate_input(input_path)
+        raw = _read_json_input(input_path)
         candidates = news.parse_candidates(raw)
         result = news.check_candidates(db_path, source_id, candidates)
     except news.CandidateInputError as exc:
@@ -310,7 +362,7 @@ def exist_cli(
     typer.echo(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
 
 
-def _read_candidate_input(input_path: str) -> str:
+def _read_json_input(input_path: str) -> str:
     if input_path == "-":
         return typer.get_text_stream("stdin").read()
     return Path(input_path).read_text(encoding="utf-8")

--- a/src/harness/commands/news.py
+++ b/src/harness/commands/news.py
@@ -16,8 +16,10 @@ from harness.portfolio_state import NON_SECURITY_TICKERS, load_json, portfolio_p
 from minerva import prices as prices_mod
 
 NEWS_HELP = (
-    "Ingest collected news, check article existence, and download market data.\n\n"
+    "Download Finnhub news and market data, ingest collected articles, and check "
+    "candidate existence.\n\n"
     "Examples:\n"
+    "  minerva news download-finnhub --date 2026-07-19\n"
     "  minerva news ingest --raw-dir ./raw --summaries-dir ./summaries\n"
     "  minerva news ingest --date 2026-07-19\n"
     "  minerva news exist --db invest.db --source-id example --input candidates.json\n"
@@ -27,6 +29,62 @@ NEWS_HELP = (
 DEFAULT_MARKET_INDEXES = ("^GSPC", "^IXIC", "^DJI", "^RUT", "^VIX")
 
 app = typer.Typer(help=NEWS_HELP, no_args_is_help=True)
+
+
+@app.command("download-finnhub")
+def download_finnhub_cli(
+    date_arg: str = typer.Option(
+        ...,
+        "--date",
+        metavar="YYYY-MM-DD",
+        help="America/New_York publication day to download.",
+    ),
+    db_path: Path | None = typer.Option(
+        None,
+        "--db",
+        help="SQLite database (default: <workspace>/data/04-database/invest.db).",
+    ),
+    symbols: list[str] = typer.Option(
+        [],
+        "--symbol",
+        help=(
+            "Only download company news for this Finnhub symbol; may repeat. "
+            "Default: all current holdings and watchlist symbols."
+        ),
+    ),
+) -> None:
+    """Download Finnhub records directly into the canonical news table."""
+    try:
+        if not news.DATE_ONLY_RE.fullmatch(date_arg):
+            raise ValueError
+        publication_date = date.fromisoformat(date_arg)
+    except ValueError:
+        _fail("--date must be a valid YYYY-MM-DD date", exit_code=2)
+
+    settings = get_settings()
+    if not settings.finnhub_api_key:
+        _fail("FINNHUB_API_KEY is not configured", exit_code=1)
+    workspace_root = settings.resolved_workspace_root
+    resolved_db_path = (
+        db_path or workspace_root / "data" / "04-database" / "invest.db"
+    )
+    try:
+        universe = load_json(portfolio_paths(workspace_root).universe, default=[])
+        if not isinstance(universe, list):
+            _fail("portfolio universe must be a JSON array", exit_code=1)
+        result = news.download_finnhub(
+            db_path=resolved_db_path,
+            api_key=settings.finnhub_api_key,
+            publication_date=publication_date,
+            universe=universe,
+            requested_symbols=symbols,
+        )
+    except news.NewsError as exc:
+        _fail(str(exc), exit_code=1)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        _fail(str(exc), exit_code=1)
+
+    typer.echo(json.dumps(result, sort_keys=True, separators=(",", ":")))
 
 
 @app.command("ingest")

--- a/src/harness/finnhub.py
+++ b/src/harness/finnhub.py
@@ -1,0 +1,94 @@
+"""Small Finnhub provider boundary shared by news consumers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+FINNHUB_CALL_DELAY_SECONDS = 0.1
+
+
+@dataclass(slots=True)
+class FinnhubNewsPayload:
+    """Raw Finnhub news grouped by endpoint, plus request failures."""
+
+    general: list[dict[str, object]]
+    company: list[dict[str, object]]
+    errors: int = 0
+
+
+def fetch_finnhub_news(
+    *,
+    api_key: str,
+    publication_date: date,
+    symbols: Mapping[str, str],
+    delay: float = FINNHUB_CALL_DELAY_SECONDS,
+) -> FinnhubNewsPayload:
+    """Fetch general news and one publication day of company news.
+
+    ``symbols`` maps Finnhub symbols to canonical security IDs. Endpoint
+    failures are isolated so one unsupported company does not abort the batch.
+    """
+    session = requests.Session()
+    general: list[dict[str, object]] = []
+    company: list[dict[str, object]] = []
+    errors = 0
+
+    try:
+        time.sleep(delay)
+        response = session.get(
+            f"{FINNHUB_BASE_URL}/news",
+            params={"category": "general", "token": api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, list):
+            general = [dict(item) for item in payload if isinstance(item, dict)]
+    except (requests.RequestException, ValueError) as exc:
+        errors += 1
+        logger.warning("failed to fetch general market news: %s", exc)
+
+    date_string = publication_date.isoformat()
+    for symbol, security_id in symbols.items():
+        try:
+            time.sleep(delay)
+            response = session.get(
+                f"{FINNHUB_BASE_URL}/company-news",
+                params={
+                    "symbol": symbol,
+                    "from": date_string,
+                    "to": date_string,
+                    "token": api_key,
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                continue
+            for raw_item in payload:
+                if not isinstance(raw_item, dict):
+                    continue
+                item = dict(raw_item)
+                item["_security_id"] = security_id
+                item["_finnhub_symbol"] = symbol
+                company.append(item)
+        except (requests.RequestException, ValueError) as exc:
+            errors += 1
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            logger.warning(
+                "skipping company-news for %s: %s",
+                symbol,
+                f"HTTP {status}" if status else type(exc).__name__,
+            )
+
+    return FinnhubNewsPayload(general=general, company=company, errors=errors)

--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -18,6 +18,7 @@ from lxml import html as lxml_html
 
 logger = logging.getLogger(__name__)
 
+from harness.finnhub import fetch_finnhub_news
 from harness.portfolio_state import (
     NON_SECURITY_TICKERS,
     append_jsonl,
@@ -1794,60 +1795,32 @@ def _load_finnhub_payload(
             }
         )
 
-    # General market news
-    news: list[dict[str, Any]] = []
-    try:
-        time_mod.sleep(delay)
-        news_response = session.get(
-            f"{base_url}/news",
-            params={"category": "general", "token": api_key},
-            timeout=30,
-        )
-        news_response.raise_for_status()
-        news = news_response.json() if isinstance(news_response.json(), list) else []
-    except Exception as exc:
-        logger.warning("failed to fetch general market news: %s", exc)
-
-    # Company-specific news
-    company_news: list[dict[str, Any]] = []
-    if universe:
-        date_str = run_date.isoformat()
-        for security in universe:
-            finnhub_sym = str(
-                security.get("finnhub_symbol") or security.get("ticker") or security.get("security_id") or ""
+    company_symbols: dict[str, str] = {}
+    for security in universe or []:
+        finnhub_symbol = str(
+            security.get("finnhub_symbol")
+            or security.get("ticker")
+            or security.get("security_id")
+            or ""
+        ).strip()
+        if finnhub_symbol and security.get("sec_registered"):
+            company_symbols[finnhub_symbol] = str(
+                security.get("security_id") or finnhub_symbol
             ).strip()
-            if not finnhub_sym:
-                continue
-            if not security.get("sec_registered"):
-                continue
-            try:
-                time_mod.sleep(delay)
-                cn_response = session.get(
-                    f"{base_url}/company-news",
-                    params={"symbol": finnhub_sym, "from": date_str, "to": date_str, "token": api_key},
-                    timeout=30,
-                )
-                cn_response.raise_for_status()
-                items = cn_response.json() if isinstance(cn_response.json(), list) else []
-                for item in items:
-                    item["_security_id"] = str(security.get("security_id") or finnhub_sym).strip()
-                    item["_finnhub_symbol"] = finnhub_sym
-                company_news.extend(items)
-            except Exception as exc:
-                status = getattr(getattr(exc, "response", None), "status_code", None)
-                logger.warning(
-                    "skipping company-news for %s: %s",
-                    finnhub_sym,
-                    f"HTTP {status}" if status else type(exc).__name__,
-                )
+    news_payload = fetch_finnhub_news(
+        api_key=api_key,
+        publication_date=run_date,
+        symbols=company_symbols,
+        delay=delay,
+    )
 
     return {
         "earnings": earnings_payload.get("earningsCalendar", earnings_payload.get("earnings", [])),
         "indexes": indexes,
         "rates": [],
         "fx": [],
-        "news": news,
-        "company_news": company_news,
+        "news": news_payload.general,
+        "company_news": news_payload.company,
     }
 
 

--- a/src/harness/news.py
+++ b/src/harness/news.py
@@ -18,6 +18,9 @@ from pathlib import Path
 from typing import Iterable, Literal, Mapping, Sequence, TypedDict
 from zoneinfo import ZoneInfo
 
+from harness.finnhub import fetch_finnhub_news
+from harness.portfolio_state import NON_SECURITY_TICKERS
+
 # Header keys we care about (case-insensitive on the label).
 META_KEYS = {"source", "url", "published", "collected", "section", "status"}
 
@@ -925,6 +928,180 @@ def load_enrichment(paths: Iterable[Path]) -> dict[str, str]:
                     if len(article_path.parts) >= 3:
                         out["/".join(article_path.parts[-3:])] = publication_input
     return out
+
+
+# ---------------------------------------------------------------------------
+# Direct Finnhub download
+# ---------------------------------------------------------------------------
+FINNHUB_PUBLICATION_TIMEZONE = ZoneInfo("America/New_York")
+
+
+def resolve_finnhub_symbols(
+    universe: Sequence[Mapping[str, object]],
+    requested_symbols: Sequence[str] = (),
+) -> dict[str, str]:
+    """Map Finnhub symbols to security IDs for the selected company universe.
+
+    Explicit symbols replace the portfolio universe. Otherwise every current
+    holding/watchlist row with a usable Finnhub symbol or ticker is included;
+    SEC registration is intentionally irrelevant to news availability.
+    """
+    if requested_symbols:
+        selected = {
+            symbol.strip().upper(): symbol.strip().upper()
+            for symbol in requested_symbols
+            if symbol.strip()
+        }
+        return dict(sorted(selected.items()))
+
+    selected: dict[str, str] = {}
+    for security in universe:
+        if not isinstance(security, Mapping):
+            continue
+        security_id = str(
+            security.get("security_id") or security.get("ticker") or ""
+        ).strip().upper()
+        symbol = str(
+            security.get("finnhub_symbol")
+            or security.get("ticker")
+            or security.get("security_id")
+            or ""
+        ).strip().upper()
+        if not symbol or symbol in NON_SECURITY_TICKERS:
+            continue
+        selected[symbol] = security_id or symbol
+    return dict(sorted(selected.items()))
+
+
+def _finnhub_source_id(value: object) -> str:
+    source_id = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower())
+    return source_id.strip("-") or "finnhub"
+
+
+def _normalize_finnhub_article(
+    item: Mapping[str, object],
+    *,
+    publication_date: date,
+    section: str,
+) -> tuple[str, int, str, str, str, str, str, str] | None:
+    timestamp = item.get("datetime")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+        return None
+    try:
+        published = datetime.fromtimestamp(
+            timestamp, timezone.utc
+        ).astimezone(FINNHUB_PUBLICATION_TIMEZONE)
+    except (OSError, OverflowError, ValueError):
+        return None
+    if published.date() != publication_date:
+        return None
+
+    title = str(item.get("headline") or "").strip()
+    if not title:
+        return None
+    source_id = _finnhub_source_id(item.get("source"))
+    published_at_raw = published.isoformat(timespec="seconds")
+    content = str(item.get("summary") or "").strip() or title
+    url = str(item.get("url") or "").strip()
+    key = article_key(source_id, publication_date.isoformat(), title)
+    return (
+        key,
+        int(timestamp),
+        published_at_raw,
+        title,
+        content,
+        source_id,
+        url,
+        section,
+    )
+
+
+def download_finnhub(
+    *,
+    db_path: Path,
+    api_key: str,
+    publication_date: date,
+    universe: Sequence[Mapping[str, object]],
+    requested_symbols: Sequence[str] = (),
+) -> dict[str, int | str]:
+    """Download one New York publication day and persist canonical news rows."""
+    symbols = resolve_finnhub_symbols(universe, requested_symbols)
+    payload = fetch_finnhub_news(
+        api_key=api_key,
+        publication_date=publication_date,
+        symbols=symbols,
+    )
+    scoped_items = [
+        (item, "finnhub-general") for item in payload.general
+    ] + [(item, "finnhub-company") for item in payload.company]
+    stats = {
+        "date": publication_date.isoformat(),
+        "timezone": str(FINNHUB_PUBLICATION_TIMEZONE),
+        "symbols": len(symbols),
+        "fetched": len(scoped_items),
+        "eligible": 0,
+        "inserted": 0,
+        "duplicates": 0,
+        "skipped": 0,
+        "errors": payload.errors,
+    }
+    collected_at = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("BEGIN")
+        ensure_schema(conn)
+        for item, section in scoped_items:
+            normalized = _normalize_finnhub_article(
+                item,
+                publication_date=publication_date,
+                section=section,
+            )
+            if normalized is None:
+                stats["skipped"] += 1
+                continue
+            stats["eligible"] += 1
+            key, epoch, raw, title, content, source, url, row_section = normalized
+            existing = None
+            if url:
+                existing = conn.execute(
+                    "SELECT 1 FROM news WHERE url = ? COLLATE BINARY LIMIT 1",
+                    (url,),
+                ).fetchone()
+            if existing is None:
+                existing = conn.execute(
+                    "SELECT 1 FROM news WHERE article_key = ? COLLATE BINARY LIMIT 1",
+                    (key,),
+                ).fetchone()
+            if existing is not None:
+                stats["duplicates"] += 1
+                continue
+            conn.execute(
+                "INSERT INTO news "
+                "(article_key, published_at, published_at_raw, title, content, "
+                "summary, source, url, section, collected_at) "
+                "VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)",
+                (
+                    key,
+                    epoch,
+                    raw,
+                    title,
+                    content,
+                    source,
+                    url,
+                    row_section,
+                    collected_at,
+                ),
+            )
+            stats["inserted"] += 1
+        conn.commit()
+        stats["db_total"] = conn.execute("SELECT COUNT(*) FROM news").fetchone()[0]
+    finally:
+        conn.close()
+    return stats
 
 
 # ---------------------------------------------------------------------------

--- a/src/harness/news.py
+++ b/src/harness/news.py
@@ -13,8 +13,9 @@ import json
 import re
 import sqlite3
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
+from time import monotonic, sleep
 from typing import Iterable, Literal, Mapping, Sequence, TypedDict
 from zoneinfo import ZoneInfo
 
@@ -33,6 +34,10 @@ class NewsError(Exception):
 
 class CandidateInputError(NewsError):
     """Raised when candidate JSON does not match the lookup contract."""
+
+
+class ArticleInputError(NewsError):
+    """Raised when single-article JSON does not match the ingest contract."""
 
 
 class SourceRegistryError(NewsError):
@@ -541,6 +546,104 @@ def article_key(source_id: str, date_only: str, title: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Single-article input
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ArticleInput:
+    """Validated normalized article supplied directly by a crawler."""
+
+    title: str
+    source_id: str
+    url: str
+    published_at_raw: str
+    published: ParsedPublished
+    content: str
+    summary: str | None = None
+    section: str | None = None
+    collected_at: str | None = None
+
+
+ArticleIngestStatus = Literal["inserted", "duplicate", "updated"]
+
+
+class ArticleIngestResult(TypedDict):
+    status: ArticleIngestStatus
+    article_key: str
+
+
+_ARTICLE_REQUIRED_FIELDS = (
+    "title",
+    "source_id",
+    "url",
+    "published_at",
+    "content",
+)
+_ARTICLE_OPTIONAL_FIELDS = {"summary", "section", "collected_at"}
+
+
+def _required_article_text(payload: Mapping[str, object], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ArticleInputError(f"article must have a non-empty string {field}")
+    return value.strip()
+
+
+def _optional_article_text(payload: Mapping[str, object], field: str) -> str | None:
+    value = payload.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ArticleInputError(f"article {field} must be a string or null")
+    return value.strip() or None
+
+
+def parse_article_input(text: str) -> ArticleInput:
+    """Parse one normalized Markdown/text article from a JSON object."""
+    try:
+        payload: object = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ArticleInputError(
+            f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ArticleInputError("article JSON must be an object")
+
+    unknown = set(payload) - set(_ARTICLE_REQUIRED_FIELDS) - _ARTICLE_OPTIONAL_FIELDS
+    if unknown:
+        raise ArticleInputError(
+            f"article has unknown field(s): {', '.join(sorted(unknown))}"
+        )
+
+    values = {
+        field: _required_article_text(payload, field)
+        for field in _ARTICLE_REQUIRED_FIELDS
+    }
+    published = normalize_published(values["published_at"])
+    if published is None:
+        raise ArticleInputError("article must have a parseable published_at")
+    if re.match(r"^(?:<!doctype\s+html\b|<html\b)", values["content"], re.IGNORECASE):
+        raise ArticleInputError(
+            "article content must be normalized Markdown/text, not raw HTML"
+        )
+
+    collected_at = _optional_article_text(payload, "collected_at")
+    if collected_at is not None:
+        collected_at = normalize_collected(collected_at)
+
+    return ArticleInput(
+        title=values["title"],
+        source_id=values["source_id"],
+        url=values["url"],
+        published_at_raw=values["published_at"],
+        published=published,
+        content=values["content"],
+        summary=_optional_article_text(payload, "summary"),
+        section=_optional_article_text(payload, "section"),
+        collected_at=collected_at,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Read-only duplicate lookup
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True, slots=True)
@@ -865,6 +968,96 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         _migrate_legacy_news(conn, set(columns))
     else:
         _create_news_schema(conn)
+
+
+def _enable_wal(conn: sqlite3.Connection) -> None:
+    """Enable WAL, retrying its lock-sensitive first-time transition."""
+    deadline = monotonic() + 30
+    while True:
+        try:
+            conn.execute("PRAGMA journal_mode = WAL")
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() or monotonic() >= deadline:
+                raise
+            sleep(0.05)
+
+
+def ingest_article(db_path: Path, article: ArticleInput) -> ArticleIngestResult:
+    """Insert or update one article in a short, serialized WAL transaction."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    key = article_key(article.source_id, article.published.date_only, article.title)
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        conn.execute("PRAGMA busy_timeout = 30000")
+        _enable_wal(conn)
+        conn.execute("BEGIN IMMEDIATE")
+        ensure_schema(conn)
+        existing = conn.execute(
+            f"SELECT {', '.join(_NEWS_COLUMNS)} FROM news "
+            "WHERE url = ? COLLATE BINARY "
+            "ORDER BY CASE WHEN article_key = ? THEN 0 ELSE 1 END, article_key "
+            "LIMIT 1",
+            (article.url, key),
+        ).fetchone()
+        if existing is None:
+            existing = conn.execute(
+                f"SELECT {', '.join(_NEWS_COLUMNS)} FROM news WHERE article_key = ?",
+                (key,),
+            ).fetchone()
+        collected_at = article.collected_at
+        if collected_at is None:
+            collected_at = (
+                existing[-1]
+                if existing is not None
+                else datetime.now(UTC)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z")
+            )
+        values = (
+            key,
+            article.published.epoch,
+            article.published_at_raw,
+            article.title,
+            article.content,
+            article.summary,
+            article.source_id,
+            article.url,
+            article.section,
+            collected_at,
+        )
+
+        if existing is None:
+            placeholders = ", ".join("?" for _ in _NEWS_COLUMNS)
+            conn.execute(
+                f"INSERT INTO news ({', '.join(_NEWS_COLUMNS)}) "
+                f"VALUES ({placeholders})",
+                values,
+            )
+            status: ArticleIngestStatus = "inserted"
+        elif tuple(existing) == values:
+            status = "duplicate"
+        elif existing[0] != key and conn.execute(
+            "SELECT 1 FROM news WHERE article_key = ?", (key,)
+        ).fetchone() is not None:
+            # The database already contains separate URL and article-key
+            # matches. Preserve both rather than guessing which row to merge.
+            status = "duplicate"
+        else:
+            assignments = ", ".join(f"{column} = ?" for column in _NEWS_COLUMNS)
+            conn.execute(
+                f"UPDATE news SET {assignments} WHERE article_key = ?",
+                (*values, existing[0]),
+            )
+            status = "updated"
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return {"status": status, "article_key": key}
 
 
 # ---------------------------------------------------------------------------

--- a/src/minerva/prices.py
+++ b/src/minerva/prices.py
@@ -1,7 +1,7 @@
-"""52-week price position tracking.
+"""Yahoo price snapshots and completed daily market movements.
 
-Pulls current price and 52-week high/low from Yahoo Finance, persists dated
-snapshots to invest.db, and reports where each ticker sits in its 52-week band:
+Pulls prices from Yahoo Finance, persists dated snapshots to invest.db, and
+reports where each ticker sits in its 52-week band:
 
     range_pct = (current - low) / (high - low)   # 0 = on 52w low, 1 = on 52w high
 
@@ -9,8 +9,8 @@ Yahoo covers US and international listings with one keyless call per ticker.
 range_pct is computed on read (via the ``price_position`` view), never stored, so a
 corrected input never leaves a stale value behind.
 
-Network access is isolated in ``fetch_price`` and injected into ``refresh_prices`` as
-a ``fetcher`` callable, which keeps the orchestration testable without mocking HTTP.
+Network access stays behind injectable fetchers, keeping orchestration testable
+without live HTTP.
 """
 
 from __future__ import annotations
@@ -18,10 +18,13 @@ from __future__ import annotations
 import logging
 import sqlite3
 import time
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, date, datetime, timedelta
+from datetime import time as datetime_time
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
 
@@ -51,29 +54,43 @@ _EXCHANGE_SUFFIX = {
     "BME": ".MC",    # Madrid
 }
 
-# Mirrored in hard-disk/data/04-database/schema.sql. Kept here so tests and the CLI
-# can materialize the table + view into any database without reading that file.
-_SCHEMA_SQL = """
+# Runtime source of truth for the prices schema. ``ensure_schema`` creates fresh
+# databases and migrates existing workspace databases without an external file.
+_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS prices (
-    id          INTEGER PRIMARY KEY,
-    ticker      TEXT NOT NULL,
-    as_of       TEXT NOT NULL,
-    current     REAL,
-    wk52_low    REAL,
-    wk52_high   REAL,
-    currency    TEXT,
-    source      TEXT NOT NULL DEFAULT 'yahoo',
-    fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    id              INTEGER PRIMARY KEY,
+    ticker          TEXT NOT NULL,
+    as_of           TEXT NOT NULL,
+    current         REAL,
+    wk52_low        REAL,
+    wk52_high       REAL,
+    currency        TEXT,
+    source          TEXT NOT NULL DEFAULT 'yahoo',
+    fetched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    previous_close  REAL,
+    change_pct      REAL,
+    instrument_type TEXT NOT NULL DEFAULT 'security',
     UNIQUE (ticker, as_of)
 );
-CREATE VIEW IF NOT EXISTS price_position AS
-SELECT
-    ticker, as_of, current, wk52_low, wk52_high, currency,
-    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
-FROM prices;
 CREATE INDEX IF NOT EXISTS idx_prices_ticker ON prices(ticker);
 CREATE INDEX IF NOT EXISTS idx_prices_asof   ON prices(as_of);
 """
+
+_PRICE_POSITION_SQL = """
+DROP VIEW IF EXISTS price_position;
+CREATE VIEW price_position AS
+SELECT
+    ticker, as_of, current, wk52_low, wk52_high, currency,
+    ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct,
+    previous_close, change_pct, instrument_type
+FROM prices;
+"""
+
+_MIGRATION_COLUMNS = {
+    "previous_close": "REAL",
+    "change_pct": "REAL",
+    "instrument_type": "TEXT NOT NULL DEFAULT 'security'",
+}
 
 
 @dataclass(slots=True)
@@ -87,6 +104,9 @@ class PriceRow:
     wk52_high: float | None
     currency: str | None = None
     source: str = "yahoo"
+    previous_close: float | None = None
+    change_pct: float | None = None
+    instrument_type: str = "security"
 
 
 def range_pct(row: PriceRow) -> float | None:
@@ -98,6 +118,13 @@ def range_pct(row: PriceRow) -> float | None:
     if span == 0:
         return None
     return (current - low) / span
+
+
+def daily_change_pct(current: float | None, previous: float | None) -> float | None:
+    """Return close-to-close change in percentage points, rounded deterministically."""
+    if current is None or previous in {None, 0}:
+        return None
+    return round((current - previous) / previous * 100, 6)
 
 
 def yahoo_symbol(ticker: str, exchange: str | None) -> str:
@@ -145,9 +172,16 @@ def tracked_companies(db_path: str | Path) -> list[tuple[str, str | None]]:
 
 
 def ensure_schema(db_path: str | Path) -> None:
-    """Create the prices table + view if absent. Idempotent."""
-    with sqlite3.connect(str(db_path)) as conn:
-        conn.executescript(_SCHEMA_SQL)
+    """Create or minimally migrate the prices table and compatible view."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as conn:
+        conn.executescript(_TABLE_SQL)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(prices)")}
+        for name, declaration in _MIGRATION_COLUMNS.items():
+            if name not in columns:
+                conn.execute(f"ALTER TABLE prices ADD COLUMN {name} {declaration}")
+        conn.executescript(_PRICE_POSITION_SQL)
         conn.commit()
 
 
@@ -159,15 +193,22 @@ def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
             conn.execute(
                 """
                 INSERT INTO prices
-                    (ticker, as_of, current, wk52_low, wk52_high, currency, source, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                    (ticker, as_of, current, wk52_low, wk52_high, currency, source,
+                     fetched_at, previous_close, change_pct, instrument_type)
+                VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), ?, ?, ?)
                 ON CONFLICT(ticker, as_of) DO UPDATE SET
-                    current    = excluded.current,
-                    wk52_low   = excluded.wk52_low,
-                    wk52_high  = excluded.wk52_high,
-                    currency   = excluded.currency,
-                    source     = excluded.source,
-                    fetched_at = excluded.fetched_at
+                    current         = excluded.current,
+                    wk52_low        = excluded.wk52_low,
+                    wk52_high       = excluded.wk52_high,
+                    currency        = excluded.currency,
+                    source          = excluded.source,
+                    fetched_at      = excluded.fetched_at,
+                    previous_close  = COALESCE(excluded.previous_close, prices.previous_close),
+                    change_pct      = CASE
+                        WHEN excluded.previous_close IS NULL THEN prices.change_pct
+                        ELSE excluded.change_pct
+                    END,
+                    instrument_type = excluded.instrument_type
                 """,
                 (
                     row.ticker,
@@ -177,6 +218,9 @@ def upsert_prices(db_path: str | Path, rows: Iterable[PriceRow]) -> int:
                     row.wk52_high,
                     row.currency,
                     row.source,
+                    row.previous_close,
+                    row.change_pct,
+                    row.instrument_type,
                 ),
             )
             written += 1
@@ -252,12 +296,169 @@ def fetch_price(
 
     return PriceRow(
         ticker=ticker.upper(),
-        as_of=datetime.now(timezone.utc).date().isoformat(),
+        as_of=datetime.now(UTC).date().isoformat(),
         current=price,
         wk52_low=to_float(meta.get("fiftyTwoWeekLow")),
         wk52_high=to_float(meta.get("fiftyTwoWeekHigh")),
         currency=meta.get("currency"),
     )
+
+
+def market_movement_from_chart(
+    ticker: str,
+    target_date: date,
+    payload: dict[str, Any],
+    *,
+    instrument_type: str = "security",
+    now: datetime | None = None,
+) -> PriceRow:
+    """Select the latest two completed Yahoo sessions on or before a date."""
+    results = (payload.get("chart") or {}).get("result") or []
+    if not results:
+        raise ValueError(f"no chart data for {ticker}")
+    chart = results[0]
+    meta = chart.get("meta") or {}
+    timezone_name = str(meta.get("exchangeTimezoneName") or "UTC")
+    try:
+        exchange_timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"unknown exchange timezone {timezone_name}") from exc
+
+    current_time = now or datetime.now(UTC)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=UTC)
+    local_today = current_time.astimezone(exchange_timezone).date()
+    completed_through = min(target_date, local_today)
+    if completed_through == local_today:
+        regular_end = to_float(
+            ((meta.get("currentTradingPeriod") or {}).get("regular") or {}).get("end")
+        )
+        if regular_end is None or current_time.timestamp() < regular_end:
+            completed_through -= timedelta(days=1)
+
+    timestamps = chart.get("timestamp") or []
+    quotes = ((chart.get("indicators") or {}).get("quote") or [{}])[0]
+    closes = quotes.get("close") or []
+    sessions: dict[date, float] = {}
+    for timestamp, raw_close in zip(timestamps, closes, strict=False):
+        close = to_float(raw_close)
+        if close is None:
+            continue
+        session_date = (
+            datetime.fromtimestamp(float(timestamp), tz=UTC)
+            .astimezone(exchange_timezone)
+            .date()
+        )
+        if session_date <= completed_through:
+            sessions[session_date] = close
+
+    selected = sorted(sessions.items())[-2:]
+    if len(selected) < 2:
+        raise ValueError(f"fewer than two completed trading sessions for {ticker}")
+    (_, previous_close), (as_of, current_close) = selected
+
+    return PriceRow(
+        ticker=ticker.strip().upper(),
+        as_of=as_of.isoformat(),
+        current=current_close,
+        wk52_low=to_float(meta.get("fiftyTwoWeekLow")),
+        wk52_high=to_float(meta.get("fiftyTwoWeekHigh")),
+        currency=meta.get("currency"),
+        previous_close=previous_close,
+        change_pct=daily_change_pct(current_close, previous_close),
+        instrument_type=instrument_type,
+    )
+
+
+def fetch_market_movement(
+    ticker: str,
+    *,
+    target_date: date,
+    exchange: str | None = None,
+    instrument_type: str = "security",
+    session: requests.Session | None = None,
+    limiter: RateLimiter | None = None,
+) -> PriceRow:
+    """Fetch Yahoo daily history and return one completed close-to-close movement."""
+    session = session or requests.Session()
+    symbol = yahoo_symbol(ticker, exchange)
+    if limiter is not None:
+        limiter.acquire()
+
+    # Thirty-two calendar days comfortably spans ordinary exchange closures while
+    # Yahoo timestamps, rather than calendar arithmetic, determine the two sessions.
+    query_end = min(
+        target_date + timedelta(days=1),
+        datetime.now(UTC).date() + timedelta(days=1),
+    )
+    query_start = query_end - timedelta(days=32)
+    response = session.get(
+        YAHOO_CHART_URL.format(symbol=symbol),
+        params={
+            "interval": "1d",
+            "period1": int(
+                datetime.combine(query_start, datetime_time(), tzinfo=UTC).timestamp()
+            ),
+            "period2": int(
+                datetime.combine(query_end, datetime_time(), tzinfo=UTC).timestamp()
+            ),
+        },
+        headers=YAHOO_HEADERS,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return market_movement_from_chart(
+        ticker,
+        target_date,
+        response.json(),
+        instrument_type=instrument_type,
+    )
+
+
+def download_market_data(
+    db_path: str | Path,
+    instruments: Sequence[tuple[str, str | None, str]],
+    target_date: date,
+    *,
+    fetcher: Callable[..., PriceRow] | None = None,
+    limiter: RateLimiter | None = None,
+) -> dict[str, Any]:
+    """Fetch and upsert daily movements with compact per-symbol accounting."""
+    ensure_schema(db_path)
+    active_fetcher = fetcher or fetch_market_movement
+    limiter = limiter or RateLimiter()
+    session = requests.Session()
+    fetched: list[PriceRow] = []
+    errors: list[dict[str, str]] = []
+
+    for ticker, exchange, instrument_type in instruments:
+        try:
+            row = active_fetcher(
+                ticker,
+                target_date=target_date,
+                exchange=exchange,
+                instrument_type=instrument_type,
+                session=session,
+                limiter=limiter,
+            )
+            row.instrument_type = instrument_type
+            row.change_pct = daily_change_pct(row.current, row.previous_close)
+            fetched.append(row)
+        except Exception as exc:  # noqa: BLE001 — isolate one symbol's failure
+            logger.warning("market data fetch failed for %s: %s", ticker, exc)
+            message = str(exc)
+            if isinstance(exc, requests.HTTPError) and exc.response is not None:
+                message = f"HTTP {exc.response.status_code}"
+            errors.append({"symbol": ticker, "error": message})
+
+    if fetched:
+        upsert_prices(db_path, fetched)
+    return {
+        "requested": len(instruments),
+        "written": len(fetched),
+        "trading_dates": sorted({row.as_of for row in fetched}),
+        "errors": errors,
+    }
 
 
 def refresh_prices(
@@ -288,4 +489,3 @@ def refresh_prices(
         upsert_prices(db_path, fetched)
 
     return {"fetched": len(fetched), "errors": errors}
-

--- a/tests/test_harness/test_extract.py
+++ b/tests/test_harness/test_extract.py
@@ -279,9 +279,10 @@ def test_build_thinking_config_unknown_model_with_thinking_raises() -> None:
         extract._build_thinking_config("some-other-model", "minimal")
 
 
-def test_api_model_name_maps_user_facing_gemini_3_flash_alias() -> None:
+def test_api_model_name_maps_only_legacy_gemini_3_flash_alias() -> None:
     assert extract._api_model_name("gemini-3-flash") == "gemini-3-flash-preview"
     assert extract._api_model_name("gemini-3-flash-preview") == "gemini-3-flash-preview"
+    assert extract._api_model_name("gemini-3.6-flash") == "gemini-3.6-flash"
 
 
 def test_api_model_name_maps_provider_qualified_openai_alias() -> None:
@@ -289,7 +290,7 @@ def test_api_model_name_maps_provider_qualified_openai_alias() -> None:
     assert extract._api_model_name("gpt-5.5") == "gpt-5.5"
 
 
-def test_extract_command_default_thinking_for_gemini_3_flash(tmp_path: Path, monkeypatch) -> None:
+def test_extract_command_defaults_to_gemini_36_flash_with_minimal_thinking(tmp_path: Path, monkeypatch) -> None:
     settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
     file_path = tmp_path / "doc.md"
     file_path.write_text("body", encoding="utf-8")
@@ -303,6 +304,7 @@ def test_extract_command_default_thinking_for_gemini_3_flash(tmp_path: Path, mon
 
     extract.extract_command(question="Q", file_path=str(file_path), settings=settings)
 
+    assert captured["model"] == "gemini-3.6-flash"
     assert captured["thinking"] == "minimal"
 
 
@@ -527,8 +529,8 @@ def test_extract_files_one_call_per_file_writes_outputs(tmp_path: Path, monkeypa
     manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
     assert len(manifest["entries"]) == 2
     assert all(entry["status"] == "ok" for entry in manifest["entries"])
-    assert manifest["model"]
-    assert manifest["api_model"]
+    assert manifest["model"] == "gemini-3.6-flash"
+    assert manifest["api_model"] == "gemini-3.6-flash"
 
 
 def test_extract_files_questions_file_passes_pack(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_harness/test_news.py
+++ b/tests/test_harness/test_news.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 from typer.testing import CliRunner
@@ -37,6 +39,18 @@ def _candidate(
     published: str = "2026-07-19",
 ) -> dict[str, str]:
     return {"title": title, "url": url, "published": published}
+
+
+def _article(**overrides: object) -> dict[str, object]:
+    article: dict[str, object] = {
+        "title": "A Big Story",
+        "source_id": "reuters-markets",
+        "url": "https://example.test/story",
+        "published_at": "2026-07-19T09:30:00-04:00",
+        "content": "Normalized article body.",
+    }
+    article.update(overrides)
+    return article
 
 
 def _write_raw(raw_dir: Path, *, title: str = "A   Big Story") -> Path:
@@ -73,6 +87,7 @@ def test_news_commands_are_registered_with_exact_help_surface() -> None:
     assert ingest_help.exit_code == 0
     assert "--raw-dir" in ingest_help.stdout
     assert "--summaries-dir" in ingest_help.stdout
+    assert "--input" in ingest_help.stdout
     assert exist_help.exit_code == 0
     assert "--db" in exist_help.stdout
     assert "--source-id" in exist_help.stdout
@@ -155,6 +170,144 @@ def test_ingest_cli_preserves_stats_report_summary_and_stable_key(
     assert second.exit_code == 0, second.output
     assert json.loads(second.stdout)["duplicates"] == 1
     assert json.loads(second.stdout)["inserted"] == 0
+
+
+def test_ingest_cli_accepts_one_article_from_stdin_or_file_and_upserts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "invest.db"
+    article = _article(summary="Investor summary.", section="markets")
+    args = ["news", "ingest", "--input", "-", "--db", str(db_path)]
+
+    inserted = runner.invoke(app, args, input=json.dumps(article))
+
+    assert inserted.exit_code == 0, inserted.output
+    inserted_result = json.loads(inserted.stdout)
+    assert inserted_result["status"] == "inserted"
+    assert inserted_result["article_key"] == news.article_key(
+        "reuters-markets", "2026-07-19", "A Big Story"
+    )
+
+    input_file = tmp_path / "article.json"
+    input_file.write_text(json.dumps(article), encoding="utf-8")
+    duplicate = runner.invoke(
+        app,
+        ["news", "ingest", "--input", str(input_file), "--db", str(db_path)],
+    )
+    assert duplicate.exit_code == 0, duplicate.output
+    assert json.loads(duplicate.stdout)["status"] == "duplicate"
+
+    article["content"] = "Corrected normalized body."
+    input_file.write_text(json.dumps(article), encoding="utf-8")
+    updated = runner.invoke(
+        app,
+        ["news", "ingest", "--input", str(input_file), "--db", str(db_path)],
+    )
+    assert updated.exit_code == 0, updated.output
+    assert json.loads(updated.stdout)["status"] == "updated"
+
+    article.update(title="Retitled Story", content="Retitled normalized body.")
+    input_file.write_text(json.dumps(article), encoding="utf-8")
+    rekeyed = runner.invoke(
+        app,
+        ["news", "ingest", "--input", str(input_file), "--db", str(db_path)],
+    )
+    assert rekeyed.exit_code == 0, rekeyed.output
+    assert json.loads(rekeyed.stdout) == {
+        "article_key": news.article_key(
+            "reuters-markets", "2026-07-19", "Retitled Story"
+        ),
+        "status": "updated",
+    }
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT title, content, summary, section, collected_at FROM news"
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][:4] == (
+        "Retitled Story",
+        "Retitled normalized body.",
+        "Investor summary.",
+        "markets",
+    )
+    assert rows[0][4].endswith("Z")
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "must be an object"),
+        (_article(content=""), "non-empty string content"),
+        (_article(published_at="July 2026"), "parseable published_at"),
+        (_article(content="<!doctype html><html></html>"), "raw HTML"),
+        (_article(browser_html="<html>raw</html>"), "unknown field"),
+    ],
+)
+def test_ingest_cli_rejects_invalid_single_article_input(
+    tmp_path: Path, payload: object, message: str
+) -> None:
+    db_path = tmp_path / "invest.db"
+
+    result = runner.invoke(
+        app,
+        ["news", "ingest", "--input", "-", "--db", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 2
+    assert message in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not db_path.exists()
+
+
+def test_ingest_cli_rejects_conflicting_single_and_batch_modes(
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "ingest",
+            "--input",
+            "-",
+            "--raw-dir",
+            str(tmp_path / "raw"),
+            "--db",
+            str(tmp_path / "invest.db"),
+        ],
+        input=json.dumps(_article()),
+    )
+
+    assert result.exit_code == 2
+    assert "exactly one of --input, --all, --date, or --raw-dir" in result.stderr
+    assert not (tmp_path / "invest.db").exists()
+
+
+def test_single_article_ingest_allows_concurrent_writers(tmp_path: Path) -> None:
+    db_path = tmp_path / "invest.db"
+    count = 4
+    barrier = Barrier(count)
+
+    def write(index: int) -> str:
+        article = news.parse_article_input(
+            json.dumps(
+                _article(
+                    title=f"Story {index}",
+                    url=f"https://example.test/{index}",
+                )
+            )
+        )
+        barrier.wait()
+        return news.ingest_article(db_path, article)["status"]
+
+    with ThreadPoolExecutor(max_workers=count) as pool:
+        statuses = list(pool.map(write, range(count)))
+
+    assert statuses == ["inserted"] * count
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM news").fetchone()[0] == count
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
 
 
 def test_ingest_cli_reports_malformed_source_registry_without_traceback(

--- a/tests/test_harness/test_news_finnhub.py
+++ b/tests/test_harness/test_news_finnhub.py
@@ -1,0 +1,242 @@
+"""Focused behavior for direct Finnhub news downloads."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from harness import news
+from harness.cli import app
+from harness.commands import news as news_commands
+from harness.config import HarnessSettings
+from harness.finnhub import FinnhubNewsPayload
+
+runner = CliRunner()
+
+
+def _timestamp(value: str) -> int:
+    return int(datetime.fromisoformat(value).timestamp())
+
+
+def _realistic_item(
+    *, published: str, url: str = "https://example.test/nvda"
+) -> dict[str, object]:
+    return {
+        "category": "company",
+        "datetime": _timestamp(published),
+        "headline": "Nvidia unveils its next AI platform",
+        "id": 129876543,
+        "image": "https://example.test/image.jpg",
+        "related": "NVDA",
+        "source": "Reuters",
+        "summary": "The company introduced a new platform for AI workloads.",
+        "url": url,
+    }
+
+
+def _settings(tmp_path: Path, *, api_key: str | None = "test-key") -> HarnessSettings:
+    return HarnessSettings(
+        workspace_root=tmp_path / "workspace", finnhub_api_key=api_key
+    )
+
+
+def test_download_finnhub_uses_current_universe_filters_new_york_day_and_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    universe_path = (
+        settings.resolved_workspace_root
+        / "data"
+        / "01-portfolio"
+        / "current"
+        / "universe.json"
+    )
+    universe_path.parent.mkdir(parents=True)
+    universe_path.write_text(
+        json.dumps(
+            [
+                {
+                    "security_id": "KPG",
+                    "ticker": "KPG",
+                    "finnhub_symbol": "KPG.AX",
+                    "sec_registered": False,
+                    "source_kind": "holding",
+                },
+                {
+                    "security_id": "SNOW",
+                    "ticker": "SNOW",
+                    "source_kind": "watchlist",
+                },
+                {"security_id": "CASH", "ticker": "CASH"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, date, dict[str, str]]] = []
+    on_date = _realistic_item(published="2026-07-19T00:15:00-04:00")
+    duplicate = dict(on_date, related="KPG.AX")
+    prior_et_day = _realistic_item(
+        published="2026-07-18T23:59:00-04:00",
+        url="https://example.test/old",
+    )
+
+    def fake_fetch(
+        *, api_key: str, publication_date: date, symbols: dict[str, str]
+    ) -> FinnhubNewsPayload:
+        calls.append((api_key, publication_date, symbols))
+        return FinnhubNewsPayload(
+            general=[on_date, prior_et_day],
+            company=[duplicate],
+            errors=0,
+        )
+
+    monkeypatch.setattr(news_commands, "get_settings", lambda: settings)
+    monkeypatch.setattr(news, "fetch_finnhub_news", fake_fetch)
+    db_path = tmp_path / "invest.db"
+    args = [
+        "news",
+        "download-finnhub",
+        "--date",
+        "2026-07-19",
+        "--db",
+        str(db_path),
+    ]
+
+    first = runner.invoke(app, args)
+    second = runner.invoke(app, args)
+
+    assert first.exit_code == 0, first.output
+    assert json.loads(first.stdout) == {
+        "date": "2026-07-19",
+        "db_total": 1,
+        "duplicates": 1,
+        "eligible": 2,
+        "errors": 0,
+        "fetched": 3,
+        "inserted": 1,
+        "skipped": 1,
+        "symbols": 2,
+        "timezone": "America/New_York",
+    }
+    assert json.loads(second.stdout) == {
+        **json.loads(first.stdout),
+        "duplicates": 2,
+        "inserted": 0,
+    }
+    assert calls == [
+        ("test-key", date(2026, 7, 19), {"KPG.AX": "KPG", "SNOW": "SNOW"}),
+        ("test-key", date(2026, 7, 19), {"KPG.AX": "KPG", "SNOW": "SNOW"}),
+    ]
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT published_at, published_at_raw, title, content, summary, "
+            "source, url, section FROM news"
+        ).fetchone()
+    assert row == (
+        _timestamp("2026-07-19T00:15:00-04:00"),
+        "2026-07-19T00:15:00-04:00",
+        "Nvidia unveils its next AI platform",
+        "The company introduced a new platform for AI workloads.",
+        None,
+        "reuters",
+        "https://example.test/nvda",
+        "finnhub-general",
+    )
+
+
+def test_download_finnhub_symbol_override_preserves_richer_existing_article(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    db_path = tmp_path / "invest.db"
+    item = _realistic_item(published="2026-07-19T12:00:00-04:00")
+    key = news.article_key("reuters", "2026-07-19", str(item["headline"]))
+    with sqlite3.connect(db_path) as conn:
+        news.ensure_schema(conn)
+        conn.execute(
+            "INSERT INTO news VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                key,
+                item["datetime"],
+                "2026-07-19T12:00:00-04:00",
+                item["headline"],
+                "Full crawler article body with substantially richer reporting.",
+                "Existing analyst summary.",
+                "reuters",
+                item["url"],
+                "markets",
+                "2026-07-19T17:00:00Z",
+            ),
+        )
+
+    captured_symbols: list[dict[str, str]] = []
+
+    def fake_fetch(
+        *, api_key: str, publication_date: date, symbols: dict[str, str]
+    ) -> FinnhubNewsPayload:
+        captured_symbols.append(symbols)
+        return FinnhubNewsPayload(general=[], company=[item], errors=0)
+
+    monkeypatch.setattr(news_commands, "get_settings", lambda: settings)
+    monkeypatch.setattr(news, "fetch_finnhub_news", fake_fetch)
+
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "download-finnhub",
+            "--date",
+            "2026-07-19",
+            "--db",
+            str(db_path),
+            "--symbol",
+            "nvda",
+            "--symbol",
+            "NVDA",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["duplicates"] == 1
+    assert json.loads(result.stdout)["inserted"] == 0
+    assert captured_symbols == [{"NVDA": "NVDA"}]
+    with sqlite3.connect(db_path) as conn:
+        stored = conn.execute(
+            "SELECT content, summary, section, COUNT(*) FROM news"
+        ).fetchone()
+    assert stored == (
+        "Full crawler article body with substantially richer reporting.",
+        "Existing analyst summary.",
+        "markets",
+        1,
+    )
+
+
+def test_download_finnhub_requires_configured_api_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path, api_key=None)
+    monkeypatch.setattr(news_commands, "get_settings", lambda: settings)
+    db_path = tmp_path / "invest.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "download-finnhub",
+            "--date",
+            "2026-07-19",
+            "--db",
+            str(db_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "FINNHUB_API_KEY is not configured" in result.stderr
+    assert not db_path.exists()

--- a/tests/test_harness/test_news_market_data.py
+++ b/tests/test_harness/test_news_market_data.py
@@ -1,0 +1,107 @@
+"""Focused tests for ``news download-market-data``."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from harness.cli import app
+from harness.commands import news as news_commands
+from harness.config import HarnessSettings
+from harness.portfolio_state import portfolio_paths, write_json
+
+runner = CliRunner()
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    paths = portfolio_paths(workspace)
+    paths.current.mkdir(parents=True)
+    write_json(
+        paths.universe,
+        [
+            {"ticker": "AAPL", "exchange": "NASDAQ"},
+            {"ticker": "TOI", "exchange": "TSXV"},
+        ],
+    )
+    return workspace
+
+
+def test_market_instruments_use_default_or_explicit_indexes_and_symbols(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+    defaults = news_commands.market_instruments(
+        workspace, indexes=None, symbols=["nvda", "^gspc"]
+    )
+    custom = news_commands.market_instruments(
+        workspace, indexes=["^STOXX50E"], symbols=["BTC-USD"]
+    )
+
+    assert [item[0] for item in defaults] == [
+        "AAPL",
+        "TOI",
+        "^GSPC",
+        "^IXIC",
+        "^DJI",
+        "^RUT",
+        "^VIX",
+        "NVDA",
+    ]
+    assert [item[0] for item in custom] == ["AAPL", "TOI", "^STOXX50E", "BTC-USD"]
+    assert {symbol: kind for symbol, _, kind in custom} == {
+        "AAPL": "security",
+        "TOI": "security",
+        "^STOXX50E": "index",
+        "BTC-USD": "security",
+    }
+
+
+def test_download_market_data_cli_emits_compact_accounting(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = _workspace(tmp_path)
+    db_path = tmp_path / "invest.db"
+
+    def fake_download(db, instruments, target_date):
+        assert (db, target_date) == (db_path, date(2026, 7, 5))
+        assert [item[0] for item in instruments] == ["AAPL", "TOI", "^GSPC", "BAD"]
+        return {
+            "requested": 4,
+            "written": 3,
+            "trading_dates": ["2026-07-02"],
+            "errors": [{"symbol": "BAD", "error": "no chart data"}],
+        }
+
+    monkeypatch.setattr(
+        news_commands,
+        "get_settings",
+        lambda: HarnessSettings(workspace_root=workspace),
+    )
+    monkeypatch.setattr(news_commands.prices_mod, "download_market_data", fake_download)
+    result = runner.invoke(
+        app,
+        [
+            "news",
+            "download-market-data",
+            "--date",
+            "2026-07-05",
+            "--db",
+            str(db_path),
+            "--index",
+            "^GSPC",
+            "--symbol",
+            "BAD",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "errors": [{"error": "no chart data", "symbol": "BAD"}],
+        "requested": 4,
+        "trading_dates": ["2026-07-02"],
+        "written": 3,
+    }

--- a/tests/test_harness/test_summarize.py
+++ b/tests/test_harness/test_summarize.py
@@ -1,0 +1,84 @@
+"""Behavioral tests for the top-level summarize command."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from harness.cli import app
+from harness.commands import extract
+from harness.config import HarnessSettings
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_generation(tmp_path: Path, monkeypatch) -> dict:
+    captured: dict = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return "Model summary"
+
+    monkeypatch.setattr("harness.commands.extract._generate_answer", fake_generate)
+    monkeypatch.setattr(
+        "harness.commands.extract.get_settings",
+        lambda: HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key"),
+    )
+    return captured
+
+
+def test_summarize_file_emits_only_summary_and_forwards_controls(
+    tmp_path: Path, captured_generation: dict
+) -> None:
+    source = tmp_path / "notes.txt"
+    source.write_text("Revenue grew while margins contracted.", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "summarize",
+            "-f",
+            str(source),
+            "--model",
+            "gemini-3-pro",
+            "--max-tokens",
+            "512",
+            "--thinking",
+            "high",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Model summary\n"
+    assert captured_generation["model"] == "gemini-3-pro"
+    assert captured_generation["max_tokens"] == 512
+    assert captured_generation["thinking"] == "high"
+    assert "Revenue grew while margins contracted." in captured_generation["prompt"]
+
+
+def test_summarize_reads_stdin_with_new_default(captured_generation: dict) -> None:
+    result = runner.invoke(app, ["summarize"], input="Résumé source")
+
+    assert result.exit_code == 0
+    assert result.output == "Model summary\n"
+    assert captured_generation["model"] == "gemini-3.6-flash"
+    assert captured_generation["thinking"] == "minimal"
+    assert "Résumé source" in captured_generation["prompt"]
+
+
+def test_summarize_rejects_non_utf8_stdin_actionably(tmp_path: Path) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path, gemini_api_key="test-key")
+    result = extract.summarize_command(stdin=b"\xff\xfe", settings=settings)
+
+    assert result.exit_code == 1
+    assert b"valid UTF-8" in result.stderr
+    assert b"convert" in result.stderr
+
+
+def test_bare_summarize_shows_help_without_calling_model() -> None:
+    result = runner.invoke(app, ["summarize"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "--file" in result.output
+    assert "What went wrong" not in result.output

--- a/tests/test_minerva/test_prices.py
+++ b/tests/test_minerva/test_prices.py
@@ -8,12 +8,16 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 from minerva.prices import (
     PriceRow,
     RateLimiter,
+    daily_change_pct,
+    download_market_data,
     ensure_schema,
+    market_movement_from_chart,
     range_pct,
     read_positions,
     refresh_prices,
@@ -25,6 +29,26 @@ from minerva.prices import (
 
 def _row(ticker: str, current: float, low: float, high: float, as_of: str = "2026-07-01") -> PriceRow:
     return PriceRow(ticker=ticker, as_of=as_of, current=current, wk52_low=low, wk52_high=high, currency="USD")
+
+
+YAHOO_DAILY_RESPONSE = {
+    "chart": {
+        "result": [
+            {
+                "meta": {
+                    "currency": "USD",
+                    "exchangeTimezoneName": "America/New_York",
+                    "fiftyTwoWeekLow": 80.0,
+                    "fiftyTwoWeekHigh": 130.0,
+                    "currentTradingPeriod": {"regular": {"end": 1783368000}},
+                },
+                "timestamp": [1782912600, 1782999000, 1783344600],
+                "indicators": {"quote": [{"close": [100.0, 110.0, 121.0]}]},
+            }
+        ],
+        "error": None,
+    }
+}
 
 
 class TestRangePct:
@@ -64,6 +88,33 @@ class TestYahooSymbol:
         assert yahoo_symbol("FOO", "NOPE") == "FOO"
 
 
+class TestMarketMovement:
+    def test_uses_actual_sessions_and_excludes_an_incomplete_current_day(self):
+        weekend = market_movement_from_chart(
+            "AAPL",
+            date(2026, 7, 5),
+            YAHOO_DAILY_RESPONSE,
+            now=datetime(2026, 7, 6, 14, tzinfo=UTC),
+        )
+        current_session = market_movement_from_chart(
+            "AAPL",
+            date(2026, 7, 6),
+            YAHOO_DAILY_RESPONSE,
+            now=datetime(2026, 7, 6, 14, tzinfo=UTC),
+        )
+
+        assert (weekend.as_of, weekend.current, weekend.previous_close) == (
+            "2026-07-02",
+            110.0,
+            100.0,
+        )
+        assert current_session.as_of == "2026-07-02"
+
+    def test_percentage_math_is_stored_in_percentage_points(self):
+        assert daily_change_pct(97.5, 100.0) == -2.5
+        assert daily_change_pct(10.0, 0.0) is None
+
+
 class TestSchemaAndPersistence:
     def test_ensure_schema_creates_table_and_view(self, tmp_path: Path):
         db = tmp_path / "test.db"
@@ -76,10 +127,43 @@ class TestSchemaAndPersistence:
             }
         assert objects == {"prices", "price_position"}
 
-    def test_ensure_schema_is_idempotent(self, tmp_path: Path):
-        db = tmp_path / "test.db"
+    def test_migrates_legacy_schema_and_preserves_price_position(self, tmp_path: Path):
+        db = tmp_path / "legacy.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE prices (
+                    id INTEGER PRIMARY KEY, ticker TEXT NOT NULL, as_of TEXT NOT NULL,
+                    current REAL, wk52_low REAL, wk52_high REAL, currency TEXT,
+                    source TEXT NOT NULL DEFAULT 'yahoo', fetched_at TEXT NOT NULL,
+                    UNIQUE (ticker, as_of)
+                );
+                CREATE VIEW price_position AS
+                SELECT ticker, as_of, current, wk52_low, wk52_high, currency,
+                       ROUND((current - wk52_low) / NULLIF(wk52_high - wk52_low, 0), 4) AS range_pct
+                FROM prices;
+                INSERT INTO prices
+                    (ticker, as_of, current, wk52_low, wk52_high, currency, fetched_at)
+                VALUES ('AAPL', '2026-07-01', 150, 100, 200, 'USD', datetime('now'));
+                """
+            )
+
         ensure_schema(db)
         ensure_schema(db)
+
+        with sqlite3.connect(db) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(prices)")}
+            view_columns = [
+                row[1] for row in conn.execute("PRAGMA table_info(price_position)")
+            ]
+            position = conn.execute(
+                "SELECT range_pct, previous_close, instrument_type FROM price_position"
+            ).fetchone()
+        assert {"previous_close", "change_pct", "instrument_type"} <= columns
+        assert view_columns[:7] == [
+            "ticker", "as_of", "current", "wk52_low", "wk52_high", "currency", "range_pct"
+        ]
+        assert position == (0.5, None, "security")
 
     def test_upsert_then_read(self, tmp_path: Path):
         db = tmp_path / "test.db"
@@ -139,6 +223,47 @@ class TestTrackedCompanies:
 
 
 class TestRefreshPrices:
+    def test_download_market_data_is_idempotent_and_reports_errors(
+        self, tmp_path: Path
+    ):
+        db = tmp_path / "test.db"
+
+        def fake_fetcher(ticker: str, *, target_date: date, **_kw) -> PriceRow:
+            if ticker == "BAD":
+                raise ValueError("no chart data")
+            return market_movement_from_chart(
+                ticker,
+                target_date,
+                YAHOO_DAILY_RESPONSE,
+                now=datetime(2026, 7, 6, 14, tzinfo=UTC),
+            )
+
+        instruments = [("AAPL", None, "security"), ("BAD", None, "security")]
+        first = download_market_data(
+            db, instruments, date(2026, 7, 5), fetcher=fake_fetcher
+        )
+        second = download_market_data(
+            db, instruments, date(2026, 7, 5), fetcher=fake_fetcher
+        )
+        # The legacy portfolio refresh path must not erase stored movement fields.
+        upsert_prices(db, [_row("AAPL", 110, 80, 130, as_of="2026-07-02")])
+
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT ticker, as_of, current, previous_close, change_pct FROM prices"
+            ).fetchall()
+        assert rows == [("AAPL", "2026-07-02", 110.0, 100.0, 10.0)]
+        assert (
+            first
+            == second
+            == {
+                "requested": 2,
+                "written": 1,
+                "trading_dates": ["2026-07-02"],
+                "errors": [{"symbol": "BAD", "error": "no chart data"}],
+            }
+        )
+
     def test_refresh_persists_all_with_fake_fetcher(self, tmp_path: Path):
         db = tmp_path / "test.db"
         ensure_schema(db)

--- a/tests/test_news_pipeline_e2e.py
+++ b/tests/test_news_pipeline_e2e.py
@@ -1,0 +1,368 @@
+"""End-to-end orchestration tests for the safe agent news pipeline."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "run_news_pipeline_e2e.sh"
+ARTICLE_URL = "https://example.test/controlled-article"
+NEWS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS news (
+    article_key TEXT PRIMARY KEY,
+    published_at INTEGER NOT NULL,
+    published_at_raw TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    summary TEXT,
+    source TEXT NOT NULL,
+    url TEXT NOT NULL,
+    section TEXT,
+    collected_at TEXT NOT NULL
+)
+"""
+
+
+def _write_executable(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _fake_minerva(tmp_path: Path) -> Path:
+    return _write_executable(
+        tmp_path / "fake-minerva.py",
+        f'''#!/usr/bin/env python3
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["COMMAND_LOG"]).open("a", encoding="utf-8") as fh:
+    fh.write(json.dumps(args) + "\\n")
+
+if args and args[0] == "summarize":
+    content = sys.stdin.read().strip()
+    if not content:
+        raise SystemExit(12)
+    print("Stub investor summary: " + content[:60])
+    raise SystemExit(0)
+
+if args[:2] == ["news", "download-finnhub"]:
+    if os.environ.get("FAIL_PHASE") == "finnhub":
+        print("stub Finnhub failure", file=sys.stderr)
+        raise SystemExit(17)
+    db = Path(args[args.index("--db") + 1])
+    run_date = args[args.index("--date") + 1]
+    with sqlite3.connect(db) as conn:
+        conn.execute({NEWS_SCHEMA!r})
+        conn.execute(
+            "INSERT INTO news VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)",
+            ("finnhub-key", 1784505600, run_date, "Stub Finnhub headline",
+             "Stub Finnhub article content.", "stubwire",
+             "https://example.test/finnhub", "finnhub-company",
+             run_date + "T12:00:00Z"),
+        )
+    print('{{"inserted":1}}')
+    raise SystemExit(0)
+
+if args[:2] == ["news", "download-market-data"]:
+    if os.environ.get("FAIL_PHASE") == "market-data":
+        print("stub market failure", file=sys.stderr)
+        raise SystemExit(18)
+    db = Path(args[args.index("--db") + 1])
+    run_date = args[args.index("--date") + 1]
+    symbol = args[args.index("--symbol") + 1].upper()
+    index = args[args.index("--index") + 1].upper()
+    with sqlite3.connect(db) as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS prices (
+                id INTEGER PRIMARY KEY, ticker TEXT, as_of TEXT,
+                current REAL, previous_close REAL, change_pct REAL,
+                instrument_type TEXT
+            )
+        """)
+        conn.executemany(
+            "INSERT INTO prices "
+            "(ticker, as_of, current, previous_close, change_pct, instrument_type) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [(symbol, run_date, 110.0, 100.0, 10.0, "security"),
+             (index, run_date, 5100.0, 5000.0, 2.0, "index")],
+        )
+    print('{{"written":2}}')
+    raise SystemExit(0)
+
+print("unexpected fake minerva command: " + repr(args), file=sys.stderr)
+raise SystemExit(99)
+''',
+    )
+
+
+def _fake_openclaw(tmp_path: Path) -> Path:
+    return _write_executable(
+        tmp_path / "fake-openclaw.py",
+        f'''#!/usr/bin/env python3
+import json
+import os
+import re
+import shlex
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+def option(name):
+    return args[args.index(name) + 1]
+message = option("--message")
+record = {{
+    "agent": option("--agent"),
+    "model": option("--model"),
+    "thinking": option("--thinking"),
+    "timeout": option("--timeout"),
+    "message": message,
+}}
+with Path(os.environ["AGENT_LOG"]).open("a", encoding="utf-8") as fh:
+    fh.write(json.dumps(record) + "\\n")
+
+if record["agent"] == os.environ["EXPECTED_COLLECTOR_AGENT"]:
+    if os.environ.get("FAIL_PHASE") == "collector":
+        raise SystemExit(19)
+    db = Path(re.search(r"Scratch database: `([^`]+)`", message).group(1))
+    url = re.search(r"Article URL: `([^`]+)`", message).group(1)
+    with sqlite3.connect(db) as conn:
+        conn.execute({NEWS_SCHEMA!r})
+        conn.execute(
+            "INSERT INTO news VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)",
+            ("collector-key", 1784505600, "2026-07-19",
+             "Controlled collector article", "Normalized collector body.",
+             "e2e-collector", url, "e2e-controlled-article",
+             "2026-07-19T12:00:00Z"),
+        )
+    print("collector stub complete")
+    raise SystemExit(0)
+
+if record["agent"] == os.environ["EXPECTED_SOL_AGENT"]:
+    if os.environ.get("FAIL_PHASE") == "sol":
+        raise SystemExit(20)
+    db = Path(re.search(r"Scratch database: `([^`]+)`", message).group(1))
+    brief = Path(re.search(r"Brief artifact: `([^`]+)`", message).group(1))
+    if os.environ.get("LEAVE_NULL_SUMMARIES") != "1":
+        with sqlite3.connect(db) as conn:
+            rows = conn.execute(
+                "SELECT article_key, content FROM news "
+                "WHERE summary IS NULL OR trim(summary) = '' "
+                "ORDER BY published_at, article_key"
+            ).fetchall()
+        generated = []
+        runner = shlex.split(os.environ["MINERVA_RUNNER"])
+        for key, content in rows:
+            result = subprocess.run(
+                runner + ["summarize", "--model", os.environ["EXPECTED_SUMMARY_MODEL"]],
+                input=content, text=True, capture_output=True, check=False,
+            )
+            if result.returncode or not result.stdout.strip():
+                raise SystemExit(21)
+            generated.append((result.stdout.strip(), key))
+        with sqlite3.connect(db) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            for summary, key in generated:
+                cursor = conn.execute(
+                    "UPDATE news SET summary=? WHERE article_key=? "
+                    "AND (summary IS NULL OR trim(summary) = '')",
+                    (summary, key),
+                )
+                if cursor.rowcount != 1:
+                    raise SystemExit(22)
+            conn.commit()
+    brief.write_text(
+        "# Dry-run brief\\n\\nDry run — not posted to Slack.\\n\\n"
+        "Stub news and market movements.\\n",
+        encoding="utf-8",
+    )
+    print("sol stub complete")
+    raise SystemExit(0)
+
+print("unexpected agent", file=sys.stderr)
+raise SystemExit(98)
+''',
+    )
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    extra_args: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    run_root = tmp_path / "runs"
+    fake_minerva = _fake_minerva(tmp_path)
+    fake_openclaw = _fake_openclaw(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "MINERVA_RUNNER": str(fake_minerva),
+            "MINERVA_E2E_OPENCLAW": str(fake_openclaw),
+            "MINERVA_E2E_RUN_ROOT": str(run_root),
+            "COMMAND_LOG": str(tmp_path / "commands.jsonl"),
+            "AGENT_LOG": str(tmp_path / "agents.jsonl"),
+            "EXPECTED_COLLECTOR_AGENT": "collector-test",
+            "EXPECTED_SOL_AGENT": "sol-test",
+            "EXPECTED_SUMMARY_MODEL": "summary-test-model",
+        }
+    )
+    (tmp_path / "home").mkdir()
+    if extra_env:
+        env.update(extra_env)
+    args = [
+        "bash",
+        str(SCRIPT),
+        "--stubbed",
+        "--date",
+        "2026-07-19",
+        "--article-url",
+        ARTICLE_URL,
+        "--symbol",
+        "nvda",
+        "--index",
+        "^gspc",
+        "--collector-agent",
+        "collector-test",
+        "--collector-model",
+        "collector-test-model",
+        "--sol-agent",
+        "sol-test",
+        "--sol-model",
+        "sol-test-model",
+        "--summary-model",
+        "summary-test-model",
+    ]
+    args.extend(extra_args or [])
+    return subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+
+
+def _run_dir(result: subprocess.CompletedProcess[str]) -> Path:
+    match = re.search(r"run_dir=([^\s]+)", result.stderr)
+    assert match, result.stderr
+    return Path(match.group(1))
+
+
+def test_default_refuses_network_or_agent_execution(tmp_path: Path) -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--article-url", ARTICLE_URL],
+        cwd=REPO_ROOT,
+        env={**os.environ, "MINERVA_E2E_RUN_ROOT": str(tmp_path / "runs")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "disabled by default" in result.stderr
+    assert not (tmp_path / "runs").exists()
+
+
+def test_stubbed_pipeline_constructs_commands_and_verifies_outputs(
+    tmp_path: Path,
+) -> None:
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "brief_nonempty": True,
+        "collector_rows": 1,
+        "finnhub_rows": 1,
+        "market_rows": 2,
+        "null_summaries": 0,
+        "ok": True,
+        "run_dir": payload["run_dir"],
+    }
+    run_dir = Path(payload["run_dir"])
+    assert run_dir.is_dir()
+    assert json.loads((run_dir / "result.json").read_text(encoding="utf-8")) == payload
+    assert "Dry run — not posted to Slack" in (
+        run_dir / "dry-run-brief.md"
+    ).read_text(encoding="utf-8")
+
+    commands = [
+        json.loads(line)
+        for line in (tmp_path / "commands.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert commands[:2] == [
+        [
+            "news", "download-finnhub", "--date", "2026-07-19", "--db",
+            str(run_dir / "scratch.db"), "--symbol", "nvda",
+        ],
+        [
+            "news", "download-market-data", "--date", "2026-07-19", "--db",
+            str(run_dir / "scratch.db"), "--index", "^gspc", "--symbol", "nvda",
+        ],
+    ]
+    assert commands[2:] == [
+        ["summarize", "--model", "summary-test-model"],
+        ["summarize", "--model", "summary-test-model"],
+    ]
+
+    agents = [
+        json.loads(line)
+        for line in (tmp_path / "agents.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [(item["agent"], item["model"]) for item in agents] == [
+        ("collector-test", "collector-test-model"),
+        ("sol-test", "sol-test-model"),
+    ]
+    assert "news ingest --input - --db" in agents[0]["message"]
+    assert str(tmp_path / "fake-minerva.py") in agents[0]["message"]
+    assert "summarize --model summary-test-model" in agents[1]["message"]
+
+
+def test_provider_failure_is_phase_specific_and_preserves_artifacts(
+    tmp_path: Path,
+) -> None:
+    result = _run(tmp_path, extra_env={"FAIL_PHASE": "market-data"})
+
+    assert result.returncode == 18
+    assert "error[market-data]: failed with status 18" in result.stderr
+    run_dir = _run_dir(result)
+    assert run_dir.is_dir()
+    assert (run_dir / "scratch.db").is_file()
+    assert (run_dir / "logs" / "market-data.stderr").read_text(
+        encoding="utf-8"
+    ).strip() == "stub market failure"
+    assert not (run_dir / "prompts" / "sol.md").exists()
+
+
+def test_verification_rejects_null_summaries_and_keeps_run_for_inspection(
+    tmp_path: Path,
+) -> None:
+    result = _run(tmp_path, extra_env={"LEAVE_NULL_SUMMARIES": "1"})
+
+    assert result.returncode == 1
+    assert "error[verify]" in result.stderr
+    run_dir = _run_dir(result)
+    diagnostics = (run_dir / "logs" / "verify.stderr").read_text(encoding="utf-8")
+    assert "news row(s) still lack summaries" in diagnostics
+    assert run_dir.is_dir()
+    assert (run_dir / "dry-run-brief.md").is_file()
+    with sqlite3.connect(run_dir / "scratch.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM news WHERE summary IS NULL").fetchone()[0] == 2


### PR DESCRIPTION
## Summary

Merge the four validated news-pipeline PRs as the exact aggregate stack tested together:

- #73 — general `minerva summarize` command and Gemini 3.6 Flash default
- #74 — daily market movement download into `prices`
- #75 — Finnhub news download directly into SQLite
- #76 — direct single-article JSON/stdin ingestion for crawler agents
- safe scratch-DB agent E2E workflow and prompt templates

## Verification

- `uv run pytest -q` — 431 passed
- live scratch-DB E2E passed:
  - collector agent extracted BLS CPI and ingested directly into SQLite
  - Finnhub inserted 18 articles
  - Yahoo stored AAPL and S&P 500 market movement
  - Gemini summarized all 19 articles
  - Sol generated a non-empty dry-run brief
  - deterministic verifier reported zero missing summaries
- canonical `invest.db` and Slack were untouched
