### PR TITLE
fix(portfolio): propagate sync failures to the shell

### DIFF
--- a/src/harness/commands/portfolio.py
+++ b/src/harness/commands/portfolio.py
@@ -709,3 +709,5 @@ def json_lines(payload: Mapping[str, object]) -> str:
 def _print(result: CommandResult) -> None:
     envelope = OutputEnvelope.from_result(result, workspace_root=get_settings().ensure_workspace_root())
     typer.echo(envelope.render())
+    if result.exit_code:
+        raise typer.Exit(result.exit_code)

--- a/tests/test_harness/test_cli.py
+++ b/tests/test_harness/test_cli.py
@@ -73,3 +73,15 @@ def test_direct_cli_missing_args_show_full_help_for_research() -> None:
     assert "What went wrong" not in result.stdout
     assert "Usage:" in result.stdout
     assert "Deep web research powered by Parallel.ai." in result.stdout
+
+
+def test_portfolio_sync_failure_exits_nonzero_after_rendering_error(tmp_path: Path, monkeypatch) -> None:
+    settings = HarnessSettings(workspace_root=tmp_path)
+    monkeypatch.setattr("harness.commands.portfolio.get_settings", lambda: settings)
+
+    result = runner.invoke(app, ["portfolio", "sync", "--holdings-source", "missing.csv"])
+
+    assert result.exit_code == 1
+    assert "failed to sync portfolio state:" in result.stdout
+    assert "provide holdings and transaction sources" in result.stdout
+    assert "[exit:1" in result.stdout


### PR DESCRIPTION
## Summary
- propagate non-zero `CommandResult` statuses from the `minerva portfolio` Typer CLI
- prevent `run_morning_brief.sh` from treating a failed portfolio sync as successful
- retain the rendered structured error and `[exit:1]` footer

## Root cause
`portfolio sync` returned an internal failure result, but `_print()` only rendered it; Typer then exited `0`. The morning workflow therefore continued with stale `universe.json`.

## Tests
- `uv run pytest tests/test_harness/test_cli.py -q` — 7 passed
- full suite run by implementation agent — 440 passed

## Follow-up after merge
The production cron also needs its stale Google Sheet ID/gids replaced with the known-working CSV export sources. That runtime change is intentionally separate from this code PR.