### PR TITLE
feat(news): scan all primary editorial sections

### DIFF
--- a/scripts/prompts/collect_news.md
+++ b/scripts/prompts/collect_news.md
@@ -14,7 +14,7 @@ Prioritize articles relevant to these current holdings/watchlist companies:
 
 ## Eligibility and safety
 
-- Scan the full landing page and collect every qualifying article. Rank direct portfolio relevance first, then material macro/market news, industry developments, market-relevant geopolitics/politics, and genuinely important business, technology, science, or world news. Exclude lifestyle, sports, entertainment, and celebrity stories.
+- Collect every qualifying article found during the browser procedure. Rank direct portfolio relevance first, then material macro/market news, industry developments, market-relevant geopolitics/politics, and genuinely important business, technology, science, or world news. Exclude lifestyle, sports, entertainment, and celebrity stories.
 - The publication window is the previous calendar date at 04:00 America/New_York inclusive through `{{DATE}}` at 04:00 America/New_York exclusive.
 - A publication value is mandatory. Prefer machine-readable source metadata such as `article:published_time` or `<time datetime>` over rendered text, and preserve its exact timezone/offset. A date alone is acceptable without an invented time or timezone. When the landing page has no date, inspect article metadata before body extraction; discard the article if no publication value exists.
 - Use the deterministic database lookup before expensive body extraction. Never estimate title similarity or calculate article hashes yourself.
@@ -57,14 +57,13 @@ A different safe in-memory JSON-producing construct is allowed, but it must end 
 
 1. Run exactly once: `browser open "{{URL}}" --new --window`.
 2. Record the returned tab alias. It is your only browser window and tab. Never run `browser open` again; close any accidentally created extra tab or window immediately.
-3. In that tab, scan the complete landing page and record candidate headline, destination URL, and visible publication value without opening article bodies.
-4. Remove visibly stale candidates, run the batch duplicate lookup, and retain only `unseen` indexes.
+3. In that tab, scan the homepage and each distinct top-level editorial section in the compact or horizontal primary navigation exactly once, including `Latest Headlines` or `World in Brief` when present. If the navigation is collapsed, open the primary menu only far enough to recover that same section list. Record candidate headline, destination URL, visible publication value, and section without opening article bodies; ignore secondary mega-menu links, subsections, topic pages, pagination, archives, search, and utility/media pages.
+4. Deduplicate candidates by destination URL, remove visibly stale candidates, run the batch duplicate lookup, and retain only `unseen` indexes.
 5. For each remaining candidate, use the same tab to:
    a. Navigate to the article and resolve missing publication metadata as specified above.
    b. Extract and normalize the full substantive body with `browser extract` or `browser ask`.
    c. Build and ingest the in-memory object.
-   d. Navigate back to the landing page.
-   e. On 404, CAPTCHA, video-only content, paywall, or extraction failure, record a skipped item and continue.
+   d. On 404, CAPTCHA, video-only content, paywall, or extraction failure, record a skipped item and continue.
 6. Close the tab with `browser close {tab_alias}`.
 7. Reply briefly with counts for inserted/updated/duplicate/skipped/failed. Do not include article bodies.
 


### PR DESCRIPTION
## Summary

- expand browser news collection from the homepage to every top-level editorial section in the source's primary section navigation
- keep the crawl bounded to one visit per landing page in one tab
- exclude secondary mega-menu links, subsections, topic/tag pages, pagination, archives, and utility/media destinations
- deduplicate candidates gathered across sections before article extraction

## Site-navigation check

Verified the current logged-in navigation on WSJ and The Economist before defining the boundary. The prompt includes current section examples but instructs the collector to follow the live primary navigation.

## Tests

- `uv run pytest tests/test_news_collection.py -q` — 22 passed
- `git diff --check`
