### PR TITLE
fix(news): retry failed editorial collectors

### DIFF
--- a/scripts/morning_brief_helper.py
+++ b/scripts/morning_brief_helper.py
@@ -16,6 +16,7 @@ from zoneinfo import ZoneInfo
 MARKET_TIMEZONE = ZoneInfo("America/New_York")
 IR_BATCH_SIZE = 10
 _PLACEHOLDER = re.compile(r"{{([A-Z_]+)}}")
+_SUCCESS_STOP_REASONS = {"completed", "end_turn", "stop"}
 
 
 def parse_run_date(value: str) -> date:
@@ -43,6 +44,37 @@ def render_prompt(template: str, replacements: dict[str, str]) -> str:
     return _PLACEHOLDER.sub(
         lambda match: replacements.get(match.group(1), match.group(0)), template
     )
+
+
+def validate_openclaw_result(text: str) -> str:
+    """Return a safe outcome code without exposing agent payload text."""
+    try:
+        envelope = json.loads(text)
+    except json.JSONDecodeError:
+        return "invalid_json"
+    if not isinstance(envelope, dict) or envelope.get("status") != "ok":
+        return "status_error"
+    result = envelope.get("result")
+    if not isinstance(result, dict):
+        return "invalid_result"
+    meta = result.get("meta")
+    payloads = result.get("payloads")
+    if not isinstance(meta, dict) or not isinstance(payloads, list):
+        return "invalid_result"
+    if meta.get("aborted") is True:
+        return "aborted"
+    if meta.get("error") is not None:
+        return "agent_error"
+    if meta.get("timeoutPhase") is not None:
+        return "timeout"
+    if any(
+        isinstance(payload, dict) and payload.get("isError") is True
+        for payload in payloads
+    ):
+        return "error_payload"
+    if meta.get("stopReason") not in _SUCCESS_STOP_REASONS:
+        return "incomplete"
+    return "ok"
 
 
 def build_ir_batches(
@@ -324,15 +356,32 @@ def _main(command: str, args: list[str]) -> None:
         )
     elif command == "render-prompt":
         _render_prompt_command(args)
+    elif command == "validate-openclaw":
+        _require(command, args, 0)
+        outcome = validate_openclaw_result(sys.stdin.read())
+        if outcome != "ok":
+            raise ValueError(outcome)
     elif command == "collector-status":
-        _require(command, args, 9)
-        output, source_id, source_name, url, session_id, status, exit_status, log, size = args
+        _require(command, args, 10)
+        (
+            output,
+            source_id,
+            source_name,
+            url,
+            session_id,
+            status,
+            exit_status,
+            log,
+            attempts,
+            error,
+        ) = args
         _write_json(
             Path(output),
             {
+                "attempts": int(attempts),
+                "error": error or None,
                 "exit_status": int(exit_status),
                 "log": log,
-                "openclaw_output_bytes": int(size),
                 "session_id": session_id,
                 "source_id": source_id,
                 "source_name": source_name,

--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -13,11 +13,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 HELPER="${ROOT_DIR}/scripts/morning_brief_helper.py"
 RUN_DATE="${1:-$(date +%F)}"
+MINERVA_EDITORIAL_TIMEOUT="${MINERVA_EDITORIAL_TIMEOUT:-1800}"
 MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-900}"
 MINERVA_WEBFETCH_TIMEOUT="${MINERVA_WEBFETCH_TIMEOUT:-300}"
 MINERVA_MAX_COLLECTORS="${MINERVA_MAX_COLLECTORS:-8}"
 MINERVA_NEWS_COLLECTOR_AGENT="${MINERVA_NEWS_COLLECTOR_AGENT:-steve}"
 for integer_name in \
+  MINERVA_EDITORIAL_TIMEOUT \
   MINERVA_BROWSER_TIMEOUT \
   MINERVA_WEBFETCH_TIMEOUT \
   MINERVA_MAX_COLLECTORS; do
@@ -233,21 +235,20 @@ else
   write_collector_status() {
     local destination="$1" source_id="$2" source_name="$3" url="$4"
     local session_id="$5" status="$6" exit_status="$7" log_file="$8"
-    local output_bytes="$9"
+    local attempts="$9" error="${10}"
     python3 "${HELPER}" collector-status \
       "${destination}" "${source_id}" "${source_name}" "${url}" \
       "${session_id}" "${status}" "${exit_status}" "${log_file}" \
-      "${output_bytes}"
+      "${attempts}" "${error}"
   }
 
   collect_source() {
     local prompt_template="$1" timeout="$2" source_id="$3" source_name="$4"
-    local url="$5" collection_scope="$6" source_root="$7"
+    local url="$5" collection_scope="$6" source_root="$7" max_attempts="$8"
     local artifact_root="${COLLECTOR_ARTIFACT_DIR}/${source_id}"
-    local session_id="news-${source_id}-${RUN_DATE}-$$-${RANDOM}"
     local lifecycle_log="${artifact_root}/collector.log"
     local status_file="${artifact_root}/status.json"
-    local prompt exit_status output_bytes result_status
+    local prompt session_id failure_reason="" attempts=0 exit_status=1 result_status=failed
     mkdir -p "${artifact_root}"
     prompt=$(render_collection_prompt "${prompt_template}" "${source_name}" \
       "${source_id}" "${url}" "${collection_scope}" "${source_root}")
@@ -256,36 +257,41 @@ else
       echo "source_id: ${source_id}"
       echo "source_name: ${source_name}"
       echo "url: ${url}"
-      echo "session_id: ${session_id}"
       echo "started_at: $(date -u +%FT%TZ)"
     } >"${lifecycle_log}"
 
-    # Count and discard agent output as a stream. Even if an agent violates the
-    # reply contract, an article body is never materialized in a temp file.
-    if output_bytes=$(openclaw agent \
-      --agent "${MINERVA_NEWS_COLLECTOR_AGENT}" \
-      --timeout "${timeout}" \
-      --model fireworks/accounts/fireworks/routers/glm-5p2-fast \
-      --thinking high \
-      --session-id "${session_id}" \
-      --message "${prompt}" 2>&1 | wc -c); then
-      exit_status=0
-      result_status=ok
-    else
-      exit_status=$?
-      result_status=failed
-    fi
-    output_bytes=$(echo "${output_bytes}" | tr -d ' ')
+    while [[ "${attempts}" -lt "${max_attempts}" ]]; do
+      attempts=$((attempts + 1))
+      session_id="news-${source_id}-${RUN_DATE}-$$-${attempts}-${RANDOM}"
+      echo "attempt_${attempts}_session_id: ${session_id}" >>"${lifecycle_log}"
+      if failure_reason=$(openclaw agent --json \
+        --agent "${MINERVA_NEWS_COLLECTOR_AGENT}" \
+        --timeout "${timeout}" \
+        --model fireworks/accounts/fireworks/routers/glm-5p2-fast \
+        --thinking high \
+        --session-id "${session_id}" \
+        --message "${prompt}" 2>/dev/null | \
+        python3 "${HELPER}" validate-openclaw 2>&1); then
+        exit_status=0
+        result_status=ok
+        failure_reason=""
+        break
+      else
+        exit_status=$?
+      fi
+      failure_reason="${failure_reason:-process_error}"
+    done
     {
       echo "finished_at: $(date -u +%FT%TZ)"
       echo "status: ${result_status}"
       echo "exit_status: ${exit_status}"
-      echo "openclaw_output_bytes: ${output_bytes}"
+      echo "attempts: ${attempts}"
+      [[ -z "${failure_reason}" ]] || echo "error: ${failure_reason}"
       echo "note: OpenClaw output discarded to prevent article-body persistence"
     } >>"${lifecycle_log}"
     write_collector_status "${status_file}" "${source_id}" "${source_name}" \
       "${url}" "${session_id}" "${result_status}" "${exit_status}" \
-      "${lifecycle_log}" "${output_bytes}"
+      "${lifecycle_log}" "${attempts}" "${failure_reason}"
 
     if [[ "${exit_status}" -eq 0 ]]; then
       echo "news: ${source_id} ok (status: ${status_file})"
@@ -308,7 +314,7 @@ else
 
   launch_source() {
     local prompt_template="$1" timeout="$2" source_id="$3" source_name="$4"
-    local url="$5" collection_scope="$6"
+    local url="$5" collection_scope="$6" max_attempts="${7:-1}"
     if ! [[ "${source_id}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
       echo "error[collectors]: unsafe source id: ${source_id}" >&2
       return 1
@@ -321,7 +327,8 @@ else
     mkdir -p "${source_root}"
     printf '%s\n' "${source_id}" >>"${NEWS_RUN_DIR}/launched.txt"
     collect_source "${prompt_template}" "${timeout}" "${source_id}" \
-      "${source_name}" "${url}" "${collection_scope}" "${source_root}" &
+      "${source_name}" "${url}" "${collection_scope}" "${source_root}" \
+      "${max_attempts}" &
     PIDS+=("$!")
     if [[ "${#PIDS[@]}" -ge "${MINERVA_MAX_COLLECTORS}" ]]; then
       wait_for_collectors
@@ -342,12 +349,12 @@ else
       collection_scope=$(echo "${entry}" | jq -r '.collect // "Items relevant to a long-only investor."')
       if [[ "${access}" == "browser" ]]; then
         echo "  spawning browser agent: ${source_id}"
-        launch_source "${BROWSER_PROMPT_TEMPLATE}" "${MINERVA_BROWSER_TIMEOUT}" \
-          "${source_id}" "${source_name}" "${url}" "${collection_scope}"
+        launch_source "${BROWSER_PROMPT_TEMPLATE}" "${MINERVA_EDITORIAL_TIMEOUT}" \
+          "${source_id}" "${source_name}" "${url}" "${collection_scope}" 2
       else
         echo "  spawning web_fetch agent: ${source_id}"
-        launch_source "${WEBFETCH_PROMPT_TEMPLATE}" "${MINERVA_WEBFETCH_TIMEOUT}" \
-          "${source_id}" "${source_name}" "${url}" "${collection_scope}"
+        launch_source "${WEBFETCH_PROMPT_TEMPLATE}" "${MINERVA_EDITORIAL_TIMEOUT}" \
+          "${source_id}" "${source_name}" "${url}" "${collection_scope}" 2
       fi
     done
   fi

--- a/tests/test_morning_brief_helper.py
+++ b/tests/test_morning_brief_helper.py
@@ -47,6 +47,40 @@ def test_render_prompt_does_not_expand_placeholders_inside_metadata() -> None:
     )
 
 
+@pytest.mark.parametrize("stop_reason", ["completed", "end_turn", "stop"])
+def test_validate_openclaw_result_accepts_completed_turns(stop_reason: str) -> None:
+    payload = {
+        "status": "ok",
+        "result": {
+            "payloads": [{"text": "must not be returned"}],
+            "meta": {"aborted": False, "stopReason": stop_reason},
+        },
+    }
+
+    assert helper.validate_openclaw_result(json.dumps(payload)) == "ok"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", "invalid_json"),
+        ("{}{}", "invalid_json"),
+        ("[]", "status_error"),
+        ('{"status":"error"}', "status_error"),
+        ('{"status":"ok","result":{}}', "invalid_result"),
+        ('{"status":"ok","result":{"payloads":[],"meta":{"aborted":true,"stopReason":"end_turn"}}}', "aborted"),
+        ('{"status":"ok","result":{"payloads":[],"meta":{"error":"boom","stopReason":"end_turn"}}}', "agent_error"),
+        ('{"status":"ok","result":{"payloads":[],"meta":{"timeoutPhase":"model","stopReason":"end_turn"}}}', "timeout"),
+        ('{"status":"ok","result":{"payloads":[{"isError":true}],"meta":{"stopReason":"end_turn"}}}', "error_payload"),
+        ('{"status":"ok","result":{"payloads":[],"meta":{"stopReason":"length"}}}', "incomplete"),
+    ],
+)
+def test_validate_openclaw_result_rejects_incomplete_or_invalid_results(
+    text: str, expected: str
+) -> None:
+    assert helper.validate_openclaw_result(text) == expected
+
+
 def test_build_ir_batches_uses_universe_for_inclusion_and_registry_for_feeds() -> None:
     security_ids = [f"C{index:02d}" for index in range(11)]
     universe = [

--- a/tests/test_news_collection.py
+++ b/tests/test_news_collection.py
@@ -139,14 +139,21 @@ set -euo pipefail
 message=""
 timeout=""
 agent=""
+session_id=""
+json_mode=0
+failure_json='{"status":"ok","result":{"payloads":[{"isError":true,"text":"SENSITIVE_PAYLOAD_SENTINEL"}],"meta":{"aborted":true,"stopReason":"aborted"}}}'
+success_json='{"status":"ok","result":{"payloads":[{"text":"SENSITIVE_PAYLOAD_SENTINEL"}],"meta":{"aborted":false,"stopReason":"end_turn"}}}'
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
+    --json) json_mode=1; shift ;;
     --message) message="$2"; shift 2 ;;
     --timeout) timeout="$2"; shift 2 ;;
     --agent) agent="$2"; shift 2 ;;
+    --session-id) session_id="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
+[[ "${json_mode}" -eq 1 ]] || exit 9
 
 # Extract the isolated metadata root and the news-ingest command rendered in
 # the prompt. Both are stable, verbatim substrings emitted by the script.
@@ -159,6 +166,10 @@ invest_db=$(printf '%s\n' "${message}" | \
 printf '%s|%s\n' "${source_id}" "${timeout}" >> "${TIMEOUT_LOG}"
 printf '%s\n' "${agent}" >> "${AGENT_LOG}"
 printf '%s\n' "${source_id}" >> "${COLLECTOR_START_LOG}"
+printf '%s|%s\n' "${source_id}" "${session_id}" >> "${SESSION_LOG}"
+attempt_file="${ATTEMPT_DIR}/${source_id}"
+attempt=$(( $(cat "${attempt_file}" 2>/dev/null || echo 0) + 1 ))
+printf '%s\n' "${attempt}" > "${attempt_file}"
 batch_json=$(printf '%s\n' "${message}" | \
   sed -n 's/^Batch companies JSON: `\(.*\)`$/\1/p' | head -n 1)
 if [[ -n "${batch_json}" ]]; then
@@ -167,6 +178,17 @@ fi
 
 if [[ "${source_id}" == "${BROKEN_SOURCE:-__unset__}" ]]; then
   exit 7
+fi
+
+logical_failure=0
+if [[ "${source_id}" == "${LOGICAL_FAILURE_SOURCE:-__unset__}" ]] || \
+   [[ "${source_id}" == "${RECOVER_SOURCE:-__unset__}" && "${attempt}" -eq 1 ]]; then
+  logical_failure=1
+fi
+if [[ "${logical_failure}" -eq 1 && \
+      "${source_id}" != "${INGEST_BEFORE_FAILURE_SOURCE:-__unset__}" ]]; then
+  printf '%s\n' "${failure_json}"
+  exit 0
 fi
 
 # The prompt must include the direct-ingest command surface. Assert it here so
@@ -196,6 +218,11 @@ PY
 )
 printf '%s\n' "${article_json}" | "${MINERVA_RUNNER}" news ingest \
   --input - --db "${invest_db}" >/dev/null
+if [[ "${logical_failure}" -eq 1 ]]; then
+  printf '%s\n' "${failure_json}"
+else
+  printf '%s\n' "${success_json}"
+fi
 """,
     )
 
@@ -232,6 +259,8 @@ def _run_wrapper(
     temp_state.mkdir(exist_ok=True)
     coordinator = tmp_path / "coordinator"
     coordinator.mkdir(exist_ok=True)
+    attempt_dir = coordinator / "attempts"
+    attempt_dir.mkdir(exist_ok=True)
     bin_dir = tmp_path / "bin"
     fake_openclaw = (
         bin_dir / "openclaw" if bin_dir.is_dir() else _fake_openclaw(tmp_path)
@@ -264,6 +293,8 @@ def _run_wrapper(
             "AGENT_LOG": str(coordinator / "agents.log"),
             "COLLECTOR_START_LOG": str(coordinator / "collector-starts.log"),
             "IR_BATCH_LOG": str(coordinator / "ir-batches.log"),
+            "SESSION_LOG": str(coordinator / "sessions.log"),
+            "ATTEMPT_DIR": str(attempt_dir),
         }
     )
     if extra_env:
@@ -304,6 +335,7 @@ def _phase_dir(tmp_path: Path, run_date: str) -> Path:
 @pytest.mark.parametrize(
     ("variable", "value"),
     [
+        ("MINERVA_EDITORIAL_TIMEOUT", "0"),
         ("MINERVA_BROWSER_TIMEOUT", "0"),
         ("MINERVA_BROWSER_TIMEOUT", "not-a-number"),
         ("MINERVA_WEBFETCH_TIMEOUT", "-1"),
@@ -632,8 +664,8 @@ def test_collectors_are_isolated_and_ingest_directly(tmp_path: Path) -> None:
             tmp_path / "coordinator" / "timeouts.log"
         ).read_text(encoding="utf-8").splitlines()
     )
-    assert timeouts["reuters-markets"] == "900"
-    assert timeouts["wsj"] == "900"
+    assert timeouts["reuters-markets"] == "1800"
+    assert timeouts["wsj"] == "1800"
     assert timeouts["ir-batch-001"] == "900"
 
     # Every collector's status.json reports ok.
@@ -644,6 +676,8 @@ def test_collectors_are_isolated_and_ingest_directly(tmp_path: Path) -> None:
         )
         assert status["status"] == "ok"
         assert status["exit_status"] == 0
+        assert status["attempts"] == 1
+        assert status["error"] is None
         assert status["source_id"] == source_id
 
     # collectors.json aggregates success totals.
@@ -672,6 +706,13 @@ def test_collectors_are_isolated_and_ingest_directly(tmp_path: Path) -> None:
         assert all(
             path.suffix != ".md" for path in source_files
         ), f"unexpected markdown file under {source_id}: {source_files}"
+    assert "SENSITIVE_PAYLOAD_SENTINEL" not in str(
+        [
+            path.read_text(encoding="utf-8")
+            for path in collector_dir.rglob("*")
+            if path.is_file()
+        ]
+    )
 
 
 def test_failed_collector_reports_status_without_blocking_pipeline(
@@ -708,8 +749,11 @@ def test_failed_collector_reports_status_without_blocking_pipeline(
         (collector_dir / "wsj" / "status.json").read_text(encoding="utf-8")
     )
     assert broken_status["status"] == "failed"
-    assert broken_status["exit_status"] == 7
+    assert broken_status["exit_status"] != 0
+    assert broken_status["attempts"] == 2
+    assert broken_status["error"] == "invalid_json"
     assert healthy_status["status"] == "ok"
+    assert healthy_status["attempts"] == 1
 
     aggregate = json.loads(
         (_phase_dir(tmp_path, run_date) / "collectors.json").read_text(
@@ -724,6 +768,111 @@ def test_failed_collector_reports_status_without_blocking_pipeline(
 
     # The degraded run is still reported on stdout for the operator.
     assert "collector error" in result.stdout
+
+
+def test_editorial_collector_retries_once_with_a_fresh_session(tmp_path: Path) -> None:
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "economist",
+                "name": "The Economist",
+                "url": "https://example.test/economist",
+                "access": "browser",
+            }
+        ],
+        run_date=run_date,
+        extra_env={"RECOVER_SOURCE": "economist"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    status = json.loads(
+        (_phase_dir(tmp_path, run_date) / "collectors/economist/status.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    sessions = [
+        line.split("|", 1)[1]
+        for line in (tmp_path / "coordinator/sessions.log").read_text().splitlines()
+        if line.startswith("economist|")
+    ]
+    assert status["status"] == "ok"
+    assert status["attempts"] == 2
+    assert len(sessions) == len(set(sessions)) == 2
+
+
+def test_partial_ingestion_survives_final_logical_failure(tmp_path: Path) -> None:
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "wsj",
+                "name": "Wall Street Journal",
+                "url": "https://example.test/wsj",
+                "access": "browser",
+            }
+        ],
+        run_date=run_date,
+        extra_env={
+            "LOGICAL_FAILURE_SOURCE": "wsj",
+            "INGEST_BEFORE_FAILURE_SOURCE": "wsj",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    phase_dir = _phase_dir(tmp_path, run_date)
+    status = json.loads((phase_dir / "collectors/wsj/status.json").read_text())
+    with sqlite3.connect(tmp_path / "invest.db") as connection:
+        count = connection.execute(
+            "SELECT COUNT(*) FROM news WHERE source='wsj'"
+        ).fetchone()[0]
+    assert count == 1
+    assert status["status"] == "failed"
+    assert status["attempts"] == 2
+    assert status["error"] == "aborted"
+    assert "SENSITIVE_PAYLOAD_SENTINEL" not in str(
+        [
+            path.read_text(encoding="utf-8")
+            for path in phase_dir.rglob("*")
+            if path.is_file()
+        ]
+    )
+
+
+def test_ir_failure_is_not_retried(tmp_path: Path) -> None:
+    run_date = date.today().isoformat()
+    result = _run_wrapper(
+        tmp_path,
+        sources=[
+            {
+                "id": "wsj",
+                "name": "Wall Street Journal",
+                "url": "https://example.test/wsj",
+                "access": "browser",
+            }
+        ],
+        ir_entries=[
+            {
+                "security_id": "AMD",
+                "company_name": "AMD",
+                "feeds": [{"url": "https://example.test/AMD"}],
+            }
+        ],
+        run_date=run_date,
+        extra_env={"BROKEN_SOURCE": "ir-batch-001"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    status = json.loads(
+        (
+            _phase_dir(tmp_path, run_date)
+            / "collectors/ir-batch-001/status.json"
+        ).read_text()
+    )
+    assert status["status"] == "failed"
+    assert status["attempts"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- give WSJ, Economist, and Reuters Markets a 30-minute editorial timeout and one fresh-session retry
- validate `openclaw agent --json` logical completion instead of trusting exit code 0
- retain only safe status metadata while preserving partial direct ingestion
- keep IR collectors at one 15-minute attempt

## Tests
- `bash -n scripts/run_morning_brief.sh`
- `python3 -m compileall -q scripts/morning_brief_helper.py tests/test_morning_brief_helper.py tests/test_news_collection.py`
- `uv run pytest tests/test_morning_brief_helper.py tests/test_news_collection.py -q` — 47 passed
- `uv run pytest -q` — 468 passed
