### PR TITLE
fix(brief): harden collector completion and flexible event counts

### DIFF
--- a/scripts/morning_brief_helper.py
+++ b/scripts/morning_brief_helper.py
@@ -17,6 +17,14 @@ MARKET_TIMEZONE = ZoneInfo("America/New_York")
 IR_BATCH_SIZE = 10
 _PLACEHOLDER = re.compile(r"{{([A-Z_]+)}}")
 _SUCCESS_STOP_REASONS = {"completed", "end_turn", "stop"}
+_COLLECTOR_REPORT_KEYS = {
+    "status",
+    "inserted",
+    "updated",
+    "duplicate",
+    "skipped",
+    "failed",
+}
 
 
 def parse_run_date(value: str) -> date:
@@ -74,6 +82,24 @@ def validate_openclaw_result(text: str) -> str:
         return "error_payload"
     if meta.get("stopReason") not in _SUCCESS_STOP_REASONS:
         return "incomplete"
+    if len(payloads) != 1 or not isinstance(payloads[0], dict):
+        return "invalid_report"
+    report_text = payloads[0].get("text")
+    if not isinstance(report_text, str):
+        return "invalid_report"
+    try:
+        report = json.loads(report_text)
+    except json.JSONDecodeError:
+        return "invalid_report"
+    if not isinstance(report, dict) or set(report) != _COLLECTOR_REPORT_KEYS:
+        return "invalid_report"
+    if report.get("status") not in {"ok", "failed"}:
+        return "invalid_report"
+    counts = [report[key] for key in _COLLECTOR_REPORT_KEYS - {"status"}]
+    if any(type(count) is not int or count < 0 for count in counts):
+        return "invalid_counts"
+    if report["status"] != "ok" or report["failed"] != 0:
+        return "collector_failed"
     return "ok"
 
 

--- a/scripts/morning_brief_helper.py
+++ b/scripts/morning_brief_helper.py
@@ -9,6 +9,7 @@ import sqlite3
 import sys
 import time as time_module
 from datetime import date, datetime, time, timedelta
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -25,6 +26,11 @@ _COLLECTOR_REPORT_KEYS = {
     "skipped",
     "failed",
 }
+
+
+class CollectorStatus(StrEnum):
+    OK = "ok"
+    FAILED = "failed"
 
 
 def parse_run_date(value: str) -> date:
@@ -93,12 +99,14 @@ def validate_openclaw_result(text: str) -> str:
         return "invalid_report"
     if not isinstance(report, dict) or set(report) != _COLLECTOR_REPORT_KEYS:
         return "invalid_report"
-    if report.get("status") not in {"ok", "failed"}:
+    try:
+        status = CollectorStatus(report["status"])
+    except (TypeError, ValueError):
         return "invalid_report"
     counts = [report[key] for key in _COLLECTOR_REPORT_KEYS - {"status"}]
     if any(type(count) is not int or count < 0 for count in counts):
         return "invalid_counts"
-    if report["status"] != "ok" or report["failed"] != 0:
+    if status is not CollectorStatus.OK or report["failed"] != 0:
         return "collector_failed"
     return "ok"
 

--- a/scripts/prompts/collect_ir_batch.md
+++ b/scripts/prompts/collect_ir_batch.md
@@ -46,15 +46,19 @@ Pipe that object directly on stdin to:
 printf '%s\n' "$article_json" | {{NEWS_INGEST_COMMAND}}
 ```
 
-A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never put release JSON or content on a command line. Require the compact command result to have status `inserted`, `updated`, or `duplicate`; otherwise count the release as failed and return a non-zero result after continuing safely.
+A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never put release JSON or content on a command line. Require the compact command result to have status `inserted`, `updated`, or `duplicate`; otherwise count the release as failed and report collector status `failed` after continuing safely.
 
 ## Browser procedure
 
 1. Open the first configured feed exactly once with `browser open ... --new --window`. Record the returned tab alias; it is the only window and tab for the whole batch. Close any accidentally created extra tab or window immediately.
 2. For each company and feed, navigate that tab to the feed URL, scan the complete listing, and record candidate headline, destination URL, and visible publication value before opening release bodies.
 3. Run the per-company batch duplicate lookup. For each remaining candidate, use the same tab to resolve publication metadata, extract the full release, and ingest the in-memory object.
-4. Continue through all feeds and companies when an individual page returns a 404, CAPTCHA, paywall, or extraction failure, recording the affected item as skipped.
+4. Continue through all feeds and companies when an individual page is unavailable or paywalled, recording the affected item as skipped. Count a browser, fetch, or extraction failure as failed and continue safely.
 5. Close the tab with `browser close {tab_alias}`.
-6. Reply briefly with per-company and total counts for inserted/updated/duplicate/skipped/failed. Do not include release bodies.
+6. Return the final report described below.
 
-If no company has an accessible configured feed, or the browser bridge prevents safe completion, return non-zero.
+If no company has an accessible configured feed, or the browser bridge prevents safe completion, report status `failed`.
+
+## Final report
+
+Your final reply must be exactly one compact JSON object with no Markdown, preamble, or trailing text: `{"status":"ok","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0}`. Use only the keys shown, with `status` set to `ok` or `failed` and every total count set to a nonnegative integer. `status` may be `ok` only when `failed` is zero; any browser, fetch, or safe-completion failure must use `failed`. Do not include release bodies.

--- a/scripts/prompts/collect_news.md
+++ b/scripts/prompts/collect_news.md
@@ -51,7 +51,7 @@ Pipe that object directly on stdin to:
 printf '%s\n' "$article_json" | {{NEWS_INGEST_COMMAND}}
 ```
 
-A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never place article JSON or content on a command line. Require the compact command result to have status `inserted`, `updated`, or `duplicate`; otherwise count the article as failed and return a non-zero result after continuing safely.
+A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never place article JSON or content on a command line. Require the compact command result to have status `inserted`, `updated`, or `duplicate`; otherwise count the article as failed and report collector status `failed` after continuing safely.
 
 ## Browser procedure
 
@@ -63,8 +63,12 @@ A different safe in-memory JSON-producing construct is allowed, but it must end 
    a. Navigate to the article and resolve missing publication metadata as specified above.
    b. Extract and normalize the full substantive body with `browser extract` or `browser ask`.
    c. Build and ingest the in-memory object.
-   d. On 404, CAPTCHA, video-only content, paywall, or extraction failure, record a skipped item and continue.
+   d. Record an unavailable, paywalled, or video-only item as skipped and continue. Count a browser or extraction failure as failed and continue safely.
 6. Close the tab with `browser close {tab_alias}`.
-7. Reply briefly with counts for inserted/updated/duplicate/skipped/failed. Do not include article bodies.
+7. Return the final report described below.
 
-If the browser bridge is unavailable or safe completion is impossible, return non-zero. Same-tab navigation is allowed; additional tabs and windows are not.
+If the browser bridge is unavailable or safe completion is impossible, report status `failed`. Same-tab navigation is allowed; additional tabs and windows are not.
+
+## Final report
+
+Your final reply must be exactly one compact JSON object with no Markdown, preamble, or trailing text: `{"status":"ok","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0}`. Use only the keys shown, with `status` set to `ok` or `failed` and every count set to a nonnegative integer. `status` may be `ok` only when `failed` is zero; any browser, fetch, or safe-completion failure must use `failed`. Do not include article bodies.

--- a/scripts/prompts/collect_news_webfetch.md
+++ b/scripts/prompts/collect_news_webfetch.md
@@ -51,7 +51,7 @@ Pipe that object directly on stdin to:
 printf '%s\n' "$article_json" | {{NEWS_INGEST_COMMAND}}
 ```
 
-A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never place content on a command line. Require the compact command result to have status `inserted`, `updated`, or `duplicate`; otherwise count the item as failed and return a non-zero result after continuing safely.
+A different safe in-memory JSON-producing construct is allowed, but it must end in the same `news ingest --input - --db ...` command. Never place content on a command line. Require the compact command result to have status `inserted`, `updated`, or `duplicate`; otherwise count the item as failed and report collector status `failed` after continuing safely.
 
 ## Procedure
 
@@ -62,6 +62,10 @@ A different safe in-memory JSON-producing construct is allowed, but it must end 
    a. Fetch its distinct URL when one exists; a calendar row without a distinct URL may use substantive content from the landing-page fetch.
    b. Resolve missing publication metadata as specified above, then extract and normalize the complete substantive item.
    c. Build and ingest the in-memory object.
-   d. Record fetch or extraction failures as skipped and continue.
-5. If the initial fetch fails or safe completion is impossible, return non-zero.
-6. Reply briefly with counts for inserted/updated/duplicate/skipped/failed. Do not include item bodies.
+   d. Record an unavailable or non-substantive item as skipped and continue. Count a fetch or extraction failure as failed and continue safely.
+5. If the initial fetch fails or safe completion is impossible, report status `failed`.
+6. Return the final report described below.
+
+## Final report
+
+Your final reply must be exactly one compact JSON object with no Markdown, preamble, or trailing text: `{"status":"ok","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0}`. Use only the keys shown, with `status` set to `ok` or `failed` and every count set to a nonnegative integer. `status` may be `ok` only when `failed` is zero; any browser, fetch, or safe-completion failure must use `failed`. Do not include article bodies.

--- a/scripts/prompts/morning_brief_synthesis.md
+++ b/scripts/prompts/morning_brief_synthesis.md
@@ -62,7 +62,7 @@ _Worth Knowing Today_
 • _{Investor takeaway}:_ {Concise helpful explanation with original-source links.}
 ```
 
-For `_Worth Knowing Today_`, select exactly 10 distinct non-portfolio events that are most useful for becoming a better investor. They may be company-specific or broader. Prefer developments with transferable lessons about economics, competition, incentives, capital allocation, regulation, technology, macro conditions, or risk.
+For `_Worth Knowing Today_`, select up to 10 distinct non-portfolio events that are most useful for becoming a better investor. When fewer than 10 events qualify, include every qualifying event. Never add filler, and never query or read rejected articles merely to reach the maximum. Events may be company-specific or broader. Prefer developments with transferable lessons about economics, competition, incentives, capital allocation, regulation, technology, macro conditions, or risk.
 
 If nothing material occurred for the portfolio or watchlist, use the approved fallback:
 

--- a/scripts/prompts/morning_brief_synthesis.md
+++ b/scripts/prompts/morning_brief_synthesis.md
@@ -70,6 +70,12 @@ If nothing material occurred for the portfolio or watchlist, use the approved fa
 • No material portfolio or watchlist developments during the collection period.
 ```
 
+If no non-portfolio event qualifies for `_Worth Knowing Today_`, use this fallback:
+
+```text
+• No qualifying non-portfolio developments during the collection period.
+```
+
 Get final article and per-source counts from the verified fixed-window query and collector successes and failures from `collector_stats`. Cite factual claims with the direct source URLs from the selected SQLite rows, linking to original articles rather than `finnhub.io/api/news` proxy pages when possible. Do not use Markdown headings or tables.
 
 ## 5. Return the result

--- a/scripts/run_morning_brief.sh
+++ b/scripts/run_morning_brief.sh
@@ -14,7 +14,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 HELPER="${ROOT_DIR}/scripts/morning_brief_helper.py"
 RUN_DATE="${1:-$(date +%F)}"
 MINERVA_EDITORIAL_TIMEOUT="${MINERVA_EDITORIAL_TIMEOUT:-1800}"
-MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-900}"
+MINERVA_BROWSER_TIMEOUT="${MINERVA_BROWSER_TIMEOUT:-1800}"
 MINERVA_WEBFETCH_TIMEOUT="${MINERVA_WEBFETCH_TIMEOUT:-300}"
 MINERVA_MAX_COLLECTORS="${MINERVA_MAX_COLLECTORS:-8}"
 MINERVA_NEWS_COLLECTOR_AGENT="${MINERVA_NEWS_COLLECTOR_AGENT:-steve}"
@@ -375,7 +375,7 @@ else
       echo "  spawning IR browser agent: ${ir_batch_id} (${company_count} companies)"
       launch_source "${IR_BATCH_PROMPT_TEMPLATE}" "${MINERVA_BROWSER_TIMEOUT}" \
         "${ir_batch_id}" "IR batch ${ir_batch_number}" "${first_url}" \
-        "${ir_companies_json}"
+        "${ir_companies_json}" 2
     done <"${NEWS_RUN_DIR}/ir-batches.jsonl"
   fi
 

--- a/tests/test_morning_brief_helper.py
+++ b/tests/test_morning_brief_helper.py
@@ -19,6 +19,17 @@ helper = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(helper)
 
 
+def test_morning_brief_prompts_do_not_require_a_worth_knowing_quota() -> None:
+    selection = (REPO_ROOT / "scripts/prompts/morning_brief_selection.md").read_text()
+    synthesis = (REPO_ROOT / "scripts/prompts/morning_brief_synthesis.md").read_text()
+
+    assert "Do not select from titles or URLs alone or impose a quota." in selection
+    assert "select up to 10 distinct non-portfolio events" in synthesis
+    assert "When fewer than 10 events qualify, include every qualifying event." in synthesis
+    assert "Never add filler, and never query or read rejected articles" in synthesis
+    assert "select exactly 10" not in synthesis
+
+
 def test_parse_run_date_is_strict_and_previous_date_cli_logic_is_exact() -> None:
     assert helper.parse_run_date("2026-03-01") == date(2026, 3, 1)
     with pytest.raises(ValueError, match="ISO date"):

--- a/tests/test_morning_brief_helper.py
+++ b/tests/test_morning_brief_helper.py
@@ -19,17 +19,6 @@ helper = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(helper)
 
 
-def test_morning_brief_prompts_do_not_require_a_worth_knowing_quota() -> None:
-    selection = (REPO_ROOT / "scripts/prompts/morning_brief_selection.md").read_text()
-    synthesis = (REPO_ROOT / "scripts/prompts/morning_brief_synthesis.md").read_text()
-
-    assert "Do not select from titles or URLs alone or impose a quota." in selection
-    assert "select up to 10 distinct non-portfolio events" in synthesis
-    assert "When fewer than 10 events qualify, include every qualifying event." in synthesis
-    assert "Never add filler, and never query or read rejected articles" in synthesis
-    assert "select exactly 10" not in synthesis
-
-
 def test_parse_run_date_is_strict_and_previous_date_cli_logic_is_exact() -> None:
     assert helper.parse_run_date("2026-03-01") == date(2026, 3, 1)
     with pytest.raises(ValueError, match="ISO date"):
@@ -59,11 +48,23 @@ def test_render_prompt_does_not_expand_placeholders_inside_metadata() -> None:
 
 
 @pytest.mark.parametrize("stop_reason", ["completed", "end_turn", "stop"])
-def test_validate_openclaw_result_accepts_completed_turns(stop_reason: str) -> None:
+def test_validate_openclaw_result_accepts_exact_collector_report(
+    stop_reason: str,
+) -> None:
+    report = {
+        "status": "ok",
+        "inserted": 2,
+        "updated": 1,
+        "duplicate": 3,
+        "skipped": 4,
+        "failed": 0,
+    }
     payload = {
         "status": "ok",
         "result": {
-            "payloads": [{"text": "must not be returned"}],
+            "payloads": [
+                {"text": json.dumps(report, separators=(",", ":"))}
+            ],
             "meta": {"aborted": False, "stopReason": stop_reason},
         },
     }
@@ -90,6 +91,56 @@ def test_validate_openclaw_result_rejects_incomplete_or_invalid_results(
     text: str, expected: str
 ) -> None:
     assert helper.validate_openclaw_result(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("report", "expected"),
+    [
+        ("", "invalid_report"),
+        ("not json", "invalid_report"),
+        ('{"status":"ok"}', "invalid_report"),
+        ('{"status":"ok","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0,"note":"extra"}', "invalid_report"),
+        ('{"status":"unknown","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0}', "invalid_report"),
+        ('{"status":"failed","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0}', "collector_failed"),
+        ('{"status":"ok","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":1}', "collector_failed"),
+        ('{"status":"ok","inserted":-1,"updated":0,"duplicate":0,"skipped":0,"failed":0}', "invalid_counts"),
+        ('{"status":"ok","inserted":true,"updated":0,"duplicate":0,"skipped":0,"failed":0}', "invalid_counts"),
+    ],
+)
+def test_validate_openclaw_result_rejects_failed_or_malformed_collector_reports(
+    report: str, expected: str
+) -> None:
+    payload = {
+        "status": "ok",
+        "result": {
+            "payloads": [{"text": report}],
+            "meta": {"stopReason": "end_turn"},
+        },
+    }
+
+    assert helper.validate_openclaw_result(json.dumps(payload)) == expected
+
+
+def test_validate_openclaw_result_rejects_missing_or_ambiguous_reports() -> None:
+    def envelope(payloads: list[dict[str, str]]) -> str:
+        return json.dumps(
+            {
+                "status": "ok",
+                "result": {
+                    "payloads": payloads,
+                    "meta": {"stopReason": "end_turn"},
+                },
+            }
+        )
+
+    valid_report = '{"status":"ok","inserted":0,"updated":0,"duplicate":0,"skipped":0,"failed":0}'
+    assert helper.validate_openclaw_result(envelope([])) == "invalid_report"
+    assert (
+        helper.validate_openclaw_result(
+            envelope([{"text": valid_report}, {"text": valid_report}])
+        )
+        == "invalid_report"
+    )
 
 
 def test_build_ir_batches_uses_universe_for_inclusion_and_registry_for_feeds() -> None:

--- a/tests/test_news_collection.py
+++ b/tests/test_news_collection.py
@@ -141,8 +141,8 @@ timeout=""
 agent=""
 session_id=""
 json_mode=0
-failure_json='{"status":"ok","result":{"payloads":[{"isError":true,"text":"SENSITIVE_PAYLOAD_SENTINEL"}],"meta":{"aborted":true,"stopReason":"aborted"}}}'
-success_json='{"status":"ok","result":{"payloads":[{"text":"SENSITIVE_PAYLOAD_SENTINEL"}],"meta":{"aborted":false,"stopReason":"end_turn"}}}'
+failure_json='{"status":"ok","result":{"payloads":[{"text":"{\"status\":\"failed\",\"inserted\":0,\"updated\":0,\"duplicate\":0,\"skipped\":0,\"failed\":1}"}],"meta":{"aborted":false,"stopReason":"end_turn"}}}'
+success_json='{"status":"ok","result":{"payloads":[{"text":"{\"status\":\"ok\",\"inserted\":1,\"updated\":0,\"duplicate\":0,\"skipped\":0,\"failed\":0}"}],"meta":{"aborted":false,"stopReason":"end_turn"}}}'
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --json) json_mode=1; shift ;;
@@ -652,21 +652,11 @@ def test_collectors_are_isolated_and_ingest_directly(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
 
-    # Every collector launched, each got its own timeout row.
+    # Every collector launched.
     starts = (
         tmp_path / "coordinator" / "collector-starts.log"
     ).read_text(encoding="utf-8").splitlines()
     assert set(starts) == {"wsj", "reuters-markets", "ir-batch-001"}
-
-    timeouts = dict(
-        line.split("|", 1)
-        for line in (
-            tmp_path / "coordinator" / "timeouts.log"
-        ).read_text(encoding="utf-8").splitlines()
-    )
-    assert timeouts["reuters-markets"] == "1800"
-    assert timeouts["wsj"] == "1800"
-    assert timeouts["ir-batch-001"] == "900"
 
     # Every collector's status.json reports ok.
     collector_dir = _phase_dir(tmp_path, run_date) / "collectors"
@@ -706,13 +696,6 @@ def test_collectors_are_isolated_and_ingest_directly(tmp_path: Path) -> None:
         assert all(
             path.suffix != ".md" for path in source_files
         ), f"unexpected markdown file under {source_id}: {source_files}"
-    assert "SENSITIVE_PAYLOAD_SENTINEL" not in str(
-        [
-            path.read_text(encoding="utf-8")
-            for path in collector_dir.rglob("*")
-            if path.is_file()
-        ]
-    )
 
 
 def test_failed_collector_reports_status_without_blocking_pipeline(
@@ -831,28 +814,14 @@ def test_partial_ingestion_survives_final_logical_failure(tmp_path: Path) -> Non
     assert count == 1
     assert status["status"] == "failed"
     assert status["attempts"] == 2
-    assert status["error"] == "aborted"
-    assert "SENSITIVE_PAYLOAD_SENTINEL" not in str(
-        [
-            path.read_text(encoding="utf-8")
-            for path in phase_dir.rglob("*")
-            if path.is_file()
-        ]
-    )
+    assert status["error"] == "collector_failed"
 
 
-def test_ir_failure_is_not_retried(tmp_path: Path) -> None:
+def test_ir_logical_failure_is_retried_once(tmp_path: Path) -> None:
     run_date = date.today().isoformat()
     result = _run_wrapper(
         tmp_path,
-        sources=[
-            {
-                "id": "wsj",
-                "name": "Wall Street Journal",
-                "url": "https://example.test/wsj",
-                "access": "browser",
-            }
-        ],
+        sources=[],
         ir_entries=[
             {
                 "security_id": "AMD",
@@ -861,7 +830,7 @@ def test_ir_failure_is_not_retried(tmp_path: Path) -> None:
             }
         ],
         run_date=run_date,
-        extra_env={"BROKEN_SOURCE": "ir-batch-001"},
+        extra_env={"RECOVER_SOURCE": "ir-batch-001"},
     )
 
     assert result.returncode == 0, result.stderr
@@ -871,8 +840,8 @@ def test_ir_failure_is_not_retried(tmp_path: Path) -> None:
             / "collectors/ir-batch-001/status.json"
         ).read_text()
     )
-    assert status["status"] == "failed"
-    assert status["attempts"] == 1
+    assert status["status"] == "ok"
+    assert status["attempts"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow the Worth Knowing section to contain up to 10 qualifying events, with a zero-event fallback and no filler
- require collector agents to return one strict success/failure report and retry invalid or failed runs once
- give IR collectors the same 30-minute attempt timeout and retry policy as editorial collectors
- test the collector result contract and retry behavior without asserting prompt wording, shell structure, or exact timeout values

## Validation
- `uv run pytest -q tests/test_morning_brief_helper.py tests/test_news_collection.py` (57 passed)
- `bash -n scripts/run_morning_brief.sh`
- `git diff --check`

Ruff is not installed in the project environment, so no Ruff check was available.
