### PR TITLE
fix(brief): strengthen synthesis editorial contract

### DIFF
--- a/scripts/morning_brief_helper.py
+++ b/scripts/morning_brief_helper.py
@@ -191,6 +191,9 @@ def synthesis_handoff(
     report_output: Path,
     slack_brief_output: Path,
     evidence_stats: Path,
+    collector_stats: Path,
+    holdings_path: Path,
+    watchlist_path: Path,
     instructions: Path,
 ) -> dict[str, Any]:
     """Build the neutral synthesis handoff contract."""
@@ -198,11 +201,14 @@ def synthesis_handoff(
     return {
         "date": run_date.isoformat(),
         "db": str(db),
+        "collector_stats": str(collector_stats),
         "evidence_stats": str(evidence_stats),
+        "holdings_path": str(holdings_path),
         "instructions": str(instructions),
         "prepared_evidence": str(prepared_evidence),
         "report_output": str(report_output),
         "slack_brief_output": str(slack_brief_output),
+        "watchlist_path": str(watchlist_path),
         "steps": [
             "Query news in the fixed [previous-run 04:00, run-date 04:00) "
             "America/New_York window whose summary is NULL or blank.",
@@ -349,8 +355,20 @@ def _main(command: str, args: list[str]) -> None:
         _require(command, args, 1)
         check_manifest(Path(args[0]))
     elif command == "write-handoff":
-        _require(command, args, 8)
-        output, run_date, db, prepared, report, slack, evidence, instructions = args
+        _require(command, args, 11)
+        (
+            output,
+            run_date,
+            db,
+            prepared,
+            report,
+            slack,
+            evidence,
+            collectors,
+            holdings,
+            watchlist,
+            instructions,
+        ) = args
         _write_json(
             Path(output),
             synthesis_handoff(
@@ -360,6 +378,9 @@ def _main(command: str, args: list[str]) -> None:
                 report_output=Path(report),
                 slack_brief_output=Path(slack),
                 evidence_stats=Path(evidence),
+                collector_stats=Path(collectors),
+                holdings_path=Path(holdings),
+                watchlist_path=Path(watchlist),
                 instructions=Path(instructions),
             ),
         )

--- a/scripts/prompts/morning_brief_synthesis.md
+++ b/scripts/prompts/morning_brief_synthesis.md
@@ -2,11 +2,15 @@
 
 The collection script has already populated prepared evidence, `news`, and `prices`. Do not repeat collection, browse the web, delegate synthesis, or post to Slack with a messaging tool.
 
-Read the `synthesis-handoff.json` path printed by `scripts/run_morning_brief.sh`. Treat its `date`, `window_start`, `window_end`, `db`, `prepared_evidence`, `report_output`, and `slack_brief_output` values as authoritative.
+## 1. Validate the input
 
-## 1. Summarize pending news
+Read the `synthesis-handoff.json` path printed by `scripts/run_morning_brief.sh`. Treat this prompt as the versioned synthesis contract. Before accessing the database, require a JSON object with `status` set to `ready`; require `date`, `window_start`, `window_end`, `db`, `prepared_evidence`, `evidence_stats`, `instructions`, `report_output`, and `slack_brief_output` with the expected types; and require `instructions` to identify this prompt. Stop with a concise schema/version error if validation fails. Do not infer missing values.
 
-- Select eligible `news` rows using `published_at` as UTC epoch seconds in the fixed half-open interval from `window_start` inclusive to `window_end` exclusive. The handoff timestamps represent the previous run date at 04:00 through the run date at 04:00 in `America/New_York`. Do not use calendar-date prefix matching or include rows outside these exact bounds.
+Use `window_start` and `window_end` exactly as provided with today's collected data.
+
+## 2. Complete pending summaries safely
+
+- Select eligible `news` rows using `published_at` as UTC epoch seconds in the fixed half-open interval from `window_start` inclusive to `window_end` exclusive. The timestamps represent the previous run date at 04:00 through the run date at 04:00 in `America/New_York`. Do not use calendar-date prefix matching or change these bounds.
 - Process only rows where `content` is non-empty and `summary` is NULL or blank.
 - For each row, pipe `content` on stdin to:
 
@@ -14,22 +18,43 @@ Read the `synthesis-handoff.json` path printed by `scripts/run_morning_brief.sh`
 uv run minerva summarize --model gemini-3.6-flash --thinking high
 ```
 
-- Use bounded parallelism of at most four subprocesses. Keep article content and generated summaries in memory; do not write article or summary files.
+- Run no more than four summarization subprocesses at once. Keep article content and generated summaries in memory; do not write article or summary files.
 - If any summarization fails, do not write a partial batch. Report the failure count and artifact paths concisely.
-- After all calls succeed, persist summaries with SQLite parameter binding in one transaction. Update by `article_key` only where the summary is still NULL or blank.
+- After all calls succeed, persist summaries with parameter binding in one SQLite transaction. Update by `article_key` only where the summary is still NULL or blank.
 - Re-query the same fixed half-open window and require zero eligible blank summaries before synthesis. Reruns must be idempotent.
 
-## 2. Synthesize the brief
+## 3. Read and select
 
-Read the prepared-evidence JSON, the summarized news rows in the fixed handoff window, and relevant `prices` rows. Prefer primary sources and material facts. Deduplicate repeated URLs and syndicated versions. Distinguish facts from interpretation.
+Read the prepared-evidence JSON, relevant `prices` rows, and the complete summary of every article from the collection period before deciding what to include. Do not select articles from headlines or URLs alone. Before writing, confirm that the number of summaries read matches the total article count in `evidence_stats`. If it does not, stop and report both counts and the diagnostic artifact path.
 
-Write:
+For Portfolio / Watchlist Events, consider only companies listed in `holdings_path` or `watchlist_path`. Do not use the broader company universe. Combine articles covering the same event.
 
-1. `report_output`: a durable Markdown report with source collection counts, market snapshot, portfolio/watchlist events, and the most important market, macro, policy, technology, and business developments.
-2. `slack_brief_output`: a concise Slack-mrkdwn brief. Use `*single asterisks*` for bold and `<url|label>` links. Do not use Markdown headings or tables.
+Include only developments that could meaningfully affect an investor's view of a company, its valuation, competitive position, capital allocation, or risk. Prefer company filings and official sources, followed by WSJ, Economist, and Reuters. Clearly identify commentary, rumors, and third-party interpretations.
 
-Cite factual claims with direct source URLs from SQLite. Do not cite `finnhub.io/api/news` proxy URLs when an original source URL is available.
+## 4. Write the outputs
 
-## 3. Return result
+Write a durable Markdown report to `report_output` with collection counts, a market snapshot, portfolio/watchlist events, significant broader developments, and direct citations. Keep this report separate from the Slack output.
 
-Do not call Slack. Return the exact contents of `slack_brief_output` as the response so the cron delivery layer posts it once. If any required phase fails, return one concise failure message naming the phase and diagnostic artifact path instead of a partial brief.
+Write `slack_brief_output` in Slack mrkdwn with exactly this structure: three sections in the order shown, with no other text or sections.
+
+```text
+_Crawler:_ {total articles} — {source} {count} · {source} {count} · ...; {successful}/{total} collectors succeeded, {failed} failed.
+
+_Portfolio / Watchlist Events_
+• _{Company/ticker — takeaway}:_ Explain what happened, the important facts, and why it matters. Cite the original sources.
+
+_Worth Knowing Today_
+• _{Investor takeaway}:_ Explain the development, why it matters to investors, and any important uncertainty. Cite the original sources.
+```
+
+If nothing material occurred for the portfolio or watchlist, use the approved fallback:
+
+```text
+• No material portfolio or watchlist developments during the collection period.
+```
+
+Get final article and per-source counts from the verified window query and collector successes and failures from `collectors.json` beside `evidence_stats`. Select for significance; combine related reporting into one bullet. Cite factual claims with direct source URLs from SQLite, linking to original articles rather than `finnhub.io/api/news` proxy pages when possible. Do not use Markdown headings or tables.
+
+## 5. Return the result
+
+Do not call Slack or any messaging tool. Return only the exact contents of `slack_brief_output`, with no preamble, commentary, or code fence, so the cron delivery layer posts it once. If a required phase fails, return one concise failure message naming the phase and diagnostic artifact path instead of a partial brief.

--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -445,7 +445,10 @@ python3 "${HELPER}" write-handoff \
   "${HANDOFF_PATH}" "${RUN_DATE}" "${INVEST_DB}" "${PREPARED_PATH}" \
   "${REPORT_DIR}/notes/morning-brief-report.md" \
   "${REPORT_DIR}/notes/slack-brief.md" \
-  "${PHASE_DIR}/window-evidence.json" "${SYNTHESIS_PROMPT}"
+  "${PHASE_DIR}/window-evidence.json" "${PHASE_DIR}/collectors.json" \
+  "${MINERVA_WORKSPACE_ROOT}/data/01-portfolio/current/holdings.json" \
+  "${MINERVA_WORKSPACE_ROOT}/data/01-portfolio/current/watchlist.json" \
+  "${SYNTHESIS_PROMPT}"
 
 echo ""
 echo "prepared_evidence: ${PREPARED_PATH}"

--- a/tests/test_harness/test_news.py
+++ b/tests/test_harness/test_news.py
@@ -797,12 +797,23 @@ def test_morning_brief_shell_and_prompts_use_direct_ingest_contract() -> None:
         assert prompt.count("Leave `summary` absent") == 1
         assert prompt.lower().count("skip the article") <= 1
 
-    assert "at most four subprocesses" in synthesis_prompt
-    assert "one transaction" in synthesis_prompt
-    assert "Do not call Slack" in synthesis_prompt
-    assert "Return the exact contents" in synthesis_prompt
-    assert "previous run date at 04:00" in synthesis_prompt
-    assert "run date at 04:00" in synthesis_prompt
+    assert "no more than four summarization subprocesses" in synthesis_prompt
+    assert "one SQLite transaction" in synthesis_prompt
+    assert "Do not call Slack or any messaging tool" in synthesis_prompt
+    assert "Return only the exact contents" in synthesis_prompt
+    assert "complete summary of every article" in synthesis_prompt
+    assert "before deciding what to include" in synthesis_prompt
+    assert "number of summaries read matches the total article count" in synthesis_prompt
+    assert "listed in `holdings_path` or `watchlist_path`" in synthesis_prompt
+    assert "Do not use the broader company universe" in synthesis_prompt
+    assert "exactly this structure" in synthesis_prompt
+    for section in (
+        "_Crawler:_",
+        "_Portfolio / Watchlist Events_",
+        "_Worth Knowing Today_",
+    ):
+        assert section in synthesis_prompt
+    assert "original articles rather than `finnhub.io/api/news` proxy pages" in synthesis_prompt
     assert "agent" not in synthesis_prompt.lower()
 
 

--- a/tests/test_morning_brief_helper.py
+++ b/tests/test_morning_brief_helper.py
@@ -147,12 +147,18 @@ def test_synthesis_handoff_has_neutral_contract_fields(tmp_path: Path) -> None:
         report_output=tmp_path / "report.md",
         slack_brief_output=tmp_path / "slack.md",
         evidence_stats=tmp_path / "window.json",
+        collector_stats=tmp_path / "collectors.json",
+        holdings_path=tmp_path / "holdings.json",
+        watchlist_path=tmp_path / "watchlist.json",
         instructions=tmp_path / "instructions.md",
     )
 
     assert payload["status"] == "ready"
     assert payload["window_start"] == "2026-07-26T04:00:00-04:00"
     assert payload["window_end"] == "2026-07-27T04:00:00-04:00"
+    assert payload["collector_stats"].endswith("collectors.json")
+    assert payload["holdings_path"].endswith("holdings.json")
+    assert payload["watchlist_path"].endswith("watchlist.json")
     assert "agent" not in " ".join(payload).lower()
     assert "minerva summarize" in " ".join(payload["steps"])
 

--- a/tests/test_news_collection.py
+++ b/tests/test_news_collection.py
@@ -899,6 +899,9 @@ def test_synthesis_handoff_is_emitted_with_fixed_window(tmp_path: Path) -> None:
     ].endswith("T04:00:00-05:00")
     assert Path(handoff["instructions"]).name == "morning_brief_synthesis.md"
     assert Path(handoff["instructions"]).is_file()
+    assert Path(handoff["collector_stats"]).name == "collectors.json"
+    assert Path(handoff["holdings_path"]).name == "holdings.json"
+    assert Path(handoff["watchlist_path"]).name == "watchlist.json"
     # Handoff enumerates the summarize -> persist -> report chain.
     steps_blob = " ".join(handoff["steps"])
     assert "minerva summarize" in steps_blob


### PR DESCRIPTION
## Summary
- require the synthesis step to read every complete article summary before selection
- scope portfolio/watchlist coverage to explicit holdings and watchlist inputs
- enforce the approved three-section Slack structure and original-source links
- expose collector, holdings, and watchlist paths in the synthesis contract

## Tests
- `bash -n scripts/run_morning_brief.sh`
- `uv run pytest -q` — 454 passed
