### PR TITLE
refactor: model closed string domains with StrEnum

### DIFF
--- a/scripts/morning_brief_helper.py
+++ b/scripts/morning_brief_helper.py
@@ -17,20 +17,41 @@ from zoneinfo import ZoneInfo
 MARKET_TIMEZONE = ZoneInfo("America/New_York")
 IR_BATCH_SIZE = 10
 _PLACEHOLDER = re.compile(r"{{([A-Z_]+)}}")
-_SUCCESS_STOP_REASONS = {"completed", "end_turn", "stop"}
-_COLLECTOR_REPORT_KEYS = {
-    "status",
-    "inserted",
-    "updated",
-    "duplicate",
-    "skipped",
-    "failed",
-}
+
+
+class OpenClawSuccessStopReason(StrEnum):
+    COMPLETED = "completed"
+    END_TURN = "end_turn"
+    STOP = "stop"
+
+
+class CollectorReportField(StrEnum):
+    STATUS = "status"
+    INSERTED = "inserted"
+    UPDATED = "updated"
+    DUPLICATE = "duplicate"
+    SKIPPED = "skipped"
+    FAILED = "failed"
 
 
 class CollectorStatus(StrEnum):
     OK = "ok"
     FAILED = "failed"
+
+
+class ValidationOutcome(StrEnum):
+    INVALID_JSON = "invalid_json"
+    STATUS_ERROR = "status_error"
+    INVALID_RESULT = "invalid_result"
+    ABORTED = "aborted"
+    AGENT_ERROR = "agent_error"
+    TIMEOUT = "timeout"
+    ERROR_PAYLOAD = "error_payload"
+    INCOMPLETE = "incomplete"
+    INVALID_REPORT = "invalid_report"
+    INVALID_COUNTS = "invalid_counts"
+    COLLECTOR_FAILED = "collector_failed"
+    OK = "ok"
 
 
 def parse_run_date(value: str) -> date:
@@ -60,55 +81,64 @@ def render_prompt(template: str, replacements: dict[str, str]) -> str:
     )
 
 
-def validate_openclaw_result(text: str) -> str:
+def validate_openclaw_result(text: str) -> ValidationOutcome:
     """Return a safe outcome code without exposing agent payload text."""
     try:
         envelope = json.loads(text)
     except json.JSONDecodeError:
-        return "invalid_json"
-    if not isinstance(envelope, dict) or envelope.get("status") != "ok":
-        return "status_error"
+        return ValidationOutcome.INVALID_JSON
+    if not isinstance(envelope, dict) or envelope.get("status") != CollectorStatus.OK:
+        return ValidationOutcome.STATUS_ERROR
     result = envelope.get("result")
     if not isinstance(result, dict):
-        return "invalid_result"
+        return ValidationOutcome.INVALID_RESULT
     meta = result.get("meta")
     payloads = result.get("payloads")
     if not isinstance(meta, dict) or not isinstance(payloads, list):
-        return "invalid_result"
+        return ValidationOutcome.INVALID_RESULT
     if meta.get("aborted") is True:
-        return "aborted"
+        return ValidationOutcome.ABORTED
     if meta.get("error") is not None:
-        return "agent_error"
+        return ValidationOutcome.AGENT_ERROR
     if meta.get("timeoutPhase") is not None:
-        return "timeout"
+        return ValidationOutcome.TIMEOUT
     if any(
         isinstance(payload, dict) and payload.get("isError") is True
         for payload in payloads
     ):
-        return "error_payload"
-    if meta.get("stopReason") not in _SUCCESS_STOP_REASONS:
-        return "incomplete"
+        return ValidationOutcome.ERROR_PAYLOAD
+    try:
+        OpenClawSuccessStopReason(meta.get("stopReason"))
+    except (TypeError, ValueError):
+        return ValidationOutcome.INCOMPLETE
     if len(payloads) != 1 or not isinstance(payloads[0], dict):
-        return "invalid_report"
+        return ValidationOutcome.INVALID_REPORT
     report_text = payloads[0].get("text")
     if not isinstance(report_text, str):
-        return "invalid_report"
+        return ValidationOutcome.INVALID_REPORT
     try:
         report = json.loads(report_text)
     except json.JSONDecodeError:
-        return "invalid_report"
-    if not isinstance(report, dict) or set(report) != _COLLECTOR_REPORT_KEYS:
-        return "invalid_report"
+        return ValidationOutcome.INVALID_REPORT
+    if not isinstance(report, dict) or set(report) != set(CollectorReportField):
+        return ValidationOutcome.INVALID_REPORT
     try:
-        status = CollectorStatus(report["status"])
+        status = CollectorStatus(report[CollectorReportField.STATUS])
     except (TypeError, ValueError):
-        return "invalid_report"
-    counts = [report[key] for key in _COLLECTOR_REPORT_KEYS - {"status"}]
+        return ValidationOutcome.INVALID_REPORT
+    counts = [
+        report[field]
+        for field in CollectorReportField
+        if field is not CollectorReportField.STATUS
+    ]
     if any(type(count) is not int or count < 0 for count in counts):
-        return "invalid_counts"
-    if status is not CollectorStatus.OK or report["failed"] != 0:
-        return "collector_failed"
-    return "ok"
+        return ValidationOutcome.INVALID_COUNTS
+    if (
+        status is not CollectorStatus.OK
+        or report[CollectorReportField.FAILED] != 0
+    ):
+        return ValidationOutcome.COLLECTOR_FAILED
+    return ValidationOutcome.OK
 
 
 def build_ir_batches(
@@ -235,10 +265,12 @@ def collector_summary(launched_path: Path, artifact_root: Path) -> dict[str, Any
                 "error": "collector exited without a status artifact",
                 "exit_status": -1,
                 "source_id": source_id,
-                "status": "failed",
+                "status": CollectorStatus.FAILED,
             }
         rows.append(row)
-    failures = [row for row in rows if row.get("status") != "ok"]
+    failures = [
+        row for row in rows if row.get("status") != CollectorStatus.OK
+    ]
     return {
         "failed": len(failures),
         "failures": failures,
@@ -393,7 +425,7 @@ def _main(command: str, args: list[str]) -> None:
     elif command == "validate-openclaw":
         _require(command, args, 0)
         outcome = validate_openclaw_result(sys.stdin.read())
-        if outcome != "ok":
+        if outcome is not ValidationOutcome.OK:
             raise ValueError(outcome)
     elif command == "collector-status":
         _require(command, args, 10)

--- a/src/harness/commands/evidence.py
+++ b/src/harness/commands/evidence.py
@@ -11,7 +11,7 @@ from harness.config import HarnessSettings, get_settings
 from harness.output import CommandResult, OutputEnvelope
 from harness.workflows.evidence.audit import DEFAULT_AUDIT_MODEL, default_audit_llm, run_audit
 from harness.workflows.evidence.constants import RECOGNIZED_CATEGORIES
-from harness.workflows.evidence.ledger import load_ledger, upsert_evidence
+from harness.workflows.evidence.ledger import EvidenceStatus, load_ledger, upsert_evidence
 from harness.workflows.evidence.paths import resolve_company_root
 from harness.workflows.evidence.registry import initialize_registry
 
@@ -114,7 +114,7 @@ def add_source_command(
     start = time.perf_counter()
 
     # Validate: downloaded requires a path.
-    if status == "downloaded" and not path:
+    if status == EvidenceStatus.DOWNLOADED and not path:
         return CommandResult.from_text(
             "",
             stderr="status=downloaded requires --path; pass a local file path for downloaded sources",

--- a/src/harness/commands/extract.py
+++ b/src/harness/commands/extract.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import time
 from datetime import datetime, timezone
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -98,7 +99,18 @@ SUMMARY_PROMPT = (
     "figures, qualifications, and conclusions. Return only the summary without a preamble."
 )
 
-VALID_THINKING_LEVELS: frozenset[str] = frozenset({"off", "minimal", "low", "medium", "high", "adaptive"})
+class ThinkingLevel(StrEnum):
+    OFF = "off"
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    ADAPTIVE = "adaptive"
+
+
+class ExtractionStatus(StrEnum):
+    OK = "ok"
+    ERROR = "error"
 
 app = typer.Typer(help=EXTRACT_HELP, no_args_is_help=False, invoke_without_command=True)
 summarize_app = typer.Typer(
@@ -408,8 +420,8 @@ def extract_files_command(
     except _UsageError as exc:
         return error_result(exc.what, exc.what_to_do, exc.alternatives, start)
 
-    resolved_thinking = _resolve_default_thinking(model, thinking)
     try:
+        resolved_thinking = _resolve_default_thinking(model, thinking)
         _build_thinking_config(model, resolved_thinking)
     except ValueError as exc:
         return error_result(
@@ -470,7 +482,9 @@ def extract_files_command(
     }
     (out_root / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
 
-    failures = [entry for entry in entries if entry["status"] != "ok"]
+    failures = [
+        entry for entry in entries if entry["status"] is not ExtractionStatus.OK
+    ]
     summary_lines = [
         f"wrote {len(entries) - len(failures)} extraction(s) under {out_root}",
         f"manifest: {out_root / 'manifest.json'}",
@@ -789,24 +803,34 @@ def _compose_prompt(*, prompt_pack: str, document_text: str) -> str:
 # ---------------------------------------------------------------------------
 # Thinking config helpers
 # ---------------------------------------------------------------------------
-def _resolve_default_thinking(model: str, explicit: str | None) -> str | None:
+def _resolve_default_thinking(
+    model: str, explicit: str | ThinkingLevel | None
+) -> ThinkingLevel | None:
     if explicit is not None:
-        return explicit
+        return _coerce_thinking_level(explicit)
     if _is_gemini_3_flash(model):
-        return "minimal"
+        return ThinkingLevel.MINIMAL
     return None
 
-def _build_thinking_config(model: str, thinking: str | None):
+
+def _coerce_thinking_level(value: str | ThinkingLevel) -> ThinkingLevel:
+    try:
+        return ThinkingLevel(value)
+    except ValueError:
+        expected = sorted(level.value for level in ThinkingLevel)
+        raise ValueError(
+            f"unknown thinking level `{value}` (expected one of {expected})"
+        ) from None
+
+
+def _build_thinking_config(model: str, thinking: str | ThinkingLevel | None):
     """Return a ThinkingConfig (or None) for the given model.
 
     Raises ValueError on unsupported (model, level) combinations.
     """
     if thinking is None:
         return None
-    if thinking not in VALID_THINKING_LEVELS:
-        raise ValueError(
-            f"unknown thinking level `{thinking}` (expected one of {sorted(VALID_THINKING_LEVELS)})"
-        )
+    level = _coerce_thinking_level(thinking)
 
     try:
         from google.genai import types as genai_types
@@ -814,20 +838,20 @@ def _build_thinking_config(model: str, thinking: str | None):
         raise RuntimeError("google-genai is not installed") from exc
 
     if _is_gemini_3(model):
-        if thinking in {"off", "adaptive"}:
+        if level in {ThinkingLevel.OFF, ThinkingLevel.ADAPTIVE}:
             raise ValueError(
-                f"`--thinking {thinking}` is not supported for Gemini 3 models; "
+                f"`--thinking {level.value}` is not supported for Gemini 3 models; "
                 "use minimal|low|medium|high"
             )
-        return genai_types.ThinkingConfig(thinking_level=thinking.upper())
+        return genai_types.ThinkingConfig(thinking_level=level.value.upper())
 
     if _is_gemini_25(model):
-        if thinking == "off":
+        if level is ThinkingLevel.OFF:
             return genai_types.ThinkingConfig(thinking_budget=0)
-        if thinking == "adaptive":
+        if level is ThinkingLevel.ADAPTIVE:
             return genai_types.ThinkingConfig(thinking_budget=-1)
         raise ValueError(
-            f"`--thinking {thinking}` is not supported for Gemini 2.5 models; use off|adaptive"
+            f"`--thinking {level.value}` is not supported for Gemini 2.5 models; use off|adaptive"
         )
 
     if _is_openai_model(model):
@@ -837,7 +861,9 @@ def _build_thinking_config(model: str, thinking: str | None):
         f"`--thinking` is not configured for model `{model}`; omit `--thinking` to skip thinking config"
     )
 
-def _build_generate_config(model: str, max_tokens: int, thinking: str | None):
+def _build_generate_config(
+    model: str, max_tokens: int, thinking: str | ThinkingLevel | None
+):
     try:
         from google.genai import types as genai_types
     except ModuleNotFoundError as exc:  # pragma: no cover
@@ -892,7 +918,7 @@ def _generate_answer(
     document_text: str,  # kept for tests/observability
     model: str,
     max_tokens: int,
-    thinking: str | None,
+    thinking: str | ThinkingLevel | None,
     api_key: str,
 ) -> str:
     if _is_openai_model(model):
@@ -916,7 +942,7 @@ def _generate_gemini_answer(
     prompt: str,
     model: str,
     max_tokens: int,
-    thinking: str | None,
+    thinking: str | ThinkingLevel | None,
     api_key: str,
 ) -> str:
     try:
@@ -933,7 +959,12 @@ def _generate_gemini_answer(
 
 
 def _generate_openai_answer(
-    *, prompt: str, model: str, max_tokens: int, thinking: str | None = None, api_key: str
+    *,
+    prompt: str,
+    model: str,
+    max_tokens: int,
+    thinking: str | ThinkingLevel | None = None,
+    api_key: str,
 ) -> str:
     try:
         import openai
@@ -946,8 +977,10 @@ def _generate_openai_answer(
         "input": prompt,
         "max_output_tokens": max_tokens,
     }
-    if thinking in {"low", "medium", "high"}:
-        kwargs["reasoning"] = {"effort": thinking}
+    if thinking is not None:
+        level = _coerce_thinking_level(thinking)
+        if level in {ThinkingLevel.LOW, ThinkingLevel.MEDIUM, ThinkingLevel.HIGH}:
+            kwargs["reasoning"] = {"effort": level.value}
     response = client.responses.create(**kwargs)
     text = _openai_response_text(response)
     if not text:
@@ -1091,7 +1124,7 @@ async def _run_extractions(
     prompt_pack: str,
     model: str,
     max_tokens: int,
-    thinking: str | None,
+    thinking: str | ThinkingLevel | None,
     api_key: str,
     concurrency: int,
 ) -> list[dict[str, Any]]:
@@ -1102,7 +1135,7 @@ async def _run_extractions(
             entry: dict[str, Any] = {
                 "source": str(src),
                 "output": str(target),
-                "status": "ok",
+                "status": ExtractionStatus.OK,
                 "error": None,
                 "started_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1121,7 +1154,7 @@ async def _run_extractions(
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_text(answer.strip() + "\n", encoding="utf-8")
             except Exception as exc:  # noqa: BLE001
-                entry["status"] = "error"
+                entry["status"] = ExtractionStatus.ERROR
                 entry["error"] = f"{type(exc).__name__}: {exc}"
             entry["finished_at"] = datetime.now(timezone.utc).isoformat()
             return entry

--- a/src/harness/morning_brief.py
+++ b/src/harness/morning_brief.py
@@ -8,6 +8,7 @@ import re
 import time as time_mod
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -42,6 +43,13 @@ DEFAULT_QUOTE_SYMBOLS = [
     "XLK", "XLF", "XLE", "XLV",
 ]
 FINNHUB_CALL_DELAY_SECONDS = 0.1
+
+
+class CollectionStatus(StrEnum):
+    SUCCESS = "success"
+    DEGRADED = "degraded"
+    ERROR = "error"
+
 
 @dataclass(slots=True)
 class RunPaths:
@@ -186,7 +194,13 @@ def collect_filings(
     rendered_path = run_paths.rendered_dir / "filings.md"
     write_json(raw_path, payload)
     rendered_path.write_text(render_event_markdown("Filings", sorted_events), encoding="utf-8")
-    status = "success" if not errors else ("degraded" if events else "error")
+    status = (
+        CollectionStatus.SUCCESS
+        if not errors
+        else CollectionStatus.DEGRADED
+        if events
+        else CollectionStatus.ERROR
+    )
     update_manifest_source(
         run_paths,
         "filings",
@@ -250,7 +264,11 @@ def collect_earnings(
         },
     )
     rendered_path.write_text(render_event_markdown("Earnings", sorted_events), encoding="utf-8")
-    status = "degraded" if degraded_reasons else "success"
+    status = (
+        CollectionStatus.DEGRADED
+        if degraded_reasons
+        else CollectionStatus.SUCCESS
+    )
     update_manifest_source(
         run_paths,
         "earnings",
@@ -318,7 +336,11 @@ def collect_macro(
         },
     )
     rendered_path.write_text(render_event_markdown("Macro", sorted_events), encoding="utf-8")
-    status = "degraded" if degraded_reasons else "success"
+    status = (
+        CollectionStatus.DEGRADED
+        if degraded_reasons
+        else CollectionStatus.SUCCESS
+    )
     update_manifest_source(
         run_paths,
         "macro",
@@ -372,7 +394,11 @@ def collect_macro_registry_events(
     }
     write_json(destination, payload)
 
-    status = "degraded" if payload["degraded_reasons"] else "success"
+    status = (
+        CollectionStatus.DEGRADED
+        if payload["degraded_reasons"]
+        else CollectionStatus.SUCCESS
+    )
     update_manifest_source(
         run_paths,
         "macro-collect",
@@ -429,7 +455,11 @@ def collect_market(
         },
     )
     rendered_path.write_text(render_event_markdown("Market", sorted_events), encoding="utf-8")
-    status = "degraded" if degraded_reasons else "success"
+    status = (
+        CollectionStatus.DEGRADED
+        if degraded_reasons
+        else CollectionStatus.SUCCESS
+    )
     update_manifest_source(
         run_paths,
         "market",
@@ -531,7 +561,7 @@ def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
         run_paths,
         "prep",
         {
-            "status": "success",
+            "status": CollectionStatus.SUCCESS,
             "event_count": len(sorted_events),
             "suppressed_count": len(suppressed),
             "prepared_path": str(prepared_path),
@@ -541,7 +571,11 @@ def prepare_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
             "universe_path": str(universe_path),
         },
     )
-    return {"status": "success", "event_count": len(sorted_events), "prepared_path": prepared_path}
+    return {
+        "status": CollectionStatus.SUCCESS,
+        "event_count": len(sorted_events),
+        "prepared_path": prepared_path,
+    }
 
 
 def audit_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
@@ -574,7 +608,9 @@ def audit_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
             missed_events.append({"source": name, "event": event})
 
     source_failures = {
-        name: details for name, details in manifest.get("sources", {}).items() if details.get("status") not in {"success", ""}
+        name: details
+        for name, details in manifest.get("sources", {}).items()
+        if details.get("status") not in {CollectionStatus.SUCCESS, ""}
     }
     covered_security_ids = {str(event.get("security_id", "")) for event in prepared_events if event.get("relationship") == "monitored"}
     universe = load_json(portfolio_paths(workspace_root).universe, default=[])
@@ -599,13 +635,17 @@ def audit_evidence(workspace_root: Path, *, run_date: date) -> dict[str, Any]:
         run_paths,
         "audit",
         {
-            "status": "success",
+            "status": CollectionStatus.SUCCESS,
             "missed_event_count": len(missed_events),
             "audit_path": str(audit_path),
             "rendered_path": str(rendered_path),
         },
     )
-    return {"status": "success", "missed_event_count": len(missed_events), "audit_path": audit_path}
+    return {
+        "status": CollectionStatus.SUCCESS,
+        "missed_event_count": len(missed_events),
+        "audit_path": audit_path,
+    }
 
 
 def append_review_log(workspace_root: Path, *, run_date: date, notes: str | None = None) -> dict[str, Any]:
@@ -620,7 +660,7 @@ def append_review_log(workspace_root: Path, *, run_date: date, notes: str | None
         "source_failures": {
             name: details
             for name, details in manifest.get("sources", {}).items()
-            if details.get("status") not in {"success", ""}
+            if details.get("status") not in {CollectionStatus.SUCCESS, ""}
         },
         "degraded_modes_used": sorted(
             {
@@ -638,13 +678,16 @@ def append_review_log(workspace_root: Path, *, run_date: date, notes: str | None
         run_paths,
         "review-log",
         {
-            "status": "success",
+            "status": CollectionStatus.SUCCESS,
             "review_log_path": str(run_paths.review_log),
             "logged_at": entry["logged_at"],
             "entry_count": len(_read_review_log(run_paths.review_log)),
         },
     )
-    return {"status": "success", "review_log_path": run_paths.review_log}
+    return {
+        "status": CollectionStatus.SUCCESS,
+        "review_log_path": run_paths.review_log,
+    }
 
 
 def _load_filings_source_payload(
@@ -1149,7 +1192,7 @@ def _collect_macro_registry_source(source_entry: dict[str, Any], run_date: date)
             "name": source_name,
             "url": source_url,
             "parser": parser,
-            "status": "degraded",
+            "status": CollectionStatus.DEGRADED,
             "event_count": 0,
             "degraded_reasons": degraded_reasons,
         }, []
@@ -1167,7 +1210,7 @@ def _collect_macro_registry_source(source_entry: dict[str, Any], run_date: date)
             "name": source_name,
             "url": source_url,
             "parser": parser,
-            "status": "degraded",
+            "status": CollectionStatus.DEGRADED,
             "event_count": 0,
             "degraded_reasons": degraded_reasons,
         }, []
@@ -1176,7 +1219,11 @@ def _collect_macro_registry_source(source_entry: dict[str, Any], run_date: date)
         "name": source_name,
         "url": source_url,
         "parser": parser,
-        "status": "degraded" if degraded_reasons else "success",
+        "status": (
+            CollectionStatus.DEGRADED
+            if degraded_reasons
+            else CollectionStatus.SUCCESS
+        ),
         "event_count": len(events),
         "degraded_reasons": degraded_reasons,
     }, events

--- a/src/harness/news.py
+++ b/src/harness/news.py
@@ -14,16 +14,53 @@ import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta, timezone
+from enum import StrEnum
 from pathlib import Path
 from time import monotonic, sleep
-from typing import Iterable, Literal, Mapping, Sequence, TypedDict
+from typing import Iterable, Mapping, Sequence, TypedDict
 from zoneinfo import ZoneInfo
 
 from harness.finnhub import fetch_finnhub_news
 from harness.portfolio_state import NON_SECURITY_TICKERS
 
-# Header keys we care about (case-insensitive on the label).
-META_KEYS = {"source", "url", "published", "collected", "section", "status"}
+class MetaKey(StrEnum):
+    """Recognized raw-markdown header fields."""
+
+    SOURCE = "source"
+    URL = "url"
+    PUBLISHED = "published"
+    COLLECTED = "collected"
+    SECTION = "section"
+    STATUS = "status"
+
+
+class ArticleField(StrEnum):
+    """Accepted fields in the normalized single-article input schema."""
+
+    TITLE = "title"
+    SOURCE_ID = "source_id"
+    URL = "url"
+    PUBLISHED_AT = "published_at"
+    CONTENT = "content"
+    SUMMARY = "summary"
+    SECTION = "section"
+    COLLECTED_AT = "collected_at"
+
+
+class NewsColumn(StrEnum):
+    """Canonical news table columns in SQL serialization order."""
+
+    ARTICLE_KEY = "article_key"
+    PUBLISHED_AT = "published_at"
+    PUBLISHED_AT_RAW = "published_at_raw"
+    TITLE = "title"
+    CONTENT = "content"
+    SUMMARY = "summary"
+    SOURCE = "source"
+    URL = "url"
+    SECTION = "section"
+    COLLECTED_AT = "collected_at"
+
 
 DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
@@ -166,9 +203,12 @@ def parse_raw_markdown(text: str) -> ParsedRaw:
             break
         if ":" in line and not line.startswith("#"):
             key, _, val = line.partition(":")
-            k = key.strip().lower()
-            if k in META_KEYS:
-                meta[k] = val.strip()
+            try:
+                meta_key = MetaKey(key.strip().lower())
+            except ValueError:
+                pass
+            else:
+                meta[meta_key.value] = val.strip()
                 idx += 1
                 continue
         break
@@ -518,10 +558,10 @@ def is_excluded_filename(name: str) -> str | None:
 
 def is_excluded_meta(meta: dict[str, str], title: str) -> str | None:
     """Content-level exclusions (belt-and-suspenders vs filename)."""
-    section = meta.get("section", "").lower()
+    section = meta.get(MetaKey.SECTION, "").lower()
     if "collection-error" in section or "collection error" in section:
         return "error"
-    status = meta.get("status", "").strip().lower()
+    status = meta.get(MetaKey.STATUS, "").strip().lower()
     if status and status != "ok":
         return "status"
     if re.match(
@@ -563,7 +603,10 @@ class ArticleInput:
     collected_at: str | None = None
 
 
-ArticleIngestStatus = Literal["inserted", "duplicate", "updated"]
+class ArticleIngestStatus(StrEnum):
+    INSERTED = "inserted"
+    DUPLICATE = "duplicate"
+    UPDATED = "updated"
 
 
 class ArticleIngestResult(TypedDict):
@@ -572,23 +615,33 @@ class ArticleIngestResult(TypedDict):
 
 
 _ARTICLE_REQUIRED_FIELDS = (
-    "title",
-    "source_id",
-    "url",
-    "published_at",
-    "content",
+    ArticleField.TITLE,
+    ArticleField.SOURCE_ID,
+    ArticleField.URL,
+    ArticleField.PUBLISHED_AT,
+    ArticleField.CONTENT,
 )
-_ARTICLE_OPTIONAL_FIELDS = {"summary", "section", "collected_at"}
+_ARTICLE_OPTIONAL_FIELDS = frozenset(
+    {
+        ArticleField.SUMMARY,
+        ArticleField.SECTION,
+        ArticleField.COLLECTED_AT,
+    }
+)
 
 
-def _required_article_text(payload: Mapping[str, object], field: str) -> str:
+def _required_article_text(
+    payload: Mapping[str, object], field: ArticleField
+) -> str:
     value = payload.get(field)
     if not isinstance(value, str) or not value.strip():
         raise ArticleInputError(f"article must have a non-empty string {field}")
     return value.strip()
 
 
-def _optional_article_text(payload: Mapping[str, object], field: str) -> str | None:
+def _optional_article_text(
+    payload: Mapping[str, object], field: ArticleField
+) -> str | None:
     value = payload.get(field)
     if value is None:
         return None
@@ -618,27 +671,31 @@ def parse_article_input(text: str) -> ArticleInput:
         field: _required_article_text(payload, field)
         for field in _ARTICLE_REQUIRED_FIELDS
     }
-    published = normalize_published(values["published_at"])
+    published = normalize_published(values[ArticleField.PUBLISHED_AT])
     if published is None:
         raise ArticleInputError("article must have a parseable published_at")
-    if re.match(r"^(?:<!doctype\s+html\b|<html\b)", values["content"], re.IGNORECASE):
+    if re.match(
+        r"^(?:<!doctype\s+html\b|<html\b)",
+        values[ArticleField.CONTENT],
+        re.IGNORECASE,
+    ):
         raise ArticleInputError(
             "article content must be normalized Markdown/text, not raw HTML"
         )
 
-    collected_at = _optional_article_text(payload, "collected_at")
+    collected_at = _optional_article_text(payload, ArticleField.COLLECTED_AT)
     if collected_at is not None:
         collected_at = normalize_collected(collected_at)
 
     return ArticleInput(
-        title=values["title"],
-        source_id=values["source_id"],
-        url=values["url"],
-        published_at_raw=values["published_at"],
+        title=values[ArticleField.TITLE],
+        source_id=values[ArticleField.SOURCE_ID],
+        url=values[ArticleField.URL],
+        published_at_raw=values[ArticleField.PUBLISHED_AT],
         published=published,
-        content=values["content"],
-        summary=_optional_article_text(payload, "summary"),
-        section=_optional_article_text(payload, "section"),
+        content=values[ArticleField.CONTENT],
+        summary=_optional_article_text(payload, ArticleField.SUMMARY),
+        section=_optional_article_text(payload, ArticleField.SECTION),
         collected_at=collected_at,
     )
 
@@ -655,8 +712,17 @@ class Candidate:
     published: str = ""
 
 
-MatchKind = Literal["url", "article_key", "batch_url", "batch_article_key"]
-ExistenceStatus = Literal["ok", "database_missing", "news_table_missing"]
+class MatchKind(StrEnum):
+    URL = "url"
+    ARTICLE_KEY = "article_key"
+    BATCH_URL = "batch_url"
+    BATCH_ARTICLE_KEY = "batch_article_key"
+
+
+class ExistenceStatus(StrEnum):
+    OK = "ok"
+    DATABASE_MISSING = "database_missing"
+    NEWS_TABLE_MISSING = "news_table_missing"
 
 
 class SeenMatch(TypedDict):
@@ -744,7 +810,7 @@ def _batch_matches(
     for index, candidate in enumerate(candidates):
         if candidate.url:
             if candidate.url in urls:
-                matches[index] = "batch_url"
+                matches[index] = MatchKind.BATCH_URL
             urls.add(candidate.url)
 
         published = normalize_published(candidate.published)
@@ -752,7 +818,7 @@ def _batch_matches(
             continue
         key = article_key(source_id, published.date_only, candidate.title)
         if matches[index] is None and key in keys:
-            matches[index] = "batch_article_key"
+            matches[index] = MatchKind.BATCH_ARTICLE_KEY
         keys.add(key)
     return matches
 
@@ -787,7 +853,7 @@ def check_candidates(
     validated = _validated_candidates(candidates)
     matches = _batch_matches(normalized_source_id, validated)
     if not db_path.is_file():
-        return _existence_result("database_missing", matches)
+        return _existence_result(ExistenceStatus.DATABASE_MISSING, matches)
 
     uri = f"{db_path.resolve().as_uri()}?mode=ro"
     with sqlite3.connect(uri, uri=True) as conn:
@@ -800,7 +866,7 @@ def check_candidates(
             ("table", "news"),
         ).fetchone()
         if table_exists is None:
-            return _existence_result("news_table_missing", matches)
+            return _existence_result(ExistenceStatus.NEWS_TABLE_MISSING, matches)
 
         for index, candidate in enumerate(validated):
             if matches[index] is not None:
@@ -811,7 +877,7 @@ def check_candidates(
                     (candidate.url,),
                 ).fetchone()
                 if url_match is not None:
-                    matches[index] = "url"
+                    matches[index] = MatchKind.URL
                     continue
 
             published = normalize_published(candidate.published)
@@ -824,9 +890,9 @@ def check_candidates(
                     (key,),
                 ).fetchone()
                 if key_match is not None:
-                    matches[index] = "article_key"
+                    matches[index] = MatchKind.ARTICLE_KEY
 
-    return _existence_result("ok", matches)
+    return _existence_result(ExistenceStatus.OK, matches)
 
 
 # ---------------------------------------------------------------------------
@@ -853,20 +919,6 @@ NEWS_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_news_url ON news(url)",
 )
 
-_NEWS_COLUMNS = (
-    "article_key",
-    "published_at",
-    "published_at_raw",
-    "title",
-    "content",
-    "summary",
-    "source",
-    "url",
-    "section",
-    "collected_at",
-)
-
-
 def _create_news_schema(conn: sqlite3.Connection) -> None:
     conn.execute(NEWS_TABLE_SQL)
     for statement in NEWS_INDEX_SQL:
@@ -889,7 +941,7 @@ def _legacy_publication_epoch(raw: str, collected_at: str) -> int:
 def _migrate_legacy_news(
     conn: sqlite3.Connection, legacy_columns: set[str]
 ) -> None:
-    required = set(_NEWS_COLUMNS) - {"published_at_raw"}
+    required = set(NewsColumn) - {NewsColumn.PUBLISHED_AT_RAW}
     missing = required - legacy_columns
     if missing:
         names = ", ".join(sorted(missing))
@@ -897,7 +949,11 @@ def _migrate_legacy_news(
             f"cannot migrate legacy news table; missing columns: {names}"
         )
 
-    select_columns = tuple(column for column in _NEWS_COLUMNS if column != "published_at_raw")
+    select_columns = tuple(
+        column
+        for column in NewsColumn
+        if column is not NewsColumn.PUBLISHED_AT_RAW
+    )
     cursor = conn.execute(f"SELECT {', '.join(select_columns)} FROM news")
     legacy_rows = [dict(zip(select_columns, row, strict=True)) for row in cursor]
 
@@ -911,29 +967,29 @@ def _migrate_legacy_news(
 
         migrated_rows = []
         for row in legacy_rows:
-            raw_value = row["published_at"]
+            raw_value = row[NewsColumn.PUBLISHED_AT]
             published_at_raw = "" if raw_value is None else str(raw_value)
-            collected_at = row["collected_at"]
+            collected_at = row[NewsColumn.COLLECTED_AT]
             migrated_rows.append(
                 (
-                    row["article_key"],
+                    row[NewsColumn.ARTICLE_KEY],
                     _legacy_publication_epoch(
                         published_at_raw,
                         "" if collected_at is None else str(collected_at),
                     ),
                     published_at_raw,
-                    row["title"],
-                    row["content"],
-                    row["summary"],
-                    row["source"],
-                    row["url"],
-                    row["section"],
+                    row[NewsColumn.TITLE],
+                    row[NewsColumn.CONTENT],
+                    row[NewsColumn.SUMMARY],
+                    row[NewsColumn.SOURCE],
+                    row[NewsColumn.URL],
+                    row[NewsColumn.SECTION],
                     collected_at,
                 )
             )
         conn.executemany(
             "INSERT INTO news "
-            f"({', '.join(_NEWS_COLUMNS)}) VALUES ({', '.join('?' for _ in _NEWS_COLUMNS)})",
+            f"({', '.join(NewsColumn)}) VALUES ({', '.join('?' for _ in NewsColumn)})",
             migrated_rows,
         )
         conn.execute("DROP TABLE news_legacy_migration")
@@ -963,8 +1019,10 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
 
     column_rows = conn.execute("PRAGMA table_info(news)").fetchall()
     columns = {row[1]: row for row in column_rows}
-    published_type = str(columns.get("published_at", (None, None, ""))[2]).upper()
-    if "published_at_raw" not in columns or published_type != "INTEGER":
+    published_type = str(
+        columns.get(NewsColumn.PUBLISHED_AT, (None, None, ""))[2]
+    ).upper()
+    if NewsColumn.PUBLISHED_AT_RAW not in columns or published_type != "INTEGER":
         _migrate_legacy_news(conn, set(columns))
     else:
         _create_news_schema(conn)
@@ -994,7 +1052,7 @@ def ingest_article(db_path: Path, article: ArticleInput) -> ArticleIngestResult:
         conn.execute("BEGIN IMMEDIATE")
         ensure_schema(conn)
         existing = conn.execute(
-            f"SELECT {', '.join(_NEWS_COLUMNS)} FROM news "
+            f"SELECT {', '.join(NewsColumn)} FROM news "
             "WHERE url = ? COLLATE BINARY "
             "ORDER BY CASE WHEN article_key = ? THEN 0 ELSE 1 END, article_key "
             "LIMIT 1",
@@ -1002,7 +1060,7 @@ def ingest_article(db_path: Path, article: ArticleInput) -> ArticleIngestResult:
         ).fetchone()
         if existing is None:
             existing = conn.execute(
-                f"SELECT {', '.join(_NEWS_COLUMNS)} FROM news WHERE article_key = ?",
+                f"SELECT {', '.join(NewsColumn)} FROM news WHERE article_key = ?",
                 (key,),
             ).fetchone()
         collected_at = article.collected_at
@@ -1028,28 +1086,28 @@ def ingest_article(db_path: Path, article: ArticleInput) -> ArticleIngestResult:
         )
 
         if existing is None:
-            placeholders = ", ".join("?" for _ in _NEWS_COLUMNS)
+            placeholders = ", ".join("?" for _ in NewsColumn)
             conn.execute(
-                f"INSERT INTO news ({', '.join(_NEWS_COLUMNS)}) "
+                f"INSERT INTO news ({', '.join(NewsColumn)}) "
                 f"VALUES ({placeholders})",
                 values,
             )
-            status: ArticleIngestStatus = "inserted"
+            status = ArticleIngestStatus.INSERTED
         elif tuple(existing) == values:
-            status = "duplicate"
+            status = ArticleIngestStatus.DUPLICATE
         elif existing[0] != key and conn.execute(
             "SELECT 1 FROM news WHERE article_key = ?", (key,)
         ).fetchone() is not None:
             # The database already contains separate URL and article-key
             # matches. Preserve both rather than guessing which row to merge.
-            status = "duplicate"
+            status = ArticleIngestStatus.DUPLICATE
         else:
-            assignments = ", ".join(f"{column} = ?" for column in _NEWS_COLUMNS)
+            assignments = ", ".join(f"{column} = ?" for column in NewsColumn)
             conn.execute(
                 f"UPDATE news SET {assignments} WHERE article_key = ?",
                 (*values, existing[0]),
             )
-            status = "updated"
+            status = ArticleIngestStatus.UPDATED
         conn.commit()
     except Exception:
         conn.rollback()
@@ -1057,7 +1115,7 @@ def ingest_article(db_path: Path, article: ArticleInput) -> ArticleIngestResult:
     finally:
         conn.close()
 
-    return {"status": status, "article_key": key}
+    return {"status": status, NewsColumn.ARTICLE_KEY.value: key}
 
 
 # ---------------------------------------------------------------------------
@@ -1466,7 +1524,7 @@ def _ingest_one(
         report.append(f"skip:no-body\t{raw_path}")
         return
 
-    collected = parsed.meta.get("collected", "").strip()
+    collected = parsed.meta.get(MetaKey.COLLECTED, "").strip()
     if not collected:
         collected = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
             "+00:00", "Z"
@@ -1490,7 +1548,7 @@ def _ingest_one(
     published_at_raw = (
         enrichment_value
         if enrichment_value is not None
-        else parsed.meta.get("published", "")
+        else parsed.meta.get(MetaKey.PUBLISHED, "")
     )
     published = normalize_published(published_at_raw)
     if published is None:
@@ -1508,8 +1566,8 @@ def _ingest_one(
         stats.publication_fallbacks += 1
         report.append(f"fallback:publication-date\t{raw_path}")
 
-    url = parsed.meta.get("url", "").strip()
-    section = parsed.meta.get("section", "").strip() or None
+    url = parsed.meta.get(MetaKey.URL, "").strip()
+    section = parsed.meta.get(MetaKey.SECTION, "").strip() or None
 
     stats.eligible += 1
 

--- a/src/harness/portfolio_state.py
+++ b/src/harness/portfolio_state.py
@@ -9,6 +9,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from enum import StrEnum
 from io import StringIO
 from pathlib import Path
 from typing import Any, Mapping, NotRequired, Sequence, TypedDict
@@ -35,6 +36,13 @@ FISCAL_PERIOD_PATTERN = re.compile(r"^(FY\d{4}|H[12] FY\d{4}|Q[1-4] FY\d{4})$")
 FISCAL_PERIOD_EXAMPLES = "FY2026, H1 FY2026, H2 FY2026, Q1 FY2026, Q2 FY2026, Q3 FY2026, Q4 FY2026"
 MAX_THESIS_LIST_ITEMS = 5
 MAX_THESIS_METRICS = 5
+
+
+class EnrichmentField(StrEnum):
+    EXCHANGE = "exchange"
+    COUNTRY = "country"
+    SEC_REGISTERED = "sec_registered"
+    FINNHUB_SYMBOL = "finnhub_symbol"
 
 
 class ThesisMetricObservation(TypedDict):
@@ -1152,9 +1160,6 @@ def parse_iso_date(raw: str | None) -> date:
     return date.fromisoformat(raw)
 
 
-_ENRICHMENT_FIELDS = ("exchange", "country", "sec_registered", "finnhub_symbol")
-
-
 def _carry_forward_enrichment(
     current: list[dict[str, Any]],
     previous: list[dict[str, Any]],
@@ -1172,17 +1177,17 @@ def _carry_forward_enrichment(
         prev = prev_by_id.get(sid)
         if not prev:
             continue
-        for field in _ENRICHMENT_FIELDS:
+        for field in EnrichmentField:
             prev_val = prev.get(field)
             new_val = record.get(field)
-            if field == "exchange":
+            if field is EnrichmentField.EXCHANGE:
                 # Prefer the new (sheet) value if present, else keep previous.
                 if not (new_val and str(new_val).strip()):
                     if prev_val is not None:
-                        record[field] = prev_val
+                        record[field.value] = prev_val
             else:
                 if new_val is None and prev_val is not None:
-                    record[field] = prev_val
+                    record[field.value] = prev_val
 
 
 def _normalize_security_row(row: dict[str, Any], *, source_kind: str) -> dict[str, Any]:

--- a/src/harness/workflows/evidence/audit.py
+++ b/src/harness/workflows/evidence/audit.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 from harness.workflows.evidence.audit_prompt import AUDIT_PROMPT_TEMPLATE
 from harness.workflows.evidence.constants import SEC_CATEGORIES
-from harness.workflows.evidence.ledger import load_ledger
+from harness.workflows.evidence.ledger import EvidenceStatus, load_ledger
 from harness.workflows.evidence.paths import CompanyPaths
 
 DEFAULT_AUDIT_MODEL = "gpt-5.5"
@@ -176,7 +176,7 @@ def _render_external_contents(paths: CompanyPaths, entries: list[dict[str, Any]]
         status = e.get("status", "")
         local_path = e.get("local_path")
 
-        if status == "downloaded" and local_path:
+        if status == EvidenceStatus.DOWNLOADED and local_path:
             abs_path = paths.root / local_path
             text = _read_source_text(abs_path)
             sections.append(f"### {title}\n\ncategory: {category}\n\n{text}")

--- a/src/harness/workflows/evidence/ledger.py
+++ b/src/harness/workflows/evidence/ledger.py
@@ -7,13 +7,19 @@ import json
 import os
 import tempfile
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 from harness.workflows.evidence.paths import CompanyPaths
 
 LEDGER_VERSION = 2
-EVIDENCE_STATUSES: frozenset[str] = frozenset({"downloaded", "discovered", "blocked"})
+
+
+class EvidenceStatus(StrEnum):
+    DOWNLOADED = "downloaded"
+    DISCOVERED = "discovered"
+    BLOCKED = "blocked"
 
 
 def make_evidence_id(
@@ -61,9 +67,11 @@ def upsert_evidence(
     collector: str | None,
 ) -> dict[str, Any]:
     """Insert-or-update an evidence record. Writes JSONL atomically + evidence.md."""
-    if status not in EVIDENCE_STATUSES:
-        raise ValueError(f"unsupported evidence status: {status}")
-    if status == "downloaded" and not local_path:
+    try:
+        evidence_status = EvidenceStatus(status)
+    except ValueError:
+        raise ValueError(f"unsupported evidence status: {status}") from None
+    if evidence_status is EvidenceStatus.DOWNLOADED and not local_path:
         raise ValueError("status=downloaded requires local_path")
 
     paths.data_dir.mkdir(parents=True, exist_ok=True)
@@ -84,7 +92,7 @@ def upsert_evidence(
             "title": title,
             "ticker": ticker.upper(),
             "category": category,
-            "status": status,
+            "status": evidence_status,
             "local_path": local_path,
             "url": url,
             "date": date,
@@ -100,7 +108,7 @@ def upsert_evidence(
                 "title": title,
                 "ticker": ticker.upper(),
                 "category": category,
-                "status": status,
+                "status": evidence_status,
                 "local_path": local_path,
                 "url": url,
                 "date": date,


### PR DESCRIPTION
## Summary
- replace closed status, reason, and schema-key string domains with named `StrEnum` classes
- cover morning-brief collection/validation statuses, extraction thinking/results, evidence statuses, news input/database fields, and portfolio enrichment fields
- preserve existing JSON, shell, CLI, and SQL wire values while removing duplicated string literals
- leave open taxonomies, configuration allowlists, data catalogs, parser grammar, extensions, and ticker/symbol lists as ordinary collections

## Verification
- `uv run pytest -q` — 479 passed
- `uv run python -m compileall -q scripts src`
- `git diff --check origin/main...HEAD`

No source-text or implementation-detail tests were added; existing behavioral coverage verifies compatibility.
