### PR TITLE
fix(news): switch daily brief to direct SQLite pipeline

### DIFF
--- a/scripts/prompts/collect_news.md
+++ b/scripts/prompts/collect_news.md
@@ -1,11 +1,10 @@
-Collect news articles from {{SOURCE_NAME}} ({{URL}}) for {{DATE}}.
+Collect and directly ingest news articles from {{SOURCE_NAME}} ({{URL}}) for {{DATE}}.
 
-Save each article as a separate markdown file in `{{NEWS_DIR}}/raw/`.
-Your isolated source root is `{{NEWS_DIR}}`. Only write within this rendered root.
+Your isolated metadata root is `{{SOURCE_ROOT}}`. You may write only the candidate and lookup JSON files rendered below. Do not write article, Markdown, text, HTML, summary, or intermediate JSON files. Article bodies must exist only in process memory and in SQLite after a successful direct ingest.
 
 ## Portfolio context
 
-Our current holdings and watchlist tickers (prioritize articles mentioning these):
+Prioritize articles relevant to these current holdings/watchlist companies:
 
 {{PORTFOLIO_TICKERS}}
 
@@ -13,73 +12,64 @@ Our current holdings and watchlist tickers (prioritize articles mentioning these
 
 {{COLLECT_SCOPE}}
 
-## Constraints
+## Selection constraints
 
-- **Source ownership:** never list, read, count, rename, modify, or delete another source's files. Do not inspect parent or sibling directories. For collector working files, use only this source's `raw/`, `candidates/`, and `lookups/` directories under `{{NEWS_DIR}}`, and every file you write must stay within `{{NEWS_DIR}}`.
-- Scan the full landing page and collect every qualifying relevant article. Prioritize: (1) direct relevance to portfolio companies above, (2) macro/market significance, (3) industry trends, (4) geopolitics or politics that affects the economy or markets, (5) genuinely interesting business, technology, science, or world stories a thoughtful investor would want to know. Skip lifestyle, sports, entertainment, and celebrity fluff.
-- **Skip articles older than 3 days** based on the visible publish date. If no date is visible, keep the article as a candidate for the URL-first check below.
-- **Skip database duplicates before opening an article.** Use the deterministic batch lookup below; do not estimate title similarity or calculate article hashes yourself.
-- If no qualifying new articles exist, save no files and report that zero items qualified. Do not create a placeholder article.
+- Scan the full landing page and collect every qualifying article. Rank direct portfolio relevance first, then material macro/market news, industry developments, market-relevant geopolitics/politics, and genuinely important business, technology, science, or world news. Skip lifestyle, sports, entertainment, and celebrity stories.
+- Skip articles older than 3 days based on the visible source publication date. If no date is visible on the landing page, retain the item for the URL-first duplicate check.
+- Check deterministic database duplicates before expensive article-body extraction. Never estimate title similarity or calculate article hashes yourself.
+- If no unseen qualifying articles exist, ingest nothing and report zero. Do not create placeholders.
+- Never invoke Slack, a webhook, another agent, or a summarizer. Leave `summary` absent so the outer Sol agent can summarize later.
 
-## Deterministic database lookup
+## Deterministic duplicate lookup
 
-Write all candidates as one JSON array to `{{CANDIDATE_FILE}}`, overwriting that file on every lookup. Each object must contain `title`, `url`, and `published`. Use the exact destination URL and visible publication value. If no date is visible on the landing page, use an empty `published` string so the command checks the URL first.
+Write candidate metadata only as one JSON array to `{{CANDIDATE_FILE}}`, overwriting it on every lookup. Every object must contain `title`, `url`, and `published`. Use the exact destination URL and visible publication value; use an empty `published` string when no date is visible.
 
-Run the lookup below and redirect its compact JSON result to the collector's own lookup file, also overwriting it:
+Run exactly this lookup and overwrite your isolated result file:
 
 ```bash
 {{NEWS_EXIST_COMMAND}} --db "{{INVEST_DB}}" --source-id "{{SOURCE_ID}}" --input "{{CANDIDATE_FILE}}" > "{{LOOKUP_FILE}}"
 ```
 
-Candidate indexes in `seen` are duplicates; only indexes in `unseen` may be visited. The command opens SQLite read-only and applies the same publication-date normalization and article identity code used during ingestion. Run one batch check for the landing page, not one command per candidate.
+Indexes in `seen` are duplicates. Only indexes in `unseen` may be visited. This command is read-only and uses the same normalized identity as ingestion. Batch the landing-page candidates in one lookup rather than invoking it once per candidate.
 
-## Steps
+## Direct ingest contract
 
-1. Run exactly once: `browser open "{{URL}}" --new --window`
-2. Note the tab alias from the output (e.g. t7). This is your only browser window and tab for the entire task. Do not run `browser open` again, create another window, or open article links in new tabs.
-3. In that one existing tab, scan the full landing page. Identify all potentially relevant articles and record each exact headline, destination URL, and visible publication date without opening any article.
-4. Remove candidates whose visible date is older than 3 days. Overwrite `{{CANDIDATE_FILE}}` with every remaining candidate, run the lookup command, read `{{LOOKUP_FILE}}`, then remove every index classified as `seen`.
-5. For each `unseen` article:
-   a. Navigate the existing tab into the article. Never open a new tab or window.
-   b. If its publication date was unavailable on the landing page, inspect the article's date or machine-readable metadata without extracting the full body. Before body extraction, overwrite `{{CANDIDATE_FILE}}` with a one-item array containing that date and the final article URL, rerun the same lookup command so `{{LOOKUP_FILE}}` is overwritten, and read the result. If the article still exposes no date, use `{{DATE}}`, matching ingestion's collection-date fallback. If it is now `seen`, navigate back and skip it.
-   c. Extract the full article text using `browser extract` or `browser ask`.
-   d. Generate a short slug from the headline (lowercase, hyphens, 3-5 words, e.g. `trump-hormuz-ships`).
-   e. Write the full article to `{{NEWS_DIR}}/raw/{{SOURCE_ID}}-{slug}.md` using the format below.
-   f. Navigate the same tab back to the landing page.
-   g. If extraction fails (404, CAPTCHA, video-only, paywall prompt), skip the article and continue to the next one.
-6. After all articles are saved, close your only browser tab: `browser close {tab_alias}`. If an extra tab or window was created accidentally, close it immediately before continuing.
-7. Reply briefly: how many articles saved, any skipped (with reason), any failures.
+For each extracted article, construct exactly one in-memory JSON object with:
 
-If the browser bridge is not connected, write one file `{{NEWS_DIR}}/raw/{{SOURCE_ID}}-error.md` with Status: failed.
-If the page shows a paywall or login prompt, note it and continue with what's accessible.
+- `title`: exact, non-empty article headline
+- `source_id`: exactly `{{SOURCE_ID}}`
+- `url`: final, non-empty article URL
+- `published_at`: the most precise source publication value available, including timezone; use `{{DATE}}` only when the article exposes no publication date
+- `content`: normalized non-empty Markdown or plain text containing the complete substantive article body, with navigation, advertisements, cookie text, and page chrome removed; never raw HTML
+- optional `section`: source section/category
+- optional `collected_at`: current ISO-8601 UTC timestamp
 
-## File format for each article
+Pipe that single object directly on stdin to this command:
 
-Write this exact format to `{{NEWS_DIR}}/raw/{{SOURCE_ID}}-{slug}.md`:
-
-```
-# {Article Headline}
-
-Source: {{SOURCE_NAME}}
-URL: {article_url}
-Published: {most precise publication datetime + timezone visible on the article}
-Collected: {current ISO timestamp}
-Section: {section if applicable}
-
-{Full article text — the complete body of the article as visible on the page}
+```bash
+printf '%s\n' "$article_json" | {{NEWS_INGEST_COMMAND}}
 ```
 
-### Recording the Published value
+A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never place article JSON or content on a command line. Confirm the compact command result has status `inserted`, `updated`, or `duplicate`; otherwise treat that article as failed and return a non-zero collector result.
 
-- Copy the most precise publication timestamp visible on the article page or its HTML metadata (`<meta property="article:published_time">`, `<time datetime="...">`, byline dateline, etc.). Prefer machine-readable page metadata over rendered text when both are present.
-- Include the timezone or UTC offset exactly as shown (e.g. `2026-07-16T09:00:00-04:00`, `July 16, 2026 9:00 AM EDT`, `Jul 16th 2026`).
-- If only a date is visible (no time), record just the date. Never invent, round, or fill in a time that is not shown on the page.
-- If no publication date is visible anywhere on the page, use `{{DATE}}` (the run date) as a last resort and flag that in your reply.
+## Browser steps
 
-## Important
+1. Run exactly once: `browser open "{{URL}}" --new --window`.
+2. Record the returned tab alias. It is your only browser window and tab. Never run `browser open` again and never create another tab/window.
+3. In that tab, scan the complete landing page. Record candidate headline, destination URL, and visible publication value without opening article bodies.
+4. Remove visibly stale candidates. Overwrite `{{CANDIDATE_FILE}}`, run the one batch lookup, read `{{LOOKUP_FILE}}`, and keep only `unseen` indexes.
+5. For each unseen candidate:
+   a. Navigate the same tab to the article.
+   b. If its date was unavailable on the landing page, inspect only date metadata first. Before body extraction, overwrite `{{CANDIDATE_FILE}}` with a one-item array using the final URL and discovered date (or `{{DATE}}` if no date exists), rerun the lookup, and skip the article if it is now `seen`.
+   c. Extract and normalize the full substantive article body with `browser extract` or `browser ask`.
+   d. Build one JSON object in memory and pipe it directly to the ingest command above. Do not write it to disk.
+   e. Navigate the same tab back to the landing page.
+   f. On 404, CAPTCHA, video-only content, paywall, or extraction failure, skip the article and continue.
+6. Close your only tab with `browser close {tab_alias}`. Close any accidentally created extra tab/window immediately.
+7. Reply briefly with counts for inserted/updated/duplicate/skipped/failed. Do not include article bodies in your reply.
 
-- One file per article. Do NOT combine articles into one file.
-- Save the FULL article text, not a summary.
-- Do NOT spawn subagents. Collect all articles yourself in exactly one browser window containing exactly one tab. Same-tab navigation is allowed; no additional windows or tabs are allowed.
-- If you detect slug collision (two articles would get the same filename), append a number: `{slug}-2`.
-- Your reply should be brief. All content goes into the files.
+## Publication value
+
+Prefer machine-readable source metadata such as `article:published_time` or `<time datetime>` over rendered text. Preserve the exact timezone/offset shown. If only a date is available, use that date without inventing a time. Use `{{DATE}}` only as the last-resort no-date fallback and mention the fallback in your brief reply.
+
+If the browser bridge is unavailable or the collector cannot complete safely, return non-zero. Do not create an error article or any article-body file. Same-tab navigation is allowed; additional tabs/windows are not.

--- a/scripts/prompts/collect_news_webfetch.md
+++ b/scripts/prompts/collect_news_webfetch.md
@@ -1,11 +1,10 @@
-Collect data from {{SOURCE_NAME}} ({{URL}}) for {{DATE}}.
+Collect and directly ingest qualifying items from {{SOURCE_NAME}} ({{URL}}) for {{DATE}} using web_fetch only.
 
-Save each item as a separate markdown file in `{{NEWS_DIR}}/raw/`.
-Your isolated source root is `{{NEWS_DIR}}`. Only write within this rendered root.
+Your isolated metadata root is `{{SOURCE_ROOT}}`. You may write only the candidate and lookup JSON files rendered below. Do not write article, Markdown, text, HTML, summary, or intermediate JSON files. Item bodies must exist only in process memory and in SQLite after a successful direct ingest.
 
 ## Portfolio context
 
-Our current holdings and watchlist tickers (prioritize items mentioning these):
+Prioritize items relevant to these current holdings/watchlist companies:
 
 {{PORTFOLIO_TICKERS}}
 
@@ -13,64 +12,57 @@ Our current holdings and watchlist tickers (prioritize items mentioning these):
 
 {{COLLECT_SCOPE}}
 
-## Constraints
+## Selection constraints
 
-- **Source ownership:** never list, read, count, rename, modify, or delete another source's files. Do not inspect parent or sibling directories. For collector working files, use only this source's `raw/`, `candidates/`, and `lookups/` directories under `{{NEWS_DIR}}`, and every file you write must stay within `{{NEWS_DIR}}`.
-- **Skip items older than 3 days** based on the visible date.
-- **Calendar pages:** collect only releases dated from 3 days before {{DATE}} through 7 days after {{DATE}}. Never collect later future entries merely because they appear on the schedule.
-- **Skip database duplicates.** Use the deterministic batch lookup below; do not estimate title similarity or calculate article hashes yourself.
-- If the fetch succeeds but no items qualify, save no files and report that zero items qualified. Do not create a placeholder or `no new releases` article.
+- Collect relevant data releases, calendar entries, press statements, policy announcements, and other material investor evidence.
+- Skip items older than 3 days based on the visible source date.
+- For calendar pages, collect only releases dated from 3 days before {{DATE}} through 7 days after {{DATE}}. Never collect later future entries merely because they appear on the schedule.
+- Check deterministic database duplicates before fetching distinct item pages or extracting their full bodies. Never estimate title similarity or calculate article hashes yourself.
+- If no unseen qualifying items exist, ingest nothing and report zero. Do not create placeholders.
+- Use web_fetch only. Never open a browser, invoke Slack/webhooks, spawn another agent, or run a summarizer. Leave `summary` absent for the outer Sol agent.
 
-## Deterministic database lookup
+## Deterministic duplicate lookup
 
-Write all candidates as one JSON array to `{{CANDIDATE_FILE}}`, overwriting that file on every lookup. Each object must contain `title`, `url`, and `published`. Use the exact item URL and visible publication value. If an item has no distinct URL, use an empty string rather than the shared landing-page URL. If neither a distinct URL nor a date is available, use `{{DATE}}` as `published`, matching ingestion's collection-date fallback; if the URL exists but the date does not, leave `published` empty for the URL-first check.
+Write candidate metadata only as one JSON array to `{{CANDIDATE_FILE}}`, overwriting it on every lookup. Every object must contain `title`, `url`, and `published`. Use the exact distinct item URL when present; use an empty URL instead of the shared landing URL when no distinct destination exists. If a URL exists but no date is visible, use an empty `published` value for URL-first matching. If neither exists, use `{{DATE}}` as `published`.
 
-Run the lookup below and redirect its compact JSON result to the collector's own lookup file, also overwriting it:
+Run exactly this lookup and overwrite your isolated result file:
 
 ```bash
 {{NEWS_EXIST_COMMAND}} --db "{{INVEST_DB}}" --source-id "{{SOURCE_ID}}" --input "{{CANDIDATE_FILE}}" > "{{LOOKUP_FILE}}"
 ```
 
-Candidate indexes in `seen` are duplicates; only indexes in `unseen` may be collected. The command opens SQLite read-only and applies the same publication-date normalization and article identity code used during ingestion. Run one batch check for all candidates.
+Indexes in `seen` are duplicates. Only `unseen` indexes may be collected. This read-only command uses the same normalized identity as ingestion. Run one batch lookup for all landing-page candidates.
+
+## Direct ingest contract
+
+For each collected item, construct exactly one in-memory JSON object with:
+
+- `title`: exact, non-empty item title
+- `source_id`: exactly `{{SOURCE_ID}}`
+- `url`: the distinct item URL, or `{{URL}}` for an item that genuinely has no distinct destination
+- `published_at`: the most precise visible publication value including timezone; use `{{DATE}}` only if none exists
+- `content`: normalized non-empty Markdown/plain text containing the complete substantive item, excluding navigation, advertisements, cookie text, and page chrome; never raw HTML
+- optional `section`: source category
+- optional `collected_at`: current ISO-8601 UTC timestamp
+
+Pipe that single object directly on stdin to:
+
+```bash
+printf '%s\n' "$article_json" | {{NEWS_INGEST_COMMAND}}
+```
+
+A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never place content on a command line. Confirm the result status is `inserted`, `updated`, or `duplicate`; otherwise treat the item as failed and return non-zero.
 
 ## Steps
 
-1. Fetch {{URL}} with the web_fetch tool.
-2. Identify relevant items: data releases, calendar entries, press statements, policy announcements. Record each exact title, destination URL, and visible publication date.
-3. Exclude items outside the date rules. Overwrite `{{CANDIDATE_FILE}}` with every remaining candidate, run the lookup command, read `{{LOOKUP_FILE}}`, and retain only the `unseen` indexes.
+1. Fetch `{{URL}}` with web_fetch.
+2. Identify qualifying candidates and record exact title, distinct destination URL (if any), and visible publication value without extracting distinct item bodies.
+3. Apply the date rules, overwrite `{{CANDIDATE_FILE}}`, run the batch duplicate lookup, read `{{LOOKUP_FILE}}`, and retain only `unseen` indexes.
 4. For each unseen item:
-   a. If it has a distinct item URL, fetch that URL with the web_fetch tool before writing anything and use the fetched item's full content. If that item fetch fails, skip it and continue. A calendar row without a distinct URL may use the already-fetched landing-page content.
-   b. Generate a short slug (lowercase, hyphens, 3-5 words).
-   c. Write to `{{NEWS_DIR}}/raw/{{SOURCE_ID}}-{slug}.md` using the format below.
-5. If the fetch itself fails, write one file `{{NEWS_DIR}}/raw/{{SOURCE_ID}}-error.md` with Status: failed. If the fetch succeeds but no items qualify, write no file.
-6. Reply briefly: how many items saved, any skipped.
+   a. If it has a distinct URL, fetch that URL before extracting content. If the fetch fails, skip it. A calendar row without a distinct URL may use substantive content from the landing-page fetch.
+   b. Extract and normalize the full substantive item.
+   c. Build one JSON object in memory and pipe it directly to the ingest command. Never write the object or body to disk.
+5. If the initial fetch fails or the collector cannot complete safely, return non-zero. Do not create an error article.
+6. Reply briefly with counts for inserted/updated/duplicate/skipped/failed. Do not include item bodies in your reply.
 
-## File format
-
-Write this exact format to `{{NEWS_DIR}}/raw/{{SOURCE_ID}}-{slug}.md`:
-
-```
-# {Item Title or Release Name}
-
-Source: {{SOURCE_NAME}}
-URL: {item_url_if_available}
-Published: {most precise publication datetime + timezone visible on the item}
-Collected: {current ISO timestamp}
-Section: {category if applicable}
-
-{Full text of the release, calendar entry, or announcement}
-```
-
-### Recording the Published value
-
-- Copy the most precise publication timestamp visible on the page or in its metadata (`<meta property="article:published_time">`, `<time datetime="...">`, dateline, release header). Prefer machine-readable page metadata over rendered text.
-- Include the timezone or UTC offset exactly as shown (e.g. `2026-07-14T08:30:00-04:00`, `July 14, 2026 8:30 AM ET`).
-- If only a date is visible (no time), record just the date. Never invent, round, or fabricate a time that is not shown.
-- If no publication date is visible anywhere, use `{{DATE}}` as a last resort and flag that in your reply.
-
-## Important
-
-- One file per item. Do NOT combine items into one file.
-- Save the full content, not a summary.
-- Use web_fetch only. Do not open browser windows or tabs; no additional windows or tabs are allowed.
-- Your reply should be brief. All content goes into the files.
+Prefer machine-readable publication metadata over rendered text and preserve exact timezone/offset information. If only a date is present, do not invent a time. No additional browser windows or tabs are allowed because this task uses web_fetch only.

--- a/scripts/prompts/morning_brief_outer_sol.md
+++ b/scripts/prompts/morning_brief_outer_sol.md
@@ -1,0 +1,35 @@
+# Morning brief outer Sol handoff
+
+You are the final synthesis agent. The collection script has already populated prepared evidence, `news`, and `prices`. Do not repeat collection, browse the web, spawn another Sol agent, or post to Slack with a messaging tool.
+
+Read the `outer-sol-handoff.json` path printed by `scripts/run_morning_brief.sh`. Treat its `date`, `db`, `prepared_evidence`, `report_output`, and `slack_brief_output` values as authoritative.
+
+## 1. Summarize pending news
+
+- Select eligible `news` rows for the handoff date using `published_at` as UTC epoch seconds bounded by the `America/New_York` calendar day. Use `published_at_raw` date-prefix matching only when `published_at` is NULL.
+- Process only rows where `content` is non-empty and `summary` is NULL or blank.
+- For each row, pipe `content` on stdin to:
+
+```bash
+uv run minerva summarize --model gemini-3.6-flash --thinking high
+```
+
+- Use bounded parallelism of at most four subprocesses. Keep article content and generated summaries in memory; do not write article or summary files.
+- If any summarization fails, do not write a partial batch. Report the failure count and artifact paths concisely.
+- After all calls succeed, persist summaries with SQLite parameter binding in one transaction. Update by `article_key` only where the summary is still NULL or blank.
+- Re-query and require zero eligible blank summaries before synthesis. Reruns must be idempotent.
+
+## 2. Synthesize the brief
+
+Read the prepared-evidence JSON, the summarized current-date `news` rows, and relevant `prices` rows. Prefer primary sources and material facts. Deduplicate repeated URLs and syndicated versions. Distinguish facts from interpretation.
+
+Write:
+
+1. `report_output`: a durable Markdown report with source collection counts, market snapshot, portfolio/watchlist events, and the most important market, macro, policy, technology, and business developments.
+2. `slack_brief_output`: a concise Slack-mrkdwn brief. Use `*single asterisks*` for bold and `<url|label>` links. Do not use Markdown headings or tables.
+
+Cite factual claims with direct source URLs from SQLite. Do not cite `finnhub.io/api/news` proxy URLs when an original source URL is available.
+
+## 3. Return result
+
+Do not call Slack. Return the exact contents of `slack_brief_output` as your final response so the cron delivery layer posts it once. If any required phase fails, return one concise failure message naming the phase and diagnostic artifact path instead of a partial brief.

--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-# Source env for API keys BEFORE strict mode
-# zshrc contains zsh-specific commands (setopt) that fail in bash with set -e
+# Source API keys before strict mode, but preserve the caller's exported
+# environment as the higher-precedence configuration layer. zshrc may contain
+# zsh-only commands, so a non-zero result is intentionally ignored.
+_CALLER_ENV_EXPORTS="$(export -p)"
 source ~/.zshrc >/dev/null 2>&1 || true
+eval "${_CALLER_ENV_EXPORTS}"
+unset _CALLER_ENV_EXPORTS
 
 set -euo pipefail
 
@@ -22,26 +26,37 @@ for integer_name in \
     exit 1
   fi
 done
+if ! python3 - "${RUN_DATE}" <<'PY'
+from datetime import date
+import sys
 
-# Ephemeral run directory: each collector gets a physically isolated source
-# root. After every collector exits, raw artifacts are copied into the central
-# raw directory for summarization and the single SQLite writer.
-NEWS_RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/morning-brief-${RUN_DATE}-XXXXXX")"
-NEWS_SOURCE_ROOTS_DIR="${NEWS_RUN_DIR}/sources"
-REPORT_DIR="${ROOT_DIR}/hard-disk/reports/03-daily-news/${RUN_DATE}"
-INVEST_DB="${INVEST_DB:-${ROOT_DIR}/hard-disk/data/04-database/invest.db}"
-INGEST_OK=0
-cleanup_run_dir() {
-  # Remove the temp run dir only when ingest into invest.db succeeded.
-  # Otherwise leave it for debugging.
-  if [[ "${INGEST_OK}" == "1" && -d "${NEWS_RUN_DIR}" ]]; then
-    rm -rf "${NEWS_RUN_DIR}"
-  fi
-}
-trap cleanup_run_dir EXIT
+try:
+    parsed = date.fromisoformat(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+if parsed.isoformat() != sys.argv[1]:
+    raise SystemExit(1)
+PY
+then
+  echo "RUN_DATE must be an ISO date (YYYY-MM-DD): ${RUN_DATE}" >&2
+  exit 1
+fi
 
 export UV_CACHE_DIR="${UV_CACHE_DIR:-${ROOT_DIR}/.uv-cache}"
 export MINERVA_WORKSPACE_ROOT="${MINERVA_WORKSPACE_ROOT:-${ROOT_DIR}/hard-disk}"
+
+REPORT_DIR="${MINERVA_REPORT_DIR:-${MINERVA_WORKSPACE_ROOT}/reports/03-daily-news/${RUN_DATE}}"
+INVEST_DB="${INVEST_DB:-${MINERVA_WORKSPACE_ROOT}/data/04-database/invest.db}"
+PHASE_DIR="${MINERVA_NEWS_ARTIFACT_DIR:-${REPORT_DIR}/data/structured/news-pipeline}"
+COLLECTOR_ARTIFACT_DIR="${PHASE_DIR}/collectors"
+NEWS_RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/morning-brief-${RUN_DATE}-XXXXXX")"
+NEWS_SOURCE_ROOTS_DIR="${NEWS_RUN_DIR}/sources"
+cleanup_run_dir() {
+  # Candidate and lookup metadata is ephemeral. Collector responses are never
+  # retained because they could accidentally contain article body text.
+  rm -rf "${NEWS_RUN_DIR}"
+}
+trap cleanup_run_dir EXIT
 
 MINERVA_RUNNER="${MINERVA_RUNNER:-uv run minerva}"
 MINERVA_BRIEF_EARNINGS_PROVIDER="${MINERVA_BRIEF_EARNINGS_PROVIDER:-finnhub}"
@@ -51,27 +66,79 @@ MINERVA_SKIP_NEWS="${MINERVA_SKIP_NEWS:-0}"
 MINERVA_ALLOW_THIN_BRIEF="${MINERVA_ALLOW_THIN_BRIEF:-0}"
 
 IFS=' ' read -r -a MINERVA_RUNNER_ARR <<< "${MINERVA_RUNNER}"
-printf -v NEWS_EXIST_RUNNER '%q ' "${MINERVA_RUNNER_ARR[@]}" news exist
-NEWS_EXIST_RUNNER="${NEWS_EXIST_RUNNER% }"
-# Collector agents run from their OpenClaw workspace, not necessarily this
-# repository. Anchor the CLI command here so `uv run minerva` resolves the
-# checked-out project rather than a stale globally installed Minerva tool.
-printf -v NEWS_EXIST_COMMAND 'cd %q && %s' "${ROOT_DIR}" "${NEWS_EXIST_RUNNER}"
-
 run() { "${MINERVA_RUNNER_ARR[@]}" "$@"; }
 
-mkdir -p \
-  "${REPORT_DIR}" \
-  "${NEWS_RUN_DIR}/raw" \
-  "${NEWS_RUN_DIR}/summaries" \
-  "${NEWS_RUN_DIR}/logs" \
+# Collector agents may run from another OpenClaw workspace. Render shell-quoted,
+# repository-anchored commands so they always use this checkout and this DB.
+printf -v NEWS_EXIST_RUNNER '%q ' "${MINERVA_RUNNER_ARR[@]}" news exist
+NEWS_EXIST_RUNNER="${NEWS_EXIST_RUNNER% }"
+printf -v NEWS_EXIST_COMMAND 'cd %q && %s' "${ROOT_DIR}" "${NEWS_EXIST_RUNNER}"
+printf -v NEWS_INGEST_RUNNER '%q ' \
+  "${MINERVA_RUNNER_ARR[@]}" news ingest --input - --db "${INVEST_DB}"
+NEWS_INGEST_RUNNER="${NEWS_INGEST_RUNNER% }"
+printf -v NEWS_INGEST_COMMAND '(cd %q && %s)' \
+  "${ROOT_DIR}" "${NEWS_INGEST_RUNNER}"
+
+mkdir -p "${REPORT_DIR}" "${PHASE_DIR}" "${COLLECTOR_ARTIFACT_DIR}" \
   "${NEWS_SOURCE_ROOTS_DIR}"
+
+write_status() {
+  local destination="$1" phase="$2" status="$3" exit_status="$4"
+  local stdout_path="${5:-}" stderr_path="${6:-}"
+  python3 - "${destination}" "${phase}" "${status}" "${exit_status}" \
+    "${stdout_path}" "${stderr_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, phase, status, exit_status, stdout_path, stderr_path = sys.argv[1:]
+payload = {
+    "exit_status": int(exit_status),
+    "phase": phase,
+    "status": status,
+}
+if stdout_path:
+    payload["stdout"] = stdout_path
+if stderr_path:
+    payload["stderr"] = stderr_path
+Path(path).write_text(
+    json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+}
+
+run_minerva_phase() {
+  local phase="$1"
+  shift
+  local stdout_path="${PHASE_DIR}/${phase}.json"
+  local stderr_path="${PHASE_DIR}/${phase}.stderr.log"
+  local status
+  if run "$@" >"${stdout_path}" 2>"${stderr_path}"; then
+    write_status "${PHASE_DIR}/${phase}.status.json" "${phase}" ok 0 \
+      "${stdout_path}" "${stderr_path}"
+    if [[ -s "${stdout_path}" ]]; then
+      echo "  ${phase}: $(tail -n 1 "${stdout_path}")"
+    else
+      echo "  ${phase}: ok"
+    fi
+  else
+    status=$?
+    write_status "${PHASE_DIR}/${phase}.status.json" "${phase}" failed \
+      "${status}" "${stdout_path}" "${stderr_path}"
+    echo "error[${phase}]: failed with status ${status}" >&2
+    echo "error[${phase}]: diagnostics: ${stderr_path}" >&2
+    [[ ! -s "${stderr_path}" ]] || tail -n 20 "${stderr_path}" >&2
+    return "${status}"
+  fi
+}
 
 echo "=== Morning Brief Pipeline ==="
 echo "date: ${RUN_DATE}"
 echo "news_run_dir: ${NEWS_RUN_DIR}"
 echo "invest_db: ${INVEST_DB}"
 echo "report_dir: ${REPORT_DIR}"
+echo "phase_artifacts: ${PHASE_DIR}"
 echo ""
 
 # ── PHASE 1: Structured data collection ──
@@ -81,30 +148,45 @@ portfolio_sync_args=(portfolio sync --date "${RUN_DATE}")
 [[ -n "${MINERVA_PORTFOLIO_HOLDINGS_SOURCE:-}" ]] && portfolio_sync_args+=(--holdings-source "${MINERVA_PORTFOLIO_HOLDINGS_SOURCE}")
 [[ -n "${MINERVA_PORTFOLIO_TRANSACTIONS_SOURCE:-}" ]] && portfolio_sync_args+=(--transactions-source "${MINERVA_PORTFOLIO_TRANSACTIONS_SOURCE}")
 [[ -n "${MINERVA_PORTFOLIO_WATCHLIST_SOURCE:-}" ]] && portfolio_sync_args+=(--watchlist-source "${MINERVA_PORTFOLIO_WATCHLIST_SOURCE}")
-run "${portfolio_sync_args[@]}"
+run_minerva_phase portfolio-sync "${portfolio_sync_args[@]}"
 
-run brief filings --date "${RUN_DATE}"
+run_minerva_phase filings brief filings --date "${RUN_DATE}"
 
 earnings_args=(brief earnings --date "${RUN_DATE}" --provider "${MINERVA_BRIEF_EARNINGS_PROVIDER}")
 [[ -n "${MINERVA_BRIEF_EARNINGS_SOURCE:-}" ]] && earnings_args+=(--source "${MINERVA_BRIEF_EARNINGS_SOURCE}")
-run "${earnings_args[@]}"
+run_minerva_phase earnings "${earnings_args[@]}"
 
 market_args=(brief market --date "${RUN_DATE}" --provider "${MINERVA_BRIEF_MARKET_PROVIDER}")
 [[ -n "${MINERVA_BRIEF_MARKET_SOURCE:-}" ]] && market_args+=(--source "${MINERVA_BRIEF_MARKET_SOURCE}")
-run "${market_args[@]}"
+run_minerva_phase market "${market_args[@]}"
 
 echo ""
 
-# ── PHASE 2a: News collection (parallel browser/web_fetch agents) ──
 if [[ "${MINERVA_SKIP_NEWS}" == "1" ]]; then
-  echo "── Phase 2a: News collection (skipped) ──"
+  echo "── Phase 2: News collection (skipped) ──"
+  write_status "${PHASE_DIR}/news.status.json" news skipped 0
+  printf '%s\n' \
+    '{"current_date":"'"${RUN_DATE}"'","current_rows":0,"null_or_blank_summaries":0,"phase":"current-evidence","sources":{},"status":"skipped"}' \
+    >"${PHASE_DIR}/current-evidence.json"
 else
-  echo "── Phase 2a: News collection ──"
+  # ── PHASE 2a: Direct aggregate downloads ──
+  echo "── Phase 2a: Direct Finnhub and market downloads ──"
+  # With no --symbol override, Finnhub uses current holdings + watchlist.
+  run_minerva_phase finnhub-news news download-finnhub \
+    --date "${RUN_DATE}" --db "${INVEST_DB}"
+  # With no --index/--symbol overrides, market data uses default indexes plus
+  # the current holdings + watchlist universe.
+  run_minerva_phase market-data news download-market-data \
+    --date "${RUN_DATE}" --db "${INVEST_DB}"
+
+  # ── PHASE 2b: Direct-ingest browser/web_fetch collectors ──
+  echo ""
+  echo "── Phase 2b: Direct-ingest collectors ──"
 
   BROWSER_PROMPT_TEMPLATE="${ROOT_DIR}/scripts/prompts/collect_news.md"
   WEBFETCH_PROMPT_TEMPLATE="${ROOT_DIR}/scripts/prompts/collect_news_webfetch.md"
-  NEWS_SOURCES="${MINERVA_NEWS_SOURCES:-${ROOT_DIR}/hard-disk/data/02-news/news-sources.json}"
-  IR_REGISTRY="${MINERVA_IR_REGISTRY:-${ROOT_DIR}/hard-disk/data/01-portfolio/current/ir-registry.json}"
+  NEWS_SOURCES="${MINERVA_NEWS_SOURCES:-${MINERVA_WORKSPACE_ROOT}/data/02-news/news-sources.json}"
+  IR_REGISTRY="${MINERVA_IR_REGISTRY:-${MINERVA_WORKSPACE_ROOT}/data/01-portfolio/current/ir-registry.json}"
   PIDS=()
 
   if [[ -f "${NEWS_SOURCES}" ]] && ! jq -e '
@@ -117,7 +199,7 @@ else
       ((has("collect") | not) or (.collect | type == "string"))
     )
   ' "${NEWS_SOURCES}" >/dev/null; then
-    echo "news: malformed source registry: ${NEWS_SOURCES}" >&2
+    echo "error[collectors]: malformed source registry: ${NEWS_SOURCES}" >&2
     exit 1
   fi
   if [[ -f "${IR_REGISTRY}" ]] && ! jq -e '
@@ -129,95 +211,55 @@ else
       all(.feeds[]; type == "object" and (.url | type == "string" and length > 0))
     )
   ' "${IR_REGISTRY}" >/dev/null; then
-    echo "news: malformed IR registry: ${IR_REGISTRY}" >&2
+    echo "error[collectors]: malformed IR registry: ${IR_REGISTRY}" >&2
     exit 1
   fi
 
-  write_collection_error() {
-    local source_root="$1" source_id="$2" source_name="$3" url="$4"
-    local sessid="$5" status="$6" log_file="$7"
-    local error_file="${source_root}/raw/${source_id}-error.md"
-
-    cat > "${error_file}" <<EOF
-# ${source_name} collection failed
-
-Source: ${source_name}
-URL: ${url}
-Published: ${RUN_DATE}
-Collected: $(date -u +%FT%TZ)
-Section: collection-error
-
-Status: failed
-Exit status: ${status}
-Session: ${sessid}
-Log: ${log_file}
-
-The collector exited non-zero. See the log file above for stdout/stderr from the child collector process.
-EOF
-  }
-
-  # ── Build portfolio company list (ticker + name) ──
-  COMPANY_DIR="${ROOT_DIR}/hard-disk/data/01-portfolio/current/company-directory.md"
-  RENDERED_PORTFOLIO="${ROOT_DIR}/hard-disk/data/01-portfolio/current/rendered.md"
+  # Build portfolio company context for relevance ranking in collector prompts.
+  COMPANY_DIR="${MINERVA_WORKSPACE_ROOT}/data/01-portfolio/current/company-directory.md"
+  RENDERED_PORTFOLIO="${MINERVA_WORKSPACE_ROOT}/data/01-portfolio/current/rendered.md"
   PORTFOLIO_TICKERS="(not available)"
-  if [[ -f "$COMPANY_DIR" && -f "$RENDERED_PORTFOLIO" ]]; then
-    # Get active tickers from rendered.md (holdings + watchlist)
-    active_tickers=$(grep -E '^- `[A-Z0-9.]+`' "$RENDERED_PORTFOLIO" | sed 's/- `\([^`]*\)`.*/\1/' | sort -u)
-    # Look up company names from the directory table, output "Ticker — Company Name"
+  if [[ -f "${RENDERED_PORTFOLIO}" ]]; then
+    active_tickers=$(grep -E '^- `[A-Z0-9.]+`' "${RENDERED_PORTFOLIO}" | sed 's/- `\([^`]*\)`.*/\1/' | sort -u || true)
     PORTFOLIO_TICKERS=""
     while read -r tkr; do
-      name=$(grep -E "^\| ${tkr} \|" "$COMPANY_DIR" 2>/dev/null | head -1 | awk -F'|' '{gsub(/^ +| +$/, "", $3); print $3}' || true)
-      if [[ -n "$name" ]]; then
-        entry="${name}"
-      else
-        entry="${tkr}"
+      [[ -n "${tkr}" ]] || continue
+      name=""
+      if [[ -f "${COMPANY_DIR}" ]]; then
+        name=$(grep -E "^\| ${tkr} \|" "${COMPANY_DIR}" 2>/dev/null | head -1 | awk -F'|' '{gsub(/^ +| +$/, "", $3); print $3}' || true)
       fi
-      if [[ -n "$PORTFOLIO_TICKERS" ]]; then
-        PORTFOLIO_TICKERS="${PORTFOLIO_TICKERS}, ${entry}"
-      else
-        PORTFOLIO_TICKERS="${entry}"
-      fi
-    done <<< "$active_tickers"
+      entry="${name:-${tkr}}"
+      PORTFOLIO_TICKERS="${PORTFOLIO_TICKERS:+${PORTFOLIO_TICKERS}, }${entry}"
+    done <<< "${active_tickers}"
+    PORTFOLIO_TICKERS="${PORTFOLIO_TICKERS:-(not available)}"
     echo "  portfolio: ${PORTFOLIO_TICKERS}"
-  elif [[ -f "$RENDERED_PORTFOLIO" ]]; then
-    PORTFOLIO_TICKERS=$(grep -E '^- `[A-Z0-9.]+`' "$RENDERED_PORTFOLIO" | sed 's/- `\([^`]*\)`.*/\1/' | sort -u | tr '\n' ', ' | sed 's/,$//')
-    echo "  portfolio tickers (no names): ${PORTFOLIO_TICKERS}"
   fi
 
   render_collection_prompt() {
     local template="$1" source_name="$2" source_id="$3" url="$4"
     local collection_scope="$5" source_root="$6"
-    local candidate_file="${source_root}/candidates/${source_id}.json"
-    local lookup_file="${source_root}/lookups/${source_id}.json"
-    python3 - "$template" "$RUN_DATE" "$source_name" "$source_id" "$url" \
-      "$source_root" "$INVEST_DB" "$NEWS_EXIST_COMMAND" "$PORTFOLIO_TICKERS" \
-      "$collection_scope" "$candidate_file" "$lookup_file" <<'PY'
+    local candidate_file="${source_root}/candidates.json"
+    local lookup_file="${source_root}/lookup.json"
+    python3 - "${template}" "${RUN_DATE}" "${source_name}" "${source_id}" \
+      "${url}" "${source_root}" "${INVEST_DB}" "${NEWS_EXIST_COMMAND}" \
+      "${NEWS_INGEST_COMMAND}" "${PORTFOLIO_TICKERS}" \
+      "${collection_scope}" "${candidate_file}" "${lookup_file}" <<'PY'
 import sys
 from pathlib import Path
 
-(
-    template,
-    run_date,
-    source_name,
-    source_id,
-    url,
-    news_dir,
-    invest_db,
-    news_exist_command,
-    portfolio_tickers,
-    collection_scope,
-    candidate_file,
-    lookup_file,
-) = sys.argv[1:]
+(template, run_date, source_name, source_id, url, source_root, invest_db,
+ news_exist_command, news_ingest_command, portfolio_tickers, collection_scope,
+ candidate_file, lookup_file) = sys.argv[1:]
 text = Path(template).read_text(encoding="utf-8")
 replacements = {
     "DATE": run_date,
     "SOURCE_NAME": source_name,
     "SOURCE_ID": source_id,
     "URL": url,
-    "NEWS_DIR": news_dir,
+    "SOURCE_ROOT": source_root,
     "INVEST_DB": invest_db,
     "NEWS_EXIST_COMMAND": news_exist_command,
+    "NEWS_INGEST_COMMAND": news_ingest_command,
     "PORTFOLIO_TICKERS": portfolio_tickers,
     "COLLECT_SCOPE": collection_scope,
     "CANDIDATE_FILE": candidate_file,
@@ -229,55 +271,98 @@ sys.stdout.write(text)
 PY
   }
 
-  # Run one collector inside its pre-created source root. Prompt template and
-  # timeout preserve browser and web_fetch behavior without duplicated launch
-  # logic.
+  write_collector_status() {
+    local destination="$1" source_id="$2" source_name="$3" url="$4"
+    local session_id="$5" status="$6" exit_status="$7" log_file="$8"
+    local output_bytes="$9"
+    python3 - "${destination}" "${source_id}" "${source_name}" "${url}" \
+      "${session_id}" "${status}" "${exit_status}" "${log_file}" \
+      "${output_bytes}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(destination, source_id, source_name, url, session_id, status, exit_status,
+ log_file, output_bytes) = sys.argv[1:]
+payload = {
+    "exit_status": int(exit_status),
+    "log": log_file,
+    "openclaw_output_bytes": int(output_bytes),
+    "session_id": session_id,
+    "source_id": source_id,
+    "source_name": source_name,
+    "status": status,
+    "url": url,
+}
+Path(destination).write_text(
+    json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+  }
+
   collect_source() {
     local prompt_template="$1" timeout="$2" source_id="$3" source_name="$4"
     local url="$5" collection_scope="$6" source_root="$7"
-    local sessid="news-${source_id}-$(date +%s)"
-    local log_file="${source_root}/logs/${source_id}.log"
-    local prompt
-    prompt=$(render_collection_prompt "${prompt_template}" \
-      "$source_name" "$source_id" "$url" "$collection_scope" "$source_root")
+    local artifact_root="${COLLECTOR_ARTIFACT_DIR}/${source_id}"
+    local session_id="news-${source_id}-${RUN_DATE}-$$-${RANDOM}"
+    local temp_output="${source_root}/openclaw-output.log"
+    local lifecycle_log="${artifact_root}/collector.log"
+    local status_file="${artifact_root}/status.json"
+    local prompt exit_status output_bytes result_status
+    mkdir -p "${artifact_root}"
+    prompt=$(render_collection_prompt "${prompt_template}" "${source_name}" \
+      "${source_id}" "${url}" "${collection_scope}" "${source_root}")
 
     {
       echo "source_id: ${source_id}"
       echo "source_name: ${source_name}"
       echo "url: ${url}"
-      echo "session_id: ${sessid}"
+      echo "session_id: ${session_id}"
       echo "started_at: $(date -u +%FT%TZ)"
-      echo ""
-    } > "${log_file}"
+    } >"${lifecycle_log}"
 
     if openclaw agent \
       --agent "${MINERVA_NEWS_COLLECTOR_AGENT}" \
       --timeout "${timeout}" \
       --model fireworks/accounts/fireworks/routers/glm-5p2-fast \
       --thinking high \
-      --session-id "${sessid}" \
-      --message "${prompt}" >>"${log_file}" 2>&1; then
-      echo "news: ${source_id} ok (log: ${log_file})"
-      return 0
+      --session-id "${session_id}" \
+      --message "${prompt}" >"${temp_output}" 2>&1; then
+      exit_status=0
+      result_status=ok
     else
-      local status=$?
-      echo "news: ${source_id} failed (status ${status}, log: ${log_file})"
-      write_collection_error \
-        "${source_root}" "${source_id}" "${source_name}" "${url}" \
-        "${sessid}" "${status}" "${log_file}"
-      return "${status}"
+      exit_status=$?
+      result_status=failed
     fi
+    output_bytes=$(wc -c <"${temp_output}" | tr -d ' ')
+    {
+      echo "finished_at: $(date -u +%FT%TZ)"
+      echo "status: ${result_status}"
+      echo "exit_status: ${exit_status}"
+      echo "openclaw_output_bytes: ${output_bytes}"
+      echo "note: OpenClaw output discarded to prevent article-body persistence"
+    } >>"${lifecycle_log}"
+    write_collector_status "${status_file}" "${source_id}" "${source_name}" \
+      "${url}" "${session_id}" "${result_status}" "${exit_status}" \
+      "${lifecycle_log}" "${output_bytes}"
+    rm -f "${temp_output}"
+
+    if [[ "${exit_status}" -eq 0 ]]; then
+      echo "news: ${source_id} ok (status: ${status_file})"
+    else
+      echo "news: ${source_id} failed (status ${exit_status}; status: ${status_file})"
+    fi
+    return "${exit_status}"
   }
 
-  # Allocate the physical root before launch so duplicate/unsafe source IDs
-  # cannot make two concurrent collectors share files.
   wait_for_collectors() {
     if [[ "${#PIDS[@]}" -eq 0 ]]; then
       return 0
     fi
     echo "  waiting for collector batch (${#PIDS[@]} agents)..."
     for pid in "${PIDS[@]}"; do
-      wait "$pid" 2>/dev/null || true
+      wait "${pid}" 2>/dev/null || true
     done
     PIDS=()
   }
@@ -286,162 +371,199 @@ PY
     local prompt_template="$1" timeout="$2" source_id="$3" source_name="$4"
     local url="$5" collection_scope="$6"
     if ! [[ "${source_id}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
-      echo "news: unsafe source id: ${source_id}" >&2
+      echo "error[collectors]: unsafe source id: ${source_id}" >&2
       return 1
     fi
     local source_root="${NEWS_SOURCE_ROOTS_DIR}/${source_id}"
     if [[ -e "${source_root}" ]]; then
-      echo "news: duplicate source id: ${source_id}" >&2
+      echo "error[collectors]: duplicate source id: ${source_id}" >&2
       return 1
     fi
-    mkdir -p \
-      "${source_root}/raw" \
-      "${source_root}/candidates" \
-      "${source_root}/lookups" \
-      "${source_root}/logs"
-    collect_source "${prompt_template}" "${timeout}" \
-      "${source_id}" "${source_name}" "${url}" "${collection_scope}" \
-      "${source_root}" &
+    mkdir -p "${source_root}"
+    printf '%s\n' "${source_id}" >>"${NEWS_RUN_DIR}/launched.txt"
+    collect_source "${prompt_template}" "${timeout}" "${source_id}" \
+      "${source_name}" "${url}" "${collection_scope}" "${source_root}" &
     PIDS+=("$!")
     if [[ "${#PIDS[@]}" -ge "${MINERVA_MAX_COLLECTORS}" ]]; then
       wait_for_collectors
     fi
   }
 
-  # Copy source artifacts in lexical source/file order only after every agent
-  # has exited. Any same-name output from different roots is a hard failure.
-  aggregate_source_raw() {
-    local LC_ALL=C
-    local source_root raw_file destination
-    for source_root in "${NEWS_SOURCE_ROOTS_DIR}"/*; do
-      [[ -d "${source_root}" ]] || continue
-      for raw_file in "${source_root}/raw/"*.md; do
-        [[ -f "${raw_file}" ]] || continue
-        destination="${NEWS_RUN_DIR}/raw/${raw_file##*/}"
-        if [[ -e "${destination}" ]]; then
-          echo "news: raw filename collision: ${raw_file##*/}" >&2
-          return 1
-        fi
-        cp "${raw_file}" "${destination}"
-      done
-    done
-  }
-
-  # Read news-sources.json and launch every configured collector.
   if [[ -f "${NEWS_SOURCES}" ]]; then
     while IFS= read -r entry; do
-      source_id=$(echo "$entry" | jq -r '.id')
-      source_name=$(echo "$entry" | jq -r '.name')
-      url=$(echo "$entry" | jq -r '.url')
-      access=$(echo "$entry" | jq -r '.access')
-      collection_scope=$(echo "$entry" | jq -r '.collect // "Items relevant to a long-only investor."')
-
-      if [[ "$access" == "browser" ]]; then
+      source_id=$(echo "${entry}" | jq -r '.id')
+      source_name=$(echo "${entry}" | jq -r '.name')
+      url=$(echo "${entry}" | jq -r '.url')
+      access=$(echo "${entry}" | jq -r '.access')
+      collection_scope=$(echo "${entry}" | jq -r '.collect // "Items relevant to a long-only investor."')
+      if [[ "${access}" == "browser" ]]; then
         echo "  spawning browser agent: ${source_id}"
         launch_source "${BROWSER_PROMPT_TEMPLATE}" "${MINERVA_BROWSER_TIMEOUT}" \
-          "$source_id" "$source_name" "$url" "$collection_scope"
-      elif [[ "$access" == "web_fetch" ]]; then
+          "${source_id}" "${source_name}" "${url}" "${collection_scope}"
+      else
         echo "  spawning web_fetch agent: ${source_id}"
         launch_source "${WEBFETCH_PROMPT_TEMPLATE}" "${MINERVA_WEBFETCH_TIMEOUT}" \
-          "$source_id" "$source_name" "$url" "$collection_scope"
+          "${source_id}" "${source_name}" "${url}" "${collection_scope}"
       fi
     done < <(jq -c '.[]' "${NEWS_SOURCES}")
   fi
 
-  # IR feeds share the same configurable collector pool as standard sources.
-  # The limit protects the Gateway from client-startup contention and can be
-  # raised without changing code as capacity grows.
   if [[ -f "${IR_REGISTRY}" ]]; then
     while IFS= read -r entry; do
-      ticker=$(echo "$entry" | jq -r '.security_id')
-      url=$(echo "$entry" | jq -r '.feeds[0].url // empty')
-
-      if [[ -z "$url" ]]; then
-        continue
-      fi
-
+      ticker=$(echo "${entry}" | jq -r '.security_id')
+      url=$(echo "${entry}" | jq -r '.feeds[0].url // empty')
+      [[ -n "${url}" ]] || continue
       echo "  spawning IR browser agent: ${ticker}"
       launch_source "${BROWSER_PROMPT_TEMPLATE}" "${MINERVA_BROWSER_TIMEOUT}" \
-        "ir-${ticker}" "IR — ${ticker}" "$url" \
+        "ir-${ticker}" "IR — ${ticker}" "${url}" \
         "New investor-relations releases, filings, earnings materials, capital-allocation announcements, or other material company updates published within the last 3 days."
     done < <(jq -c '.[]' "${IR_REGISTRY}")
   fi
 
-  # Wait for the final partial collector batch.
   echo "  waiting for news agents..."
   wait_for_collectors
 
-  aggregate_source_raw
+  python3 - "${NEWS_RUN_DIR}/launched.txt" "${COLLECTOR_ARTIFACT_DIR}" \
+    >"${PHASE_DIR}/collectors.json" <<'PY'
+import json
+import sys
+from pathlib import Path
 
-  COLLECTION_ERROR_COUNT=$(find "${NEWS_RUN_DIR}/raw" -name "*-error.md" 2>/dev/null | wc -l | tr -d ' ')
+launched_path, artifact_root = map(Path, sys.argv[1:])
+launched = (
+    launched_path.read_text(encoding="utf-8").splitlines()
+    if launched_path.is_file()
+    else []
+)
+rows = []
+for source_id in launched:
+    status_path = artifact_root / source_id / "status.json"
+    if status_path.is_file():
+        row = json.loads(status_path.read_text(encoding="utf-8"))
+    else:
+        row = {
+            "exit_status": -1,
+            "source_id": source_id,
+            "status": "failed",
+            "error": "collector exited without a status artifact",
+        }
+    rows.append(row)
+failures = [row for row in rows if row.get("status") != "ok"]
+payload = {
+    "failed": len(failures),
+    "failures": failures,
+    "phase": "collectors",
+    "status": "degraded" if failures else "ok",
+    "succeeded": len(rows) - len(failures),
+    "total": len(rows),
+}
+print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+PY
+  COLLECTION_ERROR_COUNT=$(python3 - "${PHASE_DIR}/collectors.json" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["failed"])
+PY
+)
   if [[ "${COLLECTION_ERROR_COUNT}" -gt 0 ]]; then
-    echo "  news collection completed with ${COLLECTION_ERROR_COUNT} collector error(s); source roots: ${NEWS_SOURCE_ROOTS_DIR}"
+    echo "  news collection completed with ${COLLECTION_ERROR_COUNT} collector error(s)"
+    echo "  collector diagnostics: ${PHASE_DIR}/collectors.json"
   else
-    echo "  news collection complete; source roots: ${NEWS_SOURCE_ROOTS_DIR}"
+    echo "  news collection complete: $(cat "${PHASE_DIR}/collectors.json")"
   fi
-fi
 
-echo ""
+  # ── PHASE 3: Current-date evidence gate ──
+  echo ""
+  echo "── Phase 3: Current-date evidence gate ──"
+  if python3 - "${INVEST_DB}" "${RUN_DATE}" \
+      >"${PHASE_DIR}/current-evidence.json" \
+      2>"${PHASE_DIR}/current-evidence.stderr.log" <<'PY'
+import json
+import sqlite3
+import sys
+import time as time_module
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
 
-# ── PHASE 2b: Summarize raw articles with extract-files ──
-echo "── Phase 2b: Summarize articles ──"
-
-RAW_COUNT=$(find "${NEWS_RUN_DIR}/raw" -name "*.md" -not -name "*-error.md" 2>/dev/null | wc -l | tr -d ' ')
-if [[ "${RAW_COUNT}" -gt 0 ]]; then
-  EXTRACT_PROMPT="Summarize this article for a long-only investor in one detailed paragraph. Include: the key facts, why it matters for markets or specific companies, and any portfolio implications. If the article is a press release or data release, focus on the numbers and what they signal. Be specific — name companies, figures, and dates."
-
-  run extract-files \
-    -f "${NEWS_RUN_DIR}/raw/*.md" \
-    -o "${NEWS_RUN_DIR}/summaries" \
-    --model gemini-3.6-flash \
-    --thinking high \
-    --concurrency 4 \
-    --force \
-    "${EXTRACT_PROMPT}" || echo "extract-files: failed (non-fatal)"
-
-  echo "  summarized ${RAW_COUNT} articles"
-else
-  echo "  no raw articles to summarize"
-fi
-
-echo ""
-
-# ── PHASE 2c: Ingest raw + summaries into invest.db ──
-# One writer, single SQLite transaction. Parallel collectors only perform
-# read-only existence checks; they produce markdown into NEWS_RUN_DIR.
-echo "── Phase 2c: Ingest into invest.db ──"
-
-ingest_report="${NEWS_RUN_DIR}/logs/ingest.log"
-ingest_stats="${NEWS_RUN_DIR}/logs/ingest.json"
-if [[ "${RAW_COUNT}" -gt 0 ]]; then
-  if run news ingest \
-      --raw-dir "${NEWS_RUN_DIR}/raw" \
-      --summaries-dir "${NEWS_RUN_DIR}/summaries" \
-      --db "${INVEST_DB}" \
-      --news-sources "${NEWS_SOURCES}" \
-      --ir-registry "${IR_REGISTRY}" \
-      --report "${ingest_report}" > "${ingest_stats}"; then
-    INGEST_OK=1
-    echo "  ingest stats: $(cat "${ingest_stats}")"
+raw_db, run_date = sys.argv[1:]
+db = Path(raw_db)
+result = {
+    "current_date": run_date,
+    "current_rows": 0,
+    "null_or_blank_summaries": 0,
+    "phase": "current-evidence",
+    "sources": {},
+    "status": "ok",
+}
+if db.is_file():
+    day = date.fromisoformat(run_date)
+    market_tz = ZoneInfo("America/New_York")
+    start = datetime.combine(day, time.min, tzinfo=market_tz)
+    end = datetime.combine(day + timedelta(days=1), time.min, tzinfo=market_tz)
+    lower = int(start.timestamp())
+    upper = int(end.timestamp())
+    uri = f"{db.resolve().as_uri()}?mode=ro"
+    conn = None
+    for attempt in range(5):
+        try:
+            conn = sqlite3.connect(uri, uri=True, timeout=30)
+            break
+        except sqlite3.OperationalError:
+            if attempt == 4:
+                raise
+            time_module.sleep(0.25 * (attempt + 1))
+    assert conn is not None
+    with conn:
+        conn.execute("PRAGMA query_only = ON")
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='news'"
+        ).fetchone()
+        if table is not None:
+            predicate = (
+                "trim(content) <> '' AND ("
+                "(published_at IS NOT NULL AND published_at >= ? AND published_at < ?) "
+                "OR (published_at IS NULL AND substr(trim(published_at_raw), 1, 10) = ?))"
+            )
+            params = (lower, upper, run_date)
+            result["current_rows"] = conn.execute(
+                f"SELECT COUNT(*) FROM news WHERE {predicate}", params
+            ).fetchone()[0]
+            result["null_or_blank_summaries"] = conn.execute(
+                f"SELECT COUNT(*) FROM news WHERE {predicate} "
+                "AND (summary IS NULL OR trim(summary) = '')",
+                params,
+            ).fetchone()[0]
+            result["sources"] = dict(conn.execute(
+                f"SELECT source, COUNT(*) FROM news WHERE {predicate} "
+                "GROUP BY source ORDER BY source",
+                params,
+            ).fetchall())
+print(json.dumps(result, separators=(",", ":"), sort_keys=True))
+PY
+  then
+    echo "  evidence: $(cat "${PHASE_DIR}/current-evidence.json")"
   else
-    echo "news ingest: failed (temp run dir preserved at ${NEWS_RUN_DIR})" >&2
-    exit 1
+    status=$?
+    write_status "${PHASE_DIR}/current-evidence.status.json" \
+      current-evidence failed "${status}" \
+      "${PHASE_DIR}/current-evidence.json" \
+      "${PHASE_DIR}/current-evidence.stderr.log"
+    echo "error[current-evidence]: unable to inspect ${INVEST_DB}" >&2
+    tail -n 20 "${PHASE_DIR}/current-evidence.stderr.log" >&2 || true
+    exit "${status}"
   fi
-else
-  # Nothing to ingest, but the temp dir is safe to remove.
-  echo '{"eligible": 0}' > "${ingest_stats}"
-  INGEST_OK=1
-fi
 
-echo ""
-
-if [[ "${MINERVA_SKIP_NEWS}" != "1" && "${MINERVA_ALLOW_THIN_BRIEF}" != "1" ]]; then
-  eligible_count=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("eligible", 0))' "${ingest_stats}" 2>/dev/null || echo 0)
-  if [[ "${eligible_count}" -eq 0 ]]; then
-    echo "news: no eligible articles were ingested" >&2
-    echo "news: refusing to continue without article evidence; set MINERVA_ALLOW_THIN_BRIEF=1 to allow a thin brief" >&2
-    echo "news: temp run directory preserved at ${NEWS_RUN_DIR}" >&2
-    INGEST_OK=0
+  eligible_count=$(python3 - "${PHASE_DIR}/current-evidence.json" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["current_rows"])
+PY
+)
+  if [[ "${eligible_count}" -eq 0 && "${MINERVA_ALLOW_THIN_BRIEF}" != "1" ]]; then
+    echo "news: no eligible current-date news evidence exists for ${RUN_DATE}" >&2
+    echo "news: refusing a thin brief; set MINERVA_ALLOW_THIN_BRIEF=1 to override" >&2
+    echo "news: evidence diagnostics: ${PHASE_DIR}/current-evidence.json" >&2
     exit 1
   fi
 fi
@@ -450,14 +572,11 @@ echo ""
 
 # ── PHASE 4: Evidence preparation ──
 echo "── Phase 4: Evidence preparation ──"
+run_minerva_phase prep brief prep --date "${RUN_DATE}"
 
-run brief prep --date "${RUN_DATE}"
-
-# Manifest check (relaxed: macro and ir no longer required)
 MANIFEST_PATH="${REPORT_DIR}/data/raw/manifest.json"
-
 if [[ "${MINERVA_SKIP_STATUS_CHECK}" != "1" ]]; then
-  uv run python - "${MANIFEST_PATH}" <<'PY'
+  if python3 - "${MANIFEST_PATH}" 2>"${PHASE_DIR}/manifest-check.stderr.log" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -475,13 +594,69 @@ if blocking:
     print(f"blocking morning-brief collection errors: {', '.join(blocking)}", file=sys.stderr)
     raise SystemExit(1)
 PY
+  then
+    write_status "${PHASE_DIR}/manifest-check.status.json" manifest-check ok 0
+  else
+    status=$?
+    write_status "${PHASE_DIR}/manifest-check.status.json" manifest-check failed \
+      "${status}" "" "${PHASE_DIR}/manifest-check.stderr.log"
+    echo "error[manifest-check]: prepared evidence status check failed" >&2
+    tail -n 20 "${PHASE_DIR}/manifest-check.stderr.log" >&2 || true
+    exit "${status}"
+  fi
+else
+  write_status "${PHASE_DIR}/manifest-check.status.json" manifest-check skipped 0
 fi
 
-echo ""
-
-# ── Output paths ──
 PREPARED_PATH="${REPORT_DIR}/data/structured/prepared-evidence.json"
+HANDOFF_PATH="${PHASE_DIR}/outer-sol-handoff.json"
+OUTER_SOL_PROMPT="${ROOT_DIR}/scripts/prompts/morning_brief_outer_sol.md"
+python3 - "${HANDOFF_PATH}" "${RUN_DATE}" "${INVEST_DB}" "${PREPARED_PATH}" \
+  "${REPORT_DIR}/notes/morning-brief-report.md" \
+  "${REPORT_DIR}/notes/slack-brief.md" \
+  "${PHASE_DIR}/current-evidence.json" "${OUTER_SOL_PROMPT}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    path,
+    run_date,
+    db,
+    prepared,
+    report,
+    slack_brief,
+    evidence_stats,
+    instructions,
+) = sys.argv[1:]
+payload = {
+    "date": run_date,
+    "db": db,
+    "evidence_stats": evidence_stats,
+    "final_agent": "outer-cron-sol",
+    "instructions": instructions,
+    "prepared_evidence": prepared,
+    "report_output": report,
+    "slack_brief_output": slack_brief,
+    "steps": [
+        "Query current-date news rows whose summary is NULL or blank.",
+        "Pipe each row's content through `minerva summarize`; retain generated summaries until all calls succeed.",
+        "Persist summaries with parameter binding in one safe transaction, updating only still-blank rows.",
+        "Synthesize notes/morning-brief-report.md and notes/slack-brief.md from prepared evidence and current-date news.",
+    ],
+    "status": "ready",
+}
+Path(path).write_text(
+    json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+
+echo ""
 echo "prepared_evidence: ${PREPARED_PATH}"
 echo "manifest: ${MANIFEST_PATH}"
 echo "news_db: ${INVEST_DB}"
-echo "main_agent_step: read prepared evidence + query today's fresh rows from the news table (published_at is Unix UTC seconds; use datetime(published_at, 'unixepoch') for display), then write notes/morning-brief-report.md and notes/slack-brief.md"
+echo "phase_artifacts: ${PHASE_DIR}"
+echo "outer_sol_handoff: ${HANDOFF_PATH}"
+echo "outer_sol_instructions: ${OUTER_SOL_PROMPT}"
+echo "outer_sol_step: The outer cron Sol agent (not this script) must follow the versioned instructions, summarize current-date rows with NULL/blank summary, persist all summaries safely in one transaction, synthesize both report artifacts, and return the Slack brief for cron delivery. Do not post Slack from this script."

--- a/tests/test_harness/test_morning_brief.py
+++ b/tests/test_harness/test_morning_brief.py
@@ -416,10 +416,19 @@ class MorningBriefTests(unittest.TestCase):
         )
         fake_minerva.chmod(0o755)
 
-        # Use a fake HOME so the v2 script's `source ~/.zshrc` is a no-op
-        # and doesn't re-export real env vars over our test overrides.
+        # A sourced zshrc may provide missing secrets, but explicit caller
+        # configuration must win. Poison every important path/runner here to
+        # catch precedence regressions before they can touch canonical data.
         fake_home = self.workspace / "fakehome"
         fake_home.mkdir(exist_ok=True)
+        poisoned_workspace = self.workspace / "poisoned-workspace"
+        (fake_home / ".zshrc").write_text(
+            f"export MINERVA_WORKSPACE_ROOT='{poisoned_workspace}'\n"
+            f"export INVEST_DB='{self.workspace / 'poisoned.db'}'\n"
+            "export MINERVA_RUNNER='/bin/false'\n"
+            "export FINNHUB_API_KEY='zshrc-only-test-key'\n",
+            encoding="utf-8",
+        )
 
         env = os.environ.copy()
         env.update(
@@ -448,12 +457,31 @@ class MorningBriefTests(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        # V2 prints output paths relative to ROOT_DIR/hard-disk, not MINERVA_WORKSPACE_ROOT.
         self.assertIn("prepared_evidence:", result.stdout)
         self.assertIn("manifest:", result.stdout)
-        # V2 creates dirs under ROOT_DIR/hard-disk.
-        report_dir = REPO_ROOT / "hard-disk" / "reports" / "03-daily-news" / RUN_DATE.isoformat()
+        # Report layout is anchored to MINERVA_WORKSPACE_ROOT so tests never
+        # write into the canonical hard-disk workspace.
+        workspace_root = self.workspace / "workspace"
+        report_dir = (
+            workspace_root / "reports" / "03-daily-news" / RUN_DATE.isoformat()
+        )
         self.assertTrue(report_dir.is_dir())
+        self.assertFalse(poisoned_workspace.exists())
+        self.assertFalse((self.workspace / "poisoned.db").exists())
+        # Outer-Sol handoff artifact is emitted for the cron agent.
+        handoff = (
+            report_dir
+            / "data"
+            / "structured"
+            / "news-pipeline"
+            / "outer-sol-handoff.json"
+        )
+        self.assertTrue(handoff.is_file())
+        handoff_payload = json.loads(handoff.read_text(encoding="utf-8"))
+        self.assertEqual(handoff_payload["final_agent"], "outer-cron-sol")
+        self.assertTrue(
+            any("minerva summarize" in step or "summarize" in step for step in handoff_payload["steps"])
+        )
         self.assertEqual(
             call_log.read_text(encoding="utf-8").splitlines(),
             [

--- a/tests/test_harness/test_news.py
+++ b/tests/test_harness/test_news.py
@@ -707,7 +707,8 @@ def test_ingest_cli_defaults_resolve_from_workspace(
     assert (workspace / "data" / "04-database" / "invest.db").is_file()
 
 
-def test_morning_brief_shell_and_prompts_use_news_cli_contract() -> None:
+def test_morning_brief_shell_and_prompts_use_direct_ingest_contract() -> None:
+    """The production script uses direct-ingest collectors and aggregate downloads."""
     script = (REPO_ROOT / "scripts" / "run_morning_brief.sh").read_text(
         encoding="utf-8"
     )
@@ -717,65 +718,97 @@ def test_morning_brief_shell_and_prompts_use_news_cli_contract() -> None:
     webfetch_prompt = (
         REPO_ROOT / "scripts" / "prompts" / "collect_news_webfetch.md"
     ).read_text(encoding="utf-8")
-    assert 'run news ingest \\' in script
+    outer_sol_prompt = (
+        REPO_ROOT / "scripts" / "prompts" / "morning_brief_outer_sol.md"
+    ).read_text(encoding="utf-8")
+
+    # Aggregate direct-download phases run before collectors and share the DB.
+    assert "news download-finnhub" in script
+    assert "news download-market-data" in script
+
+    # Collector stdin ingest command is rendered once and shared with agents.
+    assert "NEWS_INGEST_COMMAND" in script
+    assert "news ingest --input - --db" in script
+    assert "printf -v NEWS_INGEST_COMMAND '(cd %q && %s)'" in script
     assert "NEWS_EXIST_COMMAND" in script
     assert '"${MINERVA_RUNNER_ARR[@]}" news exist' in script
-    assert "printf -v NEWS_EXIST_COMMAND 'cd %q && %s'" in script
-    assert "Collector agents run from their OpenClaw workspace" in script
-    assert 'mkdir -p \\' in script
-    assert '"${source_root}/raw"' in script
-    assert '"${source_root}/candidates"' in script
-    assert '"${source_root}/lookups"' in script
-    assert '"${source_root}/logs"' in script
-    assert script.count("openclaw agent") == 1
-    assert "collect_source()" in script
-    assert "launch_source()" in script
-    assert "aggregate_source_raw()" in script
-    assert 'local prompt_template="$1" timeout="$2"' in script
+
+    # Configurable collector agent for OpenClaw same-agent isolation.
+    assert 'MINERVA_NEWS_COLLECTOR_AGENT="${MINERVA_NEWS_COLLECTOR_AGENT:-main}"' in script
+    assert '--agent "${MINERVA_NEWS_COLLECTOR_AGENT}"' in script
+
+    # Bounded parallel collectors, isolated source roots, phase artifacts.
     assert 'MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-900}"' in script
     assert 'MINERVA_WEBFETCH_TIMEOUT="${MINERVA_WEBFETCH_TIMEOUT:-300}"' in script
     assert 'MINERVA_MAX_COLLECTORS="${MINERVA_MAX_COLLECTORS:-8}"' in script
-    assert 'launch_source "${BROWSER_PROMPT_TEMPLATE}" "${MINERVA_BROWSER_TIMEOUT}"' in script
-    assert 'launch_source "${WEBFETCH_PROMPT_TEMPLATE}" "${MINERVA_WEBFETCH_TIMEOUT}"' in script
-    assert '"${#PIDS[@]}" -ge "${MINERVA_MAX_COLLECTORS}"' in script
-    assert "wait_for_collectors()" in script
-    assert '--concurrency 4' in script
+    assert 'wait_for_collectors' in script
+    assert "collectors.json" in script
+    assert "outer-sol-handoff.json" in script
+    assert "current-evidence.json" in script
+
+    # Current-date evidence gate refuses thin briefs unless explicitly allowed.
+    assert 'MINERVA_ALLOW_THIN_BRIEF' in script
+    assert "refusing a thin brief" in script
+    assert 'ZoneInfo("America/New_York")' in script
+
+    # The old batch-ingest architecture has been fully removed.
+    for banned in (
+        "extract-files",
+        "extract_files",
+        "aggregate_source_raw",
+        "--raw-dir",
+        "--summaries-dir",
+    ):
+        assert banned not in script, banned
+
+    # No inner Sol synthesis: reports/slack are written by the outer cron Sol.
+    assert "outer cron Sol" in script or "outer-cron-sol" in script
+    assert 'openclaw agent \\\n' in script or script.count("openclaw agent") == 1
 
     for prompt in (browser_prompt, webfetch_prompt):
+        # Deterministic duplicate check remains a mandatory pre-extraction step.
         assert '{{NEWS_EXIST_COMMAND}} --db "{{INVEST_DB}}"' in prompt
         assert '--input "{{CANDIDATE_FILE}}" > "{{LOOKUP_FILE}}"' in prompt
-        assert "one JSON array" in prompt
-        assert "overwriting" in prompt
-        assert "read-only" in prompt
-        assert "Your isolated source root is `{{NEWS_DIR}}`" in prompt
-        assert "never list, read, count, rename, modify, or delete another source's files" in prompt
-        assert "every file you write must stay within `{{NEWS_DIR}}`" in prompt
+        # Direct-ingest contract: one JSON object per article, piped to stdin.
+        assert "{{NEWS_INGEST_COMMAND}}" in prompt
+        assert "news ingest --input - --db" in prompt
+        # Article/item bodies live in SQLite only. No summary written here.
+        assert "isolated metadata root" in prompt
+        assert "SQLite" in prompt
+        assert "summarizer" in prompt
+        assert "outer Sol" in prompt
+        # Collectors never emit filesystem article/summary artifacts.
+        assert "Do not write article" in prompt
+        for forbidden in (".md`", "/raw/", "extract-files"):
+            assert forbidden not in prompt, forbidden
 
-    assert "scan the full landing page" in browser_prompt.lower()
+    # Browser prompt keeps single-tab, no-additional-window discipline.
     assert "only browser window and tab" in browser_prompt
-    assert "Do not run `browser open` again" in browser_prompt
-    assert "Never open a new tab or window" in browser_prompt
-    assert "one-item array" in browser_prompt
-    assert "rerun the same lookup command" in browser_prompt
-    assert "matching ingestion's collection-date fallback" in browser_prompt
-    assert "before body extraction" in browser_prompt.lower()
-    assert "Navigate the same tab back" in browser_prompt
-    assert "use an empty string" in webfetch_prompt
-    assert "matching ingestion's collection-date fallback" in webfetch_prompt
-    assert "fetch that URL with the web_fetch tool before writing anything" in webfetch_prompt
-    assert "calendar row without a distinct URL" in webfetch_prompt
-    assert "Same-tab navigation is allowed" in browser_prompt
-    assert "no additional windows or tabs are allowed" in browser_prompt
-    assert "Do not open browser windows or tabs" in webfetch_prompt
+    assert "one JSON array" in browser_prompt
+    assert "Never invoke Slack" in browser_prompt
+    assert "web_fetch only" in webfetch_prompt
+    assert "Never open a browser" in webfetch_prompt
+
+    # The versioned outer-Sol contract owns bounded summarization and delivery.
+    assert "at most four subprocesses" in outer_sol_prompt
+    assert "one transaction" in outer_sol_prompt
+    assert "Do not call Slack" in outer_sol_prompt
+    assert "Return the exact contents" in outer_sol_prompt
 
 
-def test_morning_brief_summarization_uses_official_gemini_model() -> None:
+def test_morning_brief_hands_summarization_off_to_outer_sol() -> None:
+    """No inner summarization: outer cron Sol handles minerva summarize + persistence."""
     script = (REPO_ROOT / "scripts" / "run_morning_brief.sh").read_text(
         encoding="utf-8"
     )
-    extract_block = script.split("run extract-files", 1)[1].split(
-        '"${EXTRACT_PROMPT}"', 1
-    )[0]
-
-    assert "--model gemini-3.6-flash" in extract_block
-    assert "--thinking high" in extract_block
+    # Script emits a handoff artifact naming outer-cron-sol as final agent.
+    assert '"outer-cron-sol"' in script
+    assert "minerva summarize" in script or "`minerva summarize`" in script
+    # The script never invokes `minerva summarize` itself (that's the outer agent).
+    assert "run summarize" not in script
+    assert '"${MINERVA_RUNNER_ARR[@]}" summarize' not in script
+    # Handoff explicitly lists final report artifacts.
+    assert "morning-brief-report.md" in script
+    assert "slack-brief.md" in script
+    # No Slack posting from this script.
+    assert "curl" not in script or "slack" not in script.lower()

--- a/tests/test_news_collection.py
+++ b/tests/test_news_collection.py
@@ -1,12 +1,13 @@
-"""Behavioral coverage for isolated morning-brief news collectors."""
+"""Behavioral coverage for direct-ingest morning-brief news collectors."""
 
 from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
+import sqlite3
 import subprocess
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -22,110 +23,175 @@ def _write_executable(path: Path, content: str) -> Path:
     return path
 
 
-def _fake_runner(tmp_path: Path) -> Path:
-    return _write_executable(
-        tmp_path / "fake-minerva",
-        """#!/usr/bin/env bash
+def _fake_minerva(tmp_path: Path) -> Path:
+    """Fake `minerva` that logs invocations and skips real work.
+
+    Aggregate downloads (`news download-finnhub`, `news download-market-data`)
+    just log. `news exist` returns an empty-seen response so collectors treat
+    every candidate as unseen. `news ingest` writes the piped article into a
+    real SQLite `news` table so the current-evidence gate sees rows.
+    """
+    script = r"""#!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "news" && "${2:-}" == "ingest" ]]; then
-  raw_dir=""
+subcommand="${1:-}"
+action="${2:-}"
+printf '%s\n' "$*" >> "${MINERVA_CALL_LOG}"
+
+if [[ "${subcommand}" == "news" && "${action}" == "exist" ]]; then
+  printf '{"seen":[],"unseen":[]}\n'
+  exit 0
+fi
+if [[ "${subcommand}" == "news" && "${action}" == "ingest" ]]; then
+  db=""
+  from_stdin=0
   shift 2
   while [[ "$#" -gt 0 ]]; do
-    if [[ "$1" == "--raw-dir" ]]; then
-      raw_dir="$2"
-      shift 2
-    else
-      shift
-    fi
+    case "$1" in
+      --db) db="$2"; shift 2 ;;
+      --input) if [[ "$2" == "-" ]]; then from_stdin=1; fi; shift 2 ;;
+      *) shift ;;
+    esac
   done
-  mkdir -p "${CAPTURE_DIR}"
-  for artifact in "${raw_dir}/"*.md; do
-    [[ -f "${artifact}" ]] || continue
-    cp "${artifact}" "${CAPTURE_DIR}/${artifact##*/}"
-  done
-  printf '{"eligible": 100}\n'
-fi
-""",
+  if [[ "${from_stdin}" -ne 1 ]]; then
+    echo "test fake minerva only supports --input -" >&2
+    exit 2
+  fi
+  payload="$(cat)"
+  DB_PATH="${db}" ARTICLE_JSON="${payload}" python3 - <<'PY'
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+
+db = os.environ["DB_PATH"]
+payload = json.loads(os.environ["ARTICLE_JSON"])
+conn = sqlite3.connect(db)
+try:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS news ("
+        "article_key TEXT PRIMARY KEY, "
+        "published_at INTEGER, "
+        "published_at_raw TEXT, "
+        "title TEXT, "
+        "content TEXT, "
+        "summary TEXT, "
+        "source TEXT, "
+        "url TEXT, "
+        "section TEXT, "
+        "collected_at TEXT)"
     )
+    key = f"{payload['source_id']}::{payload['url']}"
+    published_raw = payload.get("published_at", "")
+    try:
+        parsed = datetime.fromisoformat(published_raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        epoch = int(parsed.timestamp())
+    except (ValueError, AttributeError):
+        epoch = None
+    conn.execute(
+        "INSERT OR REPLACE INTO news "
+        "(article_key, published_at, published_at_raw, title, content, "
+        "summary, source, url, section, collected_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            key,
+            epoch,
+            published_raw,
+            payload["title"],
+            payload["content"],
+            None,
+            payload["source_id"],
+            payload["url"],
+            payload.get("section"),
+            payload.get("collected_at"),
+        ),
+    )
+    conn.commit()
+finally:
+    conn.close()
+print(json.dumps({"status": "inserted", "article_key": key}))
+PY
+  exit 0
+fi
+
+# Aggregate downloads (finnhub, market-data), brief filings/earnings/market/
+# prep, portfolio sync: just log and succeed.
+exit 0
+"""
+    return _write_executable(tmp_path / "fake-minerva", script)
 
 
 def _fake_openclaw(tmp_path: Path) -> Path:
+    """Fake OpenClaw that mimics a collector agent.
+
+    Parses `SOURCE_ROOT`, `INVEST_DB`, and `news ingest` command out of the
+    prompt, then either fails (for the broken source id) or invokes
+    `minerva news ingest --input -` via MINERVA_RUNNER so the wrapper's
+    contract with the news CLI is exercised end-to-end.
+    """
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     return _write_executable(
         fake_bin / "openclaw",
-        r'''#!/usr/bin/env bash
+        r"""#!/usr/bin/env bash
 set -euo pipefail
 message=""
 timeout=""
 agent=""
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
-    --message)
-      message="$2"
-      shift 2
-      ;;
-    --timeout)
-      timeout="$2"
-      shift 2
-      ;;
-    --agent)
-      agent="$2"
-      shift 2
-      ;;
-    *)
-      shift
-      ;;
+    --message) message="$2"; shift 2 ;;
+    --timeout) timeout="$2"; shift 2 ;;
+    --agent) agent="$2"; shift 2 ;;
+    *) shift ;;
   esac
 done
-source_root=$(printf '%s\n' "${message}" | sed -n 's/^Your isolated source root is `\([^`]*\)`.*/\1/p' | head -n 1)
+
+# Extract the isolated metadata root and the news-ingest command rendered in
+# the prompt. Both are stable, verbatim substrings emitted by the script.
+source_root=$(printf '%s\n' "${message}" | \
+  sed -n 's/^Your isolated metadata root is `\([^`]*\)`.*/\1/p' | head -n 1)
 source_id="${source_root##*/}"
+invest_db=$(printf '%s\n' "${message}" | \
+  sed -n 's|.*--db "\([^"]*\)".*|\1|p' | head -n 1)
+
 printf '%s|%s\n' "${source_id}" "${timeout}" >> "${TIMEOUT_LOG}"
 printf '%s\n' "${agent}" >> "${AGENT_LOG}"
+printf '%s\n' "${source_id}" >> "${COLLECTOR_START_LOG}"
 
-if [[ "${source_id}" == "${BROKEN_SOURCE:-}" ]]; then
+if [[ "${source_id}" == "${BROKEN_SOURCE:-__unset__}" ]]; then
   exit 7
 fi
 
-if [[ "${source_id}" == ir-* ]]; then
-  printf '%s\n' "${source_id}" >> "${IR_START_LOG}"
-  for _ in $(seq 1 500); do
-    started=$(wc -l < "${IR_START_LOG}" | tr -d ' ')
-    [[ "${started}" -ge "${EXPECTED_IR_COUNT:-0}" ]] && break
-    sleep 0.01
-  done
-  started=$(wc -l < "${IR_START_LOG}" | tr -d ' ')
-  [[ "${started}" -ge "${EXPECTED_IR_COUNT:-0}" ]] || exit 8
-  if [[ "${COLLIDE:-0}" == "1" ]]; then
-    filename="collision.md"
-  else
-    filename="${source_id}-story.md"
-  fi
-  printf 'artifact from %s\n' "${source_id}" > "${source_root}/raw/${filename}"
-  if [[ "${source_id}" == "ir-AMD" ]]; then
-    : > "${AMD_READY}"
-  fi
-  exit 0
+# The prompt must include the direct-ingest command surface. Assert it here so
+# any regression surfaces as a collector failure with a clear diagnostic.
+if ! printf '%s\n' "${message}" | grep -q "news ingest --input -"; then
+  echo "prompt missing direct-ingest command" >&2
+  exit 8
 fi
 
-if [[ "${source_id}" == "reuters-markets" ]]; then
-  for _ in $(seq 1 500); do
-    [[ -f "${AMD_READY}" ]] && break
-    sleep 0.01
-  done
-  [[ -f "${AMD_READY}" ]] || exit 9
-  printf 'file deliberately removed by Reuters\n' > "${source_root}/raw/reuters-old.md"
-  printf '%s\n' "${source_root}/raw" > "${DELETION_ROOT_LOG}"
-  find "${source_root}/raw" -maxdepth 1 -type f -delete
-fi
+# Perform the direct-ingest that a real collector would perform.
+article_json=$(SOURCE_ID="${source_id}" python3 - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
 
-if [[ "${COLLIDE:-0}" == "1" ]]; then
-  filename="collision.md"
-else
-  filename="${source_id}-story.md"
-fi
-printf 'artifact from %s\n' "${source_id}" > "${source_root}/raw/${filename}"
-''',
+source_id = os.environ["SOURCE_ID"]
+now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+print(json.dumps({
+    "title": f"Article from {source_id}",
+    "source_id": source_id,
+    "url": f"https://example.test/{source_id}/story",
+    "published_at": os.environ.get("PUBLISHED_AT", now),
+    "content": f"Body from {source_id}",
+    "collected_at": now,
+}))
+PY
+)
+printf '%s\n' "${article_json}" | "${MINERVA_RUNNER}" news ingest \
+  --input - --db "${invest_db}" >/dev/null
+""",
     )
 
 
@@ -133,23 +199,34 @@ def _run_wrapper(
     tmp_path: Path,
     *,
     sources: list[dict[str, object]],
-    ir_entries: list[dict[str, object]],
+    ir_entries: list[dict[str, object]] | None = None,
     extra_env: dict[str, str] | None = None,
+    run_date: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    ir_entries = ir_entries or []
     sources_path = tmp_path / "news-sources.json"
     sources_path.write_text(json.dumps(sources), encoding="utf-8")
     ir_path = tmp_path / "ir-registry.json"
     ir_path.write_text(json.dumps(ir_entries), encoding="utf-8")
 
     fake_home = tmp_path / "home"
-    fake_home.mkdir()
+    fake_home.mkdir(exist_ok=True)
     temp_state = tmp_path / "tmp"
-    temp_state.mkdir()
-    capture_dir = tmp_path / "captured"
+    temp_state.mkdir(exist_ok=True)
     coordinator = tmp_path / "coordinator"
-    coordinator.mkdir()
-    fake_openclaw = _fake_openclaw(tmp_path)
-    fake_runner = _fake_runner(tmp_path)
+    coordinator.mkdir(exist_ok=True)
+    bin_dir = tmp_path / "bin"
+    fake_openclaw = (
+        bin_dir / "openclaw" if bin_dir.is_dir() else _fake_openclaw(tmp_path)
+    )
+    fake_minerva_path = tmp_path / "fake-minerva"
+    fake_minerva = (
+        fake_minerva_path if fake_minerva_path.is_file() else _fake_minerva(tmp_path)
+    )
+    workspace = tmp_path / "workspace"
+    invest_db = tmp_path / "invest.db"
+    call_log = coordinator / "minerva-calls.log"
+    call_log.touch()
 
     env = os.environ.copy()
     env.pop("MINERVA_NEWS_COLLECTOR_AGENT", None)
@@ -158,40 +235,49 @@ def _run_wrapper(
             "HOME": str(fake_home),
             "PATH": f"{fake_openclaw.parent}:{env['PATH']}",
             "TMPDIR": str(temp_state),
-            "MINERVA_RUNNER": str(fake_runner),
+            "MINERVA_RUNNER": str(fake_minerva),
             "MINERVA_NEWS_SOURCES": str(sources_path),
             "MINERVA_IR_REGISTRY": str(ir_path),
             "MINERVA_SKIP_STATUS_CHECK": "1",
-            "MINERVA_ALLOW_THIN_BRIEF": "1",
-            "MINERVA_WORKSPACE_ROOT": str(tmp_path / "workspace"),
-            "INVEST_DB": str(tmp_path / "invest.db"),
-            "CAPTURE_DIR": str(capture_dir),
+            "MINERVA_WORKSPACE_ROOT": str(workspace),
+            "INVEST_DB": str(invest_db),
+            "MINERVA_CALL_LOG": str(call_log),
             "TIMEOUT_LOG": str(coordinator / "timeouts.log"),
             "AGENT_LOG": str(coordinator / "agents.log"),
-            "IR_START_LOG": str(coordinator / "ir-starts.log"),
-            "AMD_READY": str(coordinator / "amd-ready"),
-            "DELETION_ROOT_LOG": str(coordinator / "deletion-root.log"),
+            "COLLECTOR_START_LOG": str(coordinator / "collector-starts.log"),
         }
     )
     if extra_env:
         env.update(extra_env)
 
-    run_date = f"test-{tmp_path.name}"
-    report_dir = (
-        REPO_ROOT / "hard-disk" / "reports" / "03-daily-news" / run_date
+    resolved_run_date = run_date or date.today().isoformat()
+    return subprocess.run(
+        ["bash", str(PIPELINE_SCRIPT), resolved_run_date],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
     )
-    try:
-        return subprocess.run(
-            ["bash", str(PIPELINE_SCRIPT), run_date],
-            cwd=REPO_ROOT,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-    finally:
-        shutil.rmtree(report_dir, ignore_errors=True)
+
+
+def _phase_dir(tmp_path: Path, run_date: str) -> Path:
+    return (
+        tmp_path
+        / "workspace"
+        / "reports"
+        / "03-daily-news"
+        / run_date
+        / "data"
+        / "structured"
+        / "news-pipeline"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Timeout / validation
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -228,9 +314,14 @@ def test_collector_timeout_validation_precedes_temp_state(
     assert list(temp_state.iterdir()) == []
 
 
+# ---------------------------------------------------------------------------
+# Collector agent selection
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.parametrize(
     ("collector_agent", "expected"),
-    [(None, "main"), ("news-collector", "news-collector")],
+    [(None, "main"), ("steve", "steve")],
 )
 def test_collector_agent_defaults_and_can_be_overridden(
     tmp_path: Path, collector_agent: str | None, expected: str
@@ -240,6 +331,7 @@ def test_collector_agent_defaults_and_can_be_overridden(
         if collector_agent is not None
         else None
     )
+    run_date = date.today().isoformat()
     result = _run_wrapper(
         tmp_path,
         sources=[
@@ -250,20 +342,78 @@ def test_collector_agent_defaults_and_can_be_overridden(
                 "access": "web_fetch",
             }
         ],
-        ir_entries=[],
         extra_env=extra_env,
+        run_date=run_date,
     )
 
     assert result.returncode == 0, result.stderr
-    assert (tmp_path / "coordinator" / "agents.log").read_text(
+    agents = (tmp_path / "coordinator" / "agents.log").read_text(
         encoding="utf-8"
-    ).splitlines() == [expected]
+    ).splitlines()
+    assert agents == [expected]
 
 
-def test_collectors_are_isolated_launch_all_ir_and_aggregate_every_artifact(
+# ---------------------------------------------------------------------------
+# Aggregate download phases
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_download_phases_run_before_agent_collectors(
     tmp_path: Path,
 ) -> None:
-    tickers = ["AMD", "ONE", "TWO", "THREE", "FOUR", "FIVE"]
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "source-a",
+                "name": "Source A",
+                "url": "https://example.test/a",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (
+        tmp_path / "coordinator" / "minerva-calls.log"
+    ).read_text(encoding="utf-8").splitlines()
+
+    subcommands = [line for line in calls if line]
+    # Finnhub and market-data downloads share the invest.db and RUN_DATE.
+    finnhub = next(c for c in subcommands if c.startswith("news download-finnhub"))
+    assert f"--date {run_date}" in finnhub
+    assert "--db " in finnhub
+    assert "--symbol" not in finnhub
+
+    market = next(
+        c for c in subcommands if c.startswith("news download-market-data")
+    )
+    assert f"--date {run_date}" in market
+    assert "--db " in market
+    assert "--index" not in market
+
+    # Finnhub download precedes agent-collector ingests.
+    finnhub_idx = subcommands.index(finnhub)
+    ingest_indices = [
+        i for i, line in enumerate(subcommands) if line.startswith("news ingest")
+    ]
+    assert ingest_indices, "expected at least one direct-ingest call"
+    assert finnhub_idx < min(ingest_indices)
+
+    # No legacy batch-ingest / extract-files invocations.
+    for banned in ("extract-files", "--raw-dir", "--summaries-dir"):
+        assert not any(banned in line for line in subcommands), banned
+
+
+# ---------------------------------------------------------------------------
+# Collector orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_collectors_are_isolated_and_ingest_directly(tmp_path: Path) -> None:
+    run_date = date.today().isoformat()
     sources = [
         {
             "id": "reuters-markets",
@@ -272,85 +422,354 @@ def test_collectors_are_isolated_launch_all_ir_and_aggregate_every_artifact(
             "access": "browser",
         },
         {
-            "id": "broken-feed",
-            "name": "Broken Feed",
-            "url": "https://example.test/broken",
+            "id": "web-source",
+            "name": "Web Source",
+            "url": "https://example.test/web",
             "access": "web_fetch",
         },
     ]
     ir_entries = [
         {
-            "security_id": ticker,
-            "company_name": ticker,
-            "feeds": [{"url": f"https://example.test/{ticker}"}],
-        }
-        for ticker in tickers
+            "security_id": "AMD",
+            "company_name": "AMD",
+            "feeds": [{"url": "https://example.test/AMD"}],
+        },
+        {
+            "security_id": "NVDA",
+            "company_name": "NVDA",
+            "feeds": [{"url": "https://example.test/NVDA"}],
+        },
     ]
 
     result = _run_wrapper(
         tmp_path,
         sources=sources,
         ir_entries=ir_entries,
+        run_date=run_date,
+        extra_env={"MINERVA_MAX_COLLECTORS": "4"},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    # Every collector launched, each got its own timeout row.
+    starts = (
+        tmp_path / "coordinator" / "collector-starts.log"
+    ).read_text(encoding="utf-8").splitlines()
+    assert set(starts) == {"reuters-markets", "web-source", "ir-AMD", "ir-NVDA"}
+
+    timeouts = dict(
+        line.split("|", 1)
+        for line in (
+            tmp_path / "coordinator" / "timeouts.log"
+        ).read_text(encoding="utf-8").splitlines()
+    )
+    assert timeouts["reuters-markets"] == "900"
+    assert timeouts["web-source"] == "300"
+    assert timeouts["ir-AMD"] == "900"
+
+    # Every collector's status.json reports ok.
+    collector_dir = _phase_dir(tmp_path, run_date) / "collectors"
+    for source_id in ("reuters-markets", "web-source", "ir-AMD", "ir-NVDA"):
+        status = json.loads(
+            (collector_dir / source_id / "status.json").read_text(encoding="utf-8")
+        )
+        assert status["status"] == "ok"
+        assert status["exit_status"] == 0
+        assert status["source_id"] == source_id
+
+    # collectors.json aggregates success totals.
+    aggregate = json.loads(
+        (_phase_dir(tmp_path, run_date) / "collectors.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert aggregate["status"] == "ok"
+    assert aggregate["failed"] == 0
+    assert aggregate["succeeded"] == 4
+
+    # Every collector wrote one row directly to SQLite.
+    with sqlite3.connect(tmp_path / "invest.db") as conn:
+        rows = {
+            row[0]
+            for row in conn.execute(
+                "SELECT source FROM news ORDER BY source"
+            ).fetchall()
+        }
+    assert rows == {"reuters-markets", "web-source", "ir-AMD", "ir-NVDA"}
+
+    # No .md files or raw-dir aggregation happen for direct-ingest collectors.
+    for source_id in ("reuters-markets", "web-source", "ir-AMD", "ir-NVDA"):
+        source_files = list((collector_dir / source_id).iterdir())
+        assert all(
+            path.suffix != ".md" for path in source_files
+        ), f"unexpected markdown file under {source_id}: {source_files}"
+
+
+def test_failed_collector_reports_status_without_blocking_pipeline(
+    tmp_path: Path,
+) -> None:
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "healthy",
+                "name": "Healthy",
+                "url": "https://example.test/healthy",
+                "access": "web_fetch",
+            },
+            {
+                "id": "broken-feed",
+                "name": "Broken",
+                "url": "https://example.test/broken",
+                "access": "web_fetch",
+            },
+        ],
+        run_date=run_date,
+        extra_env={"BROKEN_SOURCE": "broken-feed"},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    collector_dir = _phase_dir(tmp_path, run_date) / "collectors"
+    broken_status = json.loads(
+        (collector_dir / "broken-feed" / "status.json").read_text(encoding="utf-8")
+    )
+    healthy_status = json.loads(
+        (collector_dir / "healthy" / "status.json").read_text(encoding="utf-8")
+    )
+    assert broken_status["status"] == "failed"
+    assert broken_status["exit_status"] == 7
+    assert healthy_status["status"] == "ok"
+
+    aggregate = json.loads(
+        (_phase_dir(tmp_path, run_date) / "collectors.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert aggregate["status"] == "degraded"
+    assert aggregate["failed"] == 1
+    assert aggregate["succeeded"] == 1
+    failed_ids = {row["source_id"] for row in aggregate["failures"]}
+    assert failed_ids == {"broken-feed"}
+
+    # The degraded run is still reported on stdout for the operator.
+    assert "collector error" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Current-date evidence gate
+# ---------------------------------------------------------------------------
+
+
+def test_thin_brief_refused_when_no_current_evidence(tmp_path: Path) -> None:
+    """With every collector broken and no override, script exits non-zero."""
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "broken-feed",
+                "name": "Broken",
+                "url": "https://example.test/broken",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+        extra_env={"BROKEN_SOURCE": "broken-feed"},
+    )
+
+    assert result.returncode != 0
+    assert "no eligible current-date news evidence" in result.stderr
+    assert "MINERVA_ALLOW_THIN_BRIEF=1" in result.stderr
+
+
+def test_thin_brief_allowed_when_override_set(tmp_path: Path) -> None:
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "broken-feed",
+                "name": "Broken",
+                "url": "https://example.test/broken",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
         extra_env={
-            "EXPECTED_IR_COUNT": str(len(tickers)),
             "BROKEN_SOURCE": "broken-feed",
-            "MINERVA_MAX_COLLECTORS": "8",
+            "MINERVA_ALLOW_THIN_BRIEF": "1",
         },
     )
 
     assert result.returncode == 0, result.stderr
-    captured = {path.name for path in (tmp_path / "captured").glob("*.md")}
-    assert captured == {
-        "broken-feed-error.md",
-        "reuters-markets-story.md",
-        *(f"ir-{ticker}-story.md" for ticker in tickers),
-    }
-    assert (tmp_path / "captured" / "ir-AMD-story.md").read_text(
-        encoding="utf-8"
-    ) == "artifact from ir-AMD\n"
-
-    deletion_root = (tmp_path / "coordinator" / "deletion-root.log").read_text(
-        encoding="utf-8"
-    ).strip()
-    assert deletion_root.endswith("/sources/reuters-markets/raw")
-    assert "/sources/ir-AMD/raw" != deletion_root
-
-    ir_starts = (
-        tmp_path / "coordinator" / "ir-starts.log"
-    ).read_text(encoding="utf-8").splitlines()
-    assert set(ir_starts) == {f"ir-{ticker}" for ticker in tickers}
-
-    timeout_rows = (
-        tmp_path / "coordinator" / "timeouts.log"
-    ).read_text(encoding="utf-8").splitlines()
-    timeout_by_source = dict(row.split("|", 1) for row in timeout_rows)
-    assert timeout_by_source["broken-feed"] == "300"
-    assert timeout_by_source["reuters-markets"] == "900"
-    assert all(timeout_by_source[f"ir-{ticker}"] == "900" for ticker in tickers)
 
 
-def test_aggregation_rejects_cross_source_filename_collision(tmp_path: Path) -> None:
-    sources = [
-        {
-            "id": source_id,
-            "name": source_id,
-            "url": f"https://example.test/{source_id}",
-            "access": "browser",
-        }
-        for source_id in ("source-a", "source-b")
-    ]
+def test_rerun_with_existing_rows_does_not_refuse_thin_brief(tmp_path: Path) -> None:
+    """Idempotence: if RUN_DATE rows already exist, zero new inserts is OK."""
+    run_date = date.today().isoformat()
+    # First run: healthy source populates invest.db.
+    first = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "healthy",
+                "name": "Healthy",
+                "url": "https://example.test/healthy",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+    )
+    assert first.returncode == 0, first.stderr
 
+    # Second run: same date, every collector broken, but existing row remains.
+    second = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "broken-feed",
+                "name": "Broken",
+                "url": "https://example.test/broken",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+        extra_env={"BROKEN_SOURCE": "broken-feed"},
+    )
+    assert second.returncode == 0, second.stderr
+
+    evidence = json.loads(
+        (_phase_dir(tmp_path, run_date) / "current-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert evidence["current_rows"] >= 1
+
+
+def test_current_evidence_uses_new_york_day_boundaries(tmp_path: Path) -> None:
+    """02:30 UTC on the following date still belongs to the prior ET run day."""
+    run_date = "2026-07-27"
     result = _run_wrapper(
         tmp_path,
-        sources=sources,
-        ir_entries=[],
-        extra_env={"COLLIDE": "1", "EXPECTED_IR_COUNT": "0"},
+        sources=[
+            {
+                "id": "overnight",
+                "name": "Overnight",
+                "url": "https://example.test/overnight",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+        extra_env={"PUBLISHED_AT": "2026-07-28T02:30:00Z"},
     )
 
-    assert result.returncode == 1
-    assert "news: raw filename collision: collision.md" in result.stderr
-    assert not (tmp_path / "captured").exists()
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(
+        (_phase_dir(tmp_path, run_date) / "current-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert evidence["current_rows"] == 1
 
-    match = re.search(r"^news_run_dir: (.+)$", result.stdout, flags=re.MULTILINE)
-    assert match is not None
-    shutil.rmtree(match.group(1), ignore_errors=True)
+
+def test_current_evidence_does_not_treat_utc_date_as_market_date(
+    tmp_path: Path,
+) -> None:
+    """02:30 UTC on RUN_DATE belongs to the previous New York market day."""
+    run_date = "2026-07-27"
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "prior-market-day",
+                "name": "Prior Market Day",
+                "url": "https://example.test/prior-market-day",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+        extra_env={
+            "MINERVA_ALLOW_THIN_BRIEF": "1",
+            "PUBLISHED_AT": "2026-07-27T02:30:00Z",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(
+        (_phase_dir(tmp_path, run_date) / "current-evidence.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert evidence["current_rows"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Outer-Sol handoff artifact
+# ---------------------------------------------------------------------------
+
+
+def test_outer_sol_handoff_is_emitted_with_summary_instructions(tmp_path: Path) -> None:
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "healthy",
+                "name": "Healthy",
+                "url": "https://example.test/healthy",
+                "access": "web_fetch",
+            }
+        ],
+        run_date=run_date,
+    )
+    assert result.returncode == 0, result.stderr
+
+    handoff = json.loads(
+        (_phase_dir(tmp_path, run_date) / "outer-sol-handoff.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert handoff["final_agent"] == "outer-cron-sol"
+    assert handoff["date"] == run_date
+    assert handoff["status"] == "ready"
+    assert Path(handoff["instructions"]).name == "morning_brief_outer_sol.md"
+    assert Path(handoff["instructions"]).is_file()
+    # Handoff enumerates the summarize -> persist -> report chain.
+    steps_blob = " ".join(handoff["steps"])
+    assert "minerva summarize" in steps_blob
+    assert "morning-brief-report.md" in handoff["report_output"]
+    assert "slack-brief.md" in handoff["slack_brief_output"]
+
+    # The script hands delivery back to the outer cron layer.
+    assert "Do not post Slack from this script." in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Prompt template safety
+# ---------------------------------------------------------------------------
+
+
+def test_prompts_render_direct_ingest_placeholders() -> None:
+    """Templates use the shared placeholder set consumed by the wrapper."""
+    for name in ("collect_news.md", "collect_news_webfetch.md"):
+        text = (REPO_ROOT / "scripts" / "prompts" / name).read_text(
+            encoding="utf-8"
+        )
+        for placeholder in (
+            "{{SOURCE_ROOT}}",
+            "{{CANDIDATE_FILE}}",
+            "{{LOOKUP_FILE}}",
+            "{{NEWS_EXIST_COMMAND}}",
+            "{{NEWS_INGEST_COMMAND}}",
+            "{{INVEST_DB}}",
+            "{{SOURCE_ID}}",
+            "{{URL}}",
+            "{{DATE}}",
+        ):
+            assert placeholder in text, f"{name} missing {placeholder}"
+        # Neither template invokes summarizers, Slack, or article files.
+        assert "summarizer" in text
+        assert "Slack" in text or "slack" in text
+        assert ".md" not in text.split("published")[0]


### PR DESCRIPTION
## Summary

Replace the production morning-brief article-file pipeline with the validated direct SQLite architecture:

- Finnhub news writes directly to `invest.db`
- Yahoo market/index movements write directly to `prices`
- browser and web-fetch collectors perform deterministic duplicate checks, then pipe one normalized JSON article at a time to `minerva news ingest --input -`
- remove raw article files, `extract-files`, and batch ingestion from the production path
- emit per-phase/per-collector JSON diagnostics and an outer-Sol handoff
- add versioned outer-Sol instructions for bounded Gemini summarization, transactional persistence, report synthesis, and single cron-layer Slack delivery
- preserve caller environment overrides when sourcing `.zshrc`
- make reruns idempotent and use America/New_York day boundaries

## Verification

- `uv run pytest -q` — 439 passed
- `bash -n scripts/run_morning_brief.sh`
- live scratch-workspace production-script run passed
- immediate rerun inserted 0 Finnhub rows, retained 286 current-date rows, and completed successfully
- direct BLS collector inserted into the scratch SQLite DB
- canonical `invest.db` and Slack were not touched

## Operational follow-up

After merge, update the clean runtime worktree to the new `main` and update the existing cron prompt to consume `outer-sol-handoff.json` and `morning_brief_outer_sol.md`.
