### PR TITLE
fix(brief): propagate command exit codes

### DIFF
--- a/src/harness/commands/brief.py
+++ b/src/harness/commands/brief.py
@@ -391,3 +391,5 @@ def _split_csv(raw: str) -> list[str]:
 def _print(result: CommandResult) -> None:
     envelope = OutputEnvelope.from_result(result, workspace_root=get_settings().ensure_workspace_root())
     typer.echo(envelope.render())
+    if result.exit_code:
+        raise typer.Exit(result.exit_code)


### PR DESCRIPTION
## Summary
- preserve rendered brief command output
- exit the CLI process with the underlying non-zero `CommandResult` status
- allow the morning brief wrapper's existing `set -e` behavior to stop at the actual failing collector

## Verification
- `uv run pytest -q tests/test_harness/test_cli.py` (8 passed)
- direct failing `brief earnings` invocation exits 1
- `git diff --check`

No tests added, per request.
