### PR TITLE
fix(brief): recover from unlisted command failures

### DIFF
--- a/scripts/prompts/morning_brief_synthesis.md
+++ b/scripts/prompts/morning_brief_synthesis.md
@@ -61,4 +61,4 @@ Get final article and per-source counts from the verified window query and colle
 
 ## 5. Return the result
 
-Do not call Slack or any messaging tool. Return the exact contents of `slack_brief_output`, with no preamble, commentary, or code fence, so the cron delivery layer posts it once. If a required phase fails, return one concise failure message naming the phase and diagnostic artifact path instead of a partial brief.
+Do not call Slack or any messaging tool. Return the exact contents of `slack_brief_output`, with no preamble, commentary, or code fence, so the cron delivery layer posts it once. If a required step explicitly listed in Sections 1-4 fails, return one concise failure message naming the phase and diagnostic artifact path instead of a partial brief. Only those failures are fatal. Do not invent or invoke validation commands not listed in this contract; if an unlisted command fails, correct or skip it rather than aborting when `slack_brief_output` can still be produced and read.


### PR DESCRIPTION
## Summary
- make only explicitly listed synthesis steps fatal
- forbid invented validation commands
- require recovery from unlisted command failures when the brief remains producible

## Verification
- `git diff --check`

No tests added; prompt-only one-line change.
